### PR TITLE
Add cloud detection, device code auth, and tenant-aware naming

### DIFF
--- a/Common/Export-AssessmentReport.ps1
+++ b/Common/Export-AssessmentReport.ps1
@@ -85,7 +85,8 @@ if (-not (Test-Path -Path $AssessmentFolder -PathType Container)) {
     return
 }
 
-$summaryPath = Join-Path -Path $AssessmentFolder -ChildPath '_Assessment-Summary.csv'
+$summaryFile = Get-ChildItem -Path $AssessmentFolder -Filter '_Assessment-Summary*.csv' -ErrorAction SilentlyContinue | Select-Object -First 1
+$summaryPath = if ($summaryFile) { $summaryFile.FullName } else { Join-Path -Path $AssessmentFolder -ChildPath '_Assessment-Summary.csv' }
 if (-not (Test-Path -Path $summaryPath)) {
     Write-Error "Summary CSV not found: $summaryPath"
     return

--- a/Invoke-M365Assessment.ps1
+++ b/Invoke-M365Assessment.ps1
@@ -1804,7 +1804,8 @@ foreach ($sectionName in $Section) {
 $overallEnd = Get-Date
 $overallDuration = $overallEnd - $overallStart
 
-$summaryCsvPath = Join-Path -Path $assessmentFolder -ChildPath '_Assessment-Summary.csv'
+$summarySuffix = if ($script:domainPrefix) { "_$($script:domainPrefix)" } else { '' }
+$summaryCsvPath = Join-Path -Path $assessmentFolder -ChildPath "_Assessment-Summary${summarySuffix}.csv"
 $summaryResults | Export-Csv -Path $summaryCsvPath -NoTypeInformation -Encoding UTF8
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Auto-detect M365 environment** via OpenID Connect discovery endpoint (two-pass: tries commercial authority first, then .us for GCC High/DoD). Eliminates need for `-M365Environment gcchigh` flag in most cases.
- **Device code authentication** (`-UseDeviceCode` switch) for Graph and EXO, letting users authenticate in a specific browser profile on multi-profile Edge machines.
- **Cloud environment badge** on HTML report Organization Profile card with color-coded badges (Commercial=blue, GCC=green, GCC High=amber, DoD=red).
- **Tenant domain in filenames** — folder and all output files include the onmicrosoft domain prefix (e.g., `Assessment_20260309_151555_contoso`, `_Assessment-Report_contoso.html`) for easy identification when shared. Two-phase: immediate from TenantId, or deferred rename after Graph resolves vanity domains/GUIDs.

## Test plan
- [x] Commercial tenant: auto-detects "commercial", folder/files get domain suffix
- [ ] GCC High tenant: auto-detects "gcchigh" without `-M365Environment` flag
- [ ] Device code auth: `-UseDeviceCode` displays code+URL, auth succeeds in chosen browser
- [x] Report badge: cloud badge renders in Organization Profile card
- [x] Filenames: log, report, summary CSV, and issues log all include domain prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)