### PR TITLE
Add cloud auto-detection, device code auth, and tenant-aware naming

### DIFF
--- a/Common/Connect-Service.ps1
+++ b/Common/Connect-Service.ps1
@@ -24,6 +24,10 @@
     User principal name (e.g., 'admin@contoso.onmicrosoft.com') for interactive
     authentication to Exchange Online or Purview. Bypasses the Windows Authentication
     Manager (WAM) broker which can cause RuntimeBroker errors on some systems.
+.PARAMETER UseDeviceCode
+    Use device code authentication flow instead of browser-based interactive auth.
+    Graph uses -UseDeviceCode, Exchange Online uses -Device. Purview does not
+    support device code and will fall back to browser/UPN-based auth with a warning.
 .PARAMETER M365Environment
     Target cloud environment. Commercial and GCC use standard endpoints.
     GCCHigh and DoD route to sovereign cloud endpoints for Graph, Exchange,
@@ -72,6 +76,9 @@ param(
 
     [Parameter()]
     [string]$UserPrincipalName,
+
+    [Parameter()]
+    [switch]$UseDeviceCode,
 
     [Parameter()]
     [ValidateSet('commercial', 'gcc', 'gcchigh', 'dod')]
@@ -140,6 +147,9 @@ try {
             }
             else {
                 $connectParams['Scopes'] = $Scopes
+                if ($UseDeviceCode) {
+                    $connectParams['UseDeviceCode'] = $true
+                }
             }
 
             if ($currentEnv.GraphEnvironment) {
@@ -166,6 +176,9 @@ try {
                 $connectParams['AppId'] = $ClientId
                 $connectParams['CertificateThumbprint'] = $CertificateThumbprint
             }
+            elseif ($UseDeviceCode) {
+                $connectParams['Device'] = $true
+            }
             elseif ($UserPrincipalName) {
                 $connectParams['UserPrincipalName'] = $UserPrincipalName
             }
@@ -188,6 +201,10 @@ try {
             }
             elseif ($UserPrincipalName) {
                 $connectParams['UserPrincipalName'] = $UserPrincipalName
+            }
+
+            if ($UseDeviceCode) {
+                Write-Warning "Purview (Connect-IPPSSession) does not support device code auth. Falling back to browser-based login."
             }
 
             foreach ($key in $currentEnv.PurviewParams.Keys) {

--- a/Common/Export-AssessmentReport.ps1
+++ b/Common/Export-AssessmentReport.ps1
@@ -92,6 +92,8 @@ if (-not (Test-Path -Path $summaryPath)) {
 }
 
 if (-not $OutputPath) {
+    # Derive domain prefix from tenant data for filename (resolved later, fallback to generic)
+    $reportDomainPrefix = ''
     $OutputPath = Join-Path -Path $AssessmentFolder -ChildPath '_Assessment-Report.html'
 }
 
@@ -99,7 +101,8 @@ if (-not $OutputPath) {
 # Load assessment data
 # ------------------------------------------------------------------
 $summary = Import-Csv -Path $summaryPath
-$issueReportPath = Join-Path -Path $AssessmentFolder -ChildPath '_Assessment-Issues.log'
+$issueFile = Get-ChildItem -Path $AssessmentFolder -Filter '_Assessment-Issues*.log' -ErrorAction SilentlyContinue | Select-Object -First 1
+$issueReportPath = if ($issueFile) { $issueFile.FullName } else { Join-Path -Path $AssessmentFolder -ChildPath '_Assessment-Issues.log' }
 $issueContent = if (Test-Path -Path $issueReportPath) { Get-Content -Path $issueReportPath -Raw } else { '' }
 
 # Load Tenant Info CSV for organization profile card and cover page
@@ -140,16 +143,41 @@ if (-not $TenantName) {
     }
 }
 
-# Read assessment version from log if available
+# Derive domain prefix from tenant CSV for report filename
+if ($reportDomainPrefix -eq '' -and $tenantData) {
+    $defaultDomainVal = if ($tenantData[0].PSObject.Properties.Name -contains 'DefaultDomain') { $tenantData[0].DefaultDomain } else { '' }
+    if ($defaultDomainVal -match '^([^.]+)\.onmicrosoft\.(com|us)$') {
+        $reportDomainPrefix = $Matches[1]
+        $OutputPath = Join-Path -Path $AssessmentFolder -ChildPath "_Assessment-Report_${reportDomainPrefix}.html"
+    }
+}
+
+# Read assessment version and cloud environment from log if available
 $assessmentVersion = '0.3.0'
-$logPath = Join-Path -Path $AssessmentFolder -ChildPath '_Assessment-Log.txt'
+$cloudEnvironment = 'commercial'
+# Find the log file (may have domain suffix, e.g., _Assessment-Log_contoso.txt)
+$logFile = Get-ChildItem -Path $AssessmentFolder -Filter '_Assessment-Log*.txt' -ErrorAction SilentlyContinue | Select-Object -First 1
+$logPath = if ($logFile) { $logFile.FullName } else { Join-Path -Path $AssessmentFolder -ChildPath '_Assessment-Log.txt' }
 if (Test-Path -Path $logPath) {
     $logHead = Get-Content -Path $logPath -TotalCount 10
     $versionLine = $logHead | Where-Object { $_ -match 'Version:\s+v(.+)' }
     if ($versionLine) {
         $assessmentVersion = $Matches[1]
     }
+    $cloudLine = $logHead | Where-Object { $_ -match 'Cloud:\s+(.+)' }
+    if ($cloudLine) {
+        $cloudEnvironment = $Matches[1].Trim()
+    }
 }
+
+# Map cloud environment to display names and CSS classes
+$cloudDisplayNames = @{
+    'commercial' = 'Commercial'
+    'gcc'        = 'GCC'
+    'gcchigh'    = 'GCC High'
+    'dod'        = 'DoD'
+}
+$cloudDisplayName = if ($cloudDisplayNames.ContainsKey($cloudEnvironment)) { $cloudDisplayNames[$cloudEnvironment] } else { $cloudEnvironment }
 
 # Get assessment date from folder name
 $folderName = Split-Path -Leaf $AssessmentFolder
@@ -403,10 +431,10 @@ foreach ($sectionName in $sections) {
         if ($verifiedDomains) {
             $allDomains = @($verifiedDomains -split ';\s*' | Where-Object { $_ } | Sort-Object)
             $customDomains = @($allDomains | Where-Object {
-                $_ -notmatch '\.onmicrosoft\.com$' -and $_ -notmatch '\.excl\.cloud$'
+                $_ -notmatch '\.onmicrosoft\.(com|us)$' -and $_ -notmatch '\.excl\.cloud$'
             })
             $systemDomains = @($allDomains | Where-Object {
-                $_ -match '\.onmicrosoft\.com$' -or $_ -match '\.excl\.cloud$'
+                $_ -match '\.onmicrosoft\.(com|us)$' -or $_ -match '\.excl\.cloud$'
             })
         }
 
@@ -429,6 +457,7 @@ foreach ($sectionName in $sections) {
         if ($defaultDomain) {
             $null = $sectionHtml.AppendLine("<div class='tenant-fact'><span class='fact-label'>Primary Domain</span><span class='fact-value'>$(ConvertTo-HtmlSafe -Text $defaultDomain)</span></div>")
         }
+        $null = $sectionHtml.AppendLine("<div class='tenant-fact'><span class='fact-label'>Cloud</span><span class='cloud-badge cloud-$(ConvertTo-HtmlSafe -Text $cloudEnvironment)'>$(ConvertTo-HtmlSafe -Text $cloudDisplayName)</span></div>")
         if ($createdDisplay) {
             $null = $sectionHtml.AppendLine("<div class='tenant-fact'><span class='fact-label'>Established</span><span class='fact-value'>$(ConvertTo-HtmlSafe -Text $createdDisplay)</span></div>")
         }
@@ -1410,6 +1439,35 @@ $html = @"
             font-family: 'Consolas', 'Courier New', monospace;
             font-size: 9.5pt !important;
             letter-spacing: 0.5px;
+        }
+
+        .cloud-badge {
+            display: inline-block;
+            padding: 3px 12px;
+            border-radius: 4px;
+            font-size: 10pt;
+            font-weight: 600;
+            letter-spacing: 0.3px;
+        }
+        .cloud-commercial {
+            background: #e8f0fe;
+            color: #1a73e8;
+            border: 1px solid #c5d9f7;
+        }
+        .cloud-gcc {
+            background: #e6f4ea;
+            color: #137333;
+            border: 1px solid #b7e1c5;
+        }
+        .cloud-gcchigh {
+            background: #fef3e0;
+            color: #c26401;
+            border: 1px solid #f5d9a8;
+        }
+        .cloud-dod {
+            background: #fce8e6;
+            color: #c5221f;
+            border: 1px solid #f5b7b1;
         }
 
         .tenant-domains {

--- a/Invoke-M365Assessment.ps1
+++ b/Invoke-M365Assessment.ps1
@@ -35,10 +35,16 @@
 .PARAMETER ScubaProductNames
     ScubaGear product codes to assess. Only used when the ScubaGear section is
     selected. Defaults to all six products.
+.PARAMETER UseDeviceCode
+    Use device code authentication flow instead of browser-based interactive auth.
+    Displays a code and URL that you can open in any browser profile, which is
+    useful on machines with multiple Edge profiles (e.g., corporate + GCC).
+    Note: Purview (Security & Compliance) does not support device code and will
+    fall back to browser-based or UPN-hint authentication.
 .PARAMETER M365Environment
     Target cloud environment for all service connections. Commercial and GCC
     use standard endpoints. GCCHigh and DoD use sovereign cloud endpoints.
-    Defaults to 'commercial'.
+    Auto-detected from tenant metadata when not explicitly specified.
 .EXAMPLE
     PS> .\Invoke-M365Assessment.ps1 -TenantId 'contoso.onmicrosoft.com'
 
@@ -59,6 +65,11 @@
     PS> .\Invoke-M365Assessment.ps1 -TenantId 'contoso.onmicrosoft.com' -UserPrincipalName 'admin@contoso.onmicrosoft.com'
 
     Runs a full assessment using UPN-based auth for EXO/Purview (avoids WAM broker errors).
+.EXAMPLE
+    PS> .\Invoke-M365Assessment.ps1 -TenantId 'contoso.onmicrosoft.us' -UseDeviceCode
+
+    Runs a full assessment using device code auth. You choose which browser profile
+    to authenticate in (useful for multi-profile machines).
 .EXAMPLE
     PS> .\Invoke-M365Assessment.ps1 -Section ScubaGear -TenantId 'contoso.onmicrosoft.com'
 
@@ -92,6 +103,9 @@ param(
 
     [Parameter()]
     [string]$UserPrincipalName,
+
+    [Parameter()]
+    [switch]$UseDeviceCode,
 
     [Parameter()]
     [ValidateSet('aad', 'defender', 'exo', 'powerplatform', 'sharepoint', 'teams')]
@@ -355,6 +369,9 @@ function Show-InteractiveWizard {
     Write-Host "    Sections:  $sectionDisplay" -ForegroundColor $cNormal
     Write-Host "    Tenant:    $tenantDisplay" -ForegroundColor $cNormal
     Write-Host "    Auth:      $authDisplay" -ForegroundColor $cNormal
+    if ($UseDeviceCode) {
+        $authDisplay += ' (device code)'
+    }
     if ($M365Environment -ne 'commercial') {
         Write-Host "    Cloud:     $M365Environment" -ForegroundColor $cNormal
     }
@@ -394,6 +411,59 @@ function Show-InteractiveWizard {
     }
 
     return $wizardResult
+}
+
+# ------------------------------------------------------------------
+# Helper: Resolve-M365Environment — auto-detect cloud via OpenID
+# ------------------------------------------------------------------
+function Resolve-M365Environment {
+    <#
+    .SYNOPSIS
+        Detects the M365 cloud environment for a tenant using the public OpenID
+        Connect discovery endpoint (no authentication required).
+    .DESCRIPTION
+        Queries the well-known OpenID configuration to determine whether a tenant
+        is Commercial, GCC, GCC High, or DoD. Tries the commercial authority first
+        (handles legacy GCC High .com domains), then falls back to the US Government
+        authority if the tenant is not found.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$TenantId
+    )
+
+    $authorities = @(
+        'https://login.microsoftonline.com'
+        'https://login.microsoftonline.us'
+    )
+
+    foreach ($authority in $authorities) {
+        $url = "$authority/$TenantId/v2.0/.well-known/openid-configuration"
+        try {
+            $response = Invoke-RestMethod -Uri $url -Method Get -TimeoutSec 10 -ErrorAction Stop
+
+            # Parse region fields to determine cloud environment
+            $regionScope    = $response.tenant_region_scope
+            $regionSubScope = $response.tenant_region_sub_scope
+
+            if ($regionSubScope -eq 'GCC') {
+                return 'gcc'
+            }
+            if ($regionScope -eq 'USGov') {
+                # Cannot distinguish GCC High from DoD pre-auth; default to gcchigh
+                return 'gcchigh'
+            }
+            return 'commercial'
+        }
+        catch {
+            # Tenant not found on this authority, try next
+            continue
+        }
+    }
+
+    # Both authorities failed — return $null so caller keeps the current value
+    return $null
 }
 
 # ------------------------------------------------------------------
@@ -519,7 +589,7 @@ function Get-RecommendedAction {
     param([string]$ErrorMessage)
 
     $actionPatterns = @(
-        @{ Pattern = 'WAM|broker|RuntimeBroker'; Action = 'WAM broker issue. Try -UserPrincipalName admin@tenant.onmicrosoft.com, certificate auth (-ClientId/-CertificateThumbprint), or -SkipConnection with a pre-existing session.' }
+        @{ Pattern = 'WAM|broker|RuntimeBroker'; Action = 'WAM broker issue. Try -UseDeviceCode (choose your browser profile), -UserPrincipalName admin@tenant.onmicrosoft.com, certificate auth (-ClientId/-CertificateThumbprint), or -SkipConnection with a pre-existing session.' }
         @{ Pattern = '401|Unauthorized'; Action = 'Re-authenticate or ensure admin consent has been granted for the required scopes.' }
         @{ Pattern = '403|Forbidden|Insufficient privileges'; Action = 'Grant the required Graph/API permissions to the app registration or user account.' }
         @{ Pattern = 'not recognized|not found|not installed'; Action = 'Ensure the required PowerShell module is installed and the service is connected.' }
@@ -627,7 +697,8 @@ function Show-AssessmentHeader {
     Write-Host ''
     Write-Host "    Output: $OutputPath" -ForegroundColor White
     if ($LogPath) {
-        Write-Host "    Log:    _Assessment-Log.txt" -ForegroundColor DarkGray
+        $logBaseName = Split-Path -Leaf $LogPath
+        Write-Host "    Log:    $logBaseName" -ForegroundColor DarkGray
     }
     Write-Host ''
 }
@@ -744,15 +815,19 @@ function Show-AssessmentSummary {
         }
 
         Write-Host ''
-        $logRelPath = if ($AssessmentFolder) { Join-Path $AssessmentFolder '_Assessment-Log.txt' } else { '_Assessment-Log.txt' }
-        $issueRelPath = if ($AssessmentFolder) { Join-Path $AssessmentFolder '_Assessment-Issues.log' } else { '_Assessment-Issues.log' }
+        $logName = if ($script:logFileName) { $script:logFileName } else { '_Assessment-Log.txt' }
+        $issueName = if ($script:issueFileName) { $script:issueFileName } else { '_Assessment-Issues.log' }
+        $logRelPath = if ($AssessmentFolder) { Join-Path $AssessmentFolder $logName } else { $logName }
+        $issueRelPath = if ($AssessmentFolder) { Join-Path $AssessmentFolder $issueName } else { $issueName }
         Write-Host "    Full details: $logRelPath" -ForegroundColor DarkGray
         Write-Host "    Issue report: $issueRelPath" -ForegroundColor DarkGray
     }
 
     # Report file references
     Write-Host ''
-    $reportRelPath = if ($AssessmentFolder) { Join-Path $AssessmentFolder '_Assessment-Report.html' } else { '_Assessment-Report.html' }
+    $reportSuffix = if ($script:domainPrefix) { "_$($script:domainPrefix)" } else { '' }
+    $reportName = "_Assessment-Report${reportSuffix}.html"
+    $reportRelPath = if ($AssessmentFolder) { Join-Path $AssessmentFolder $reportName } else { $reportName }
     if (Test-Path -Path $reportRelPath -ErrorAction SilentlyContinue) {
         Write-Host "    HTML report: $reportRelPath" -ForegroundColor Cyan
     }
@@ -887,10 +962,39 @@ $dnsCollector = @{
 }
 
 # ------------------------------------------------------------------
+# Auto-detect cloud environment (when not explicitly specified)
+# ------------------------------------------------------------------
+if ($TenantId -and -not $PSBoundParameters.ContainsKey('M365Environment')) {
+    $detectedEnv = Resolve-M365Environment -TenantId $TenantId
+    if ($detectedEnv -and $detectedEnv -ne $M365Environment) {
+        $envDisplayNames = @{
+            'commercial' = 'Commercial'
+            'gcc'        = 'GCC'
+            'gcchigh'    = 'GCC High'
+            'dod'        = 'DoD'
+        }
+        $M365Environment = $detectedEnv
+        Write-Host ''
+        Write-Host "  Cloud environment detected: $($envDisplayNames[$detectedEnv])" -ForegroundColor Cyan
+        if ($detectedEnv -eq 'gcchigh') {
+            Write-Host '  (If this is a DoD tenant, re-run with -M365Environment dod)' -ForegroundColor DarkGray
+        }
+    }
+}
+
+# ------------------------------------------------------------------
 # Create timestamped output folder
 # ------------------------------------------------------------------
 $timestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
-$assessmentFolder = Join-Path -Path $OutputFolder -ChildPath "Assessment_$timestamp"
+
+# Extract domain prefix for folder/file naming (Phase A: from TenantId if onmicrosoft)
+$script:domainPrefix = ''
+if ($TenantId -match '^([^.]+)\.onmicrosoft\.(com|us)$') {
+    $script:domainPrefix = $Matches[1]
+}
+
+$folderSuffix = if ($script:domainPrefix) { "_$($script:domainPrefix)" } else { '' }
+$assessmentFolder = Join-Path -Path $OutputFolder -ChildPath "Assessment_${timestamp}${folderSuffix}"
 
 try {
     $null = New-Item -Path $assessmentFolder -ItemType Directory -Force
@@ -903,17 +1007,17 @@ catch {
 # ------------------------------------------------------------------
 # Initialize log file
 # ------------------------------------------------------------------
-$script:logFilePath = Join-Path -Path $assessmentFolder -ChildPath '_Assessment-Log.txt'
+$logFileSuffix = if ($script:domainPrefix) { "_$($script:domainPrefix)" } else { '' }
+$script:logFileName = "_Assessment-Log${logFileSuffix}.txt"
+$script:logFilePath = Join-Path -Path $assessmentFolder -ChildPath $script:logFileName
 $logHeaderLines = @(
     ('=' * 80)
     '  M365 Environment Assessment Log'
     "  Version:  v$script:AssessmentVersion"
     "  Started:  $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')"
     "  Tenant:   $TenantId"
+    "  Cloud:    $M365Environment"
 )
-if ($M365Environment -ne 'commercial') {
-    $logHeaderLines += "  Cloud:    $M365Environment"
-}
 $logHeaderLines += @(
     "  Sections: $($Section -join ', ')"
     ('=' * 80)
@@ -1061,21 +1165,32 @@ function Connect-RequiredService {
             if ($M365Environment -ne 'commercial') {
                 $connectParams['M365Environment'] = $M365Environment
             }
+            if ($UseDeviceCode) {
+                $connectParams['UseDeviceCode'] = $true
+            }
 
-            # Suppress noisy output during connection:
-            #   2>$null  — PowerShell error stream (non-terminating)
-            #   6>$null  — PowerShell Information stream (Write-Host, e.g. EXO module banner)
-            #   Console.SetOut/SetError — .NET direct writes (MSAL/WAM stack traces)
+            # Suppress noisy output during connection (skip when device code
+            # is active — the user needs to see the code and URL).
+            $suppressOutput = -not $UseDeviceCode
             $prevConsoleOut = [Console]::Out
             $prevConsoleError = [Console]::Error
-            [Console]::SetOut([System.IO.TextWriter]::Null)
-            [Console]::SetError([System.IO.TextWriter]::Null)
+            if ($suppressOutput) {
+                [Console]::SetOut([System.IO.TextWriter]::Null)
+                [Console]::SetError([System.IO.TextWriter]::Null)
+            }
             try {
-                & $connectServicePath @connectParams 2>$null 6>$null
+                if ($suppressOutput) {
+                    & $connectServicePath @connectParams 2>$null 6>$null
+                }
+                else {
+                    & $connectServicePath @connectParams
+                }
             }
             finally {
-                [Console]::SetOut($prevConsoleOut)
-                [Console]::SetError($prevConsoleError)
+                if ($suppressOutput) {
+                    [Console]::SetOut($prevConsoleOut)
+                    [Console]::SetError($prevConsoleError)
+                }
             }
 
             $connectedServices.Add($svc) | Out-Null
@@ -1092,6 +1207,28 @@ function Connect-RequiredService {
                         $script:resolvedTenantId = $orgInfo.Id
                         $script:resolvedTenantDisplayName = $orgInfo.DisplayName
                         Write-AssessmentLog -Level INFO -Message "Connected tenant: $($script:resolvedTenantDisplayName) ($($script:resolvedTenantDomain)) [ID: $($script:resolvedTenantId)]" -Section $SectionName
+
+                        # Phase B: Rename folder/files to include domain prefix if not already set
+                        if (-not $script:domainPrefix -and $script:resolvedTenantDomain -match '^([^.]+)\.onmicrosoft\.(com|us)$') {
+                            $script:domainPrefix = $Matches[1]
+                            try {
+                                # Rename assessment folder
+                                $newFolderName = "Assessment_${timestamp}_$($script:domainPrefix)"
+                                Rename-Item -Path $assessmentFolder -NewName $newFolderName -ErrorAction Stop
+                                $assessmentFolder = Join-Path -Path $OutputFolder -ChildPath $newFolderName
+
+                                # Rename log file
+                                $newLogName = "_Assessment-Log_$($script:domainPrefix).txt"
+                                Rename-Item -Path $script:logFilePath -NewName $newLogName -ErrorAction Stop
+                                $script:logFileName = $newLogName
+                                $script:logFilePath = Join-Path -Path $assessmentFolder -ChildPath $newLogName
+
+                                Write-AssessmentLog -Level INFO -Message "Renamed output to include tenant domain: $($script:domainPrefix)" -Section $SectionName
+                            }
+                            catch {
+                                Write-AssessmentLog -Level WARN -Message "Could not rename output folder/files: $($_.Exception.Message)" -Section $SectionName
+                            }
+                        }
                     }
                 }
                 catch {
@@ -1669,7 +1806,9 @@ $summaryResults | Export-Csv -Path $summaryCsvPath -NoTypeInformation -Encoding 
 # Export issue report (if any issues exist)
 # ------------------------------------------------------------------
 if ($issues.Count -gt 0) {
-    $issueReportPath = Join-Path -Path $assessmentFolder -ChildPath '_Assessment-Issues.log'
+    $issueFileSuffix = if ($script:domainPrefix) { "_$($script:domainPrefix)" } else { '' }
+    $script:issueFileName = "_Assessment-Issues${issueFileSuffix}.log"
+    $issueReportPath = Join-Path -Path $assessmentFolder -ChildPath $script:issueFileName
     Export-IssueReport -Path $issueReportPath -Issues @($issues) -TenantName $TenantId -OutputPath $assessmentFolder -Version $script:AssessmentVersion
     Write-AssessmentLog -Level INFO -Message "Issue report exported: $issueReportPath ($($issues.Count) issues)"
 }


### PR DESCRIPTION
## Summary

- **Auto-detect M365 cloud environment** — Queries the public OpenID Connect discovery endpoint (no auth required) to determine Commercial, GCC, GCC High, or DoD before connecting. Two-pass detection handles legacy GCC High `.com` domains. Only activates when `-M365Environment` is not explicitly specified.

- **Device code authentication** (`-UseDeviceCode`) — Enables device code flow so users can authenticate in their preferred browser profile. Solves the multi-profile Edge issue where WAM/default browser keeps reverting to the wrong identity. Graph uses `-UseDeviceCode`, EXO uses `-Device`, Purview warns and falls back to browser auth.

- **Tenant-aware file naming** — Appends the onmicrosoft domain prefix to the assessment folder, log, report, and issue filenames (e.g., `Assessment_20260309_120000_contoso/`, `_Assessment-Report_contoso.html`). Two-phase naming: immediate if TenantId is an onmicrosoft domain, deferred rename after Graph resolves the initial domain for vanity domains/GUIDs.

- **Cloud environment badge on report** — Adds a color-coded badge (Commercial=blue, GCC=green, GCC High=amber, DoD=red) to the Organization Profile card in the HTML report. Log header now always writes the Cloud field.

- **Fix**: `.onmicrosoft.us` domains (GCC High/DoD) were classified as custom domains in the report's verified domains list instead of system domains.

## Test plan

- [ ] Run against a Commercial tenant without `-M365Environment` — verify auto-detection logs "commercial"
- [ ] Run against a GCC High tenant without `-M365Environment` — verify auto-detection sets "gcchigh"
- [ ] Run with `-UseDeviceCode` — verify code+URL displayed, auth succeeds in chosen browser profile
- [ ] Verify assessment folder and files include the onmicrosoft domain prefix
- [ ] Open HTML report and verify cloud badge appears on Organization Profile card
- [ ] Run with explicit `-M365Environment dod` — verify it is respected (no auto-detection override)
- [ ] Run with `-SkipConnection` — verify filenames remain generic (no domain resolution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)