### PR TITLE
docs: Announce dark mode in README and regenerate sample report

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ The assessment automatically generates a self-contained HTML report (`_Assessmen
 
 **Report features:**
 
+- **Light / Dark mode** — floating toggle button with automatic detection via `prefers-color-scheme`, persisted to `localStorage`. Every element is themed — badges, framework tags, stat cards, table headers, and compliance rows all adapt
 - **Cover page** with M365 Assess branding and tenant name
 - **Organization profile card** — non-collapsible header showing org name, primary domain, creation date, and security defaults status
 - **Executive summary** with section/collector stat cards and issue overview
@@ -284,7 +285,8 @@ The assessment automatically generates a self-contained HTML report (`_Assessmen
 - **Security config highlighting** — Entra, EXO, Defender, SharePoint, and Teams security config tables show color-coded status badges (Pass/Fail/Warning/Review) with row-level tinting
 - **Microsoft Secure Score** — visual stat cards and progress bar showing current score, points earned, and comparison to the M365 global average
 - **Issues & recommendations** with severity badges and remediation guidance
-- **Print-friendly styling** — open in any browser and print to PDF with automatic page breaks
+- **Accessibility** — semantic HTML landmarks (`<header>`, `<main>`, `<footer>`), `scope="col"` on all table headers, focus-visible outlines
+- **Print-friendly styling** — open in any browser and print to PDF with automatic page breaks and repeated table headers
 
 The report generator can also be run standalone to regenerate the HTML from existing CSV data without re-running the assessment:
 

--- a/docs/sample-report/Example-Report.html
+++ b/docs/sample-report/Example-Report.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>M365 Assessment Report - Northwind Traders</title>
+    <title>M365 Assessment Report - Contoso Corporation</title>
     <style>
         /* ----------------------------------------------------------
            M365 Assess Theme
@@ -18,6 +18,42 @@
             --m365a-light-gray: #F1F5F9;
             --m365a-border: #CBD5E1;
             --m365a-white: #ffffff;
+            --m365a-success: #2ecc71;
+            --m365a-warning: #f39c12;
+            --m365a-danger: #e74c3c;
+            --m365a-info: #3498db;
+            --m365a-success-bg: #d4edda;
+            --m365a-warning-bg: #fff3cd;
+            --m365a-danger-bg: #f8d7da;
+            --m365a-info-bg: #d1ecf1;
+            --m365a-body-bg: #ffffff;
+            --m365a-text: #1E293B;
+            --m365a-card-bg: #ffffff;
+            --m365a-hover-bg: #e8f4f8;
+        }
+
+        body.dark-theme {
+            --m365a-primary: #60A5FA;
+            --m365a-dark-primary: #93C5FD;
+            --m365a-accent: #3B82F6;
+            --m365a-dark: #F1F5F9;
+            --m365a-dark-gray: #E2E8F0;
+            --m365a-medium-gray: #94A3B8;
+            --m365a-light-gray: #1E293B;
+            --m365a-border: #334155;
+            --m365a-white: #0F172A;
+            --m365a-body-bg: #0F172A;
+            --m365a-text: #E2E8F0;
+            --m365a-card-bg: #1E293B;
+            --m365a-hover-bg: #1E3A5F;
+            --m365a-success: #34D399;
+            --m365a-warning: #FBBF24;
+            --m365a-danger: #F87171;
+            --m365a-info: #60A5FA;
+            --m365a-success-bg: #064E3B;
+            --m365a-warning-bg: #78350F;
+            --m365a-danger-bg: #7F1D1D;
+            --m365a-info-bg: #1E3A5F;
         }
 
         * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -26,8 +62,8 @@
             font-family: 'Calibri', 'Segoe UI', Arial, sans-serif;
             font-size: 11pt;
             line-height: 1.5;
-            color: var(--m365a-dark-gray);
-            background: var(--m365a-white);
+            color: var(--m365a-text);
+            background: var(--m365a-body-bg);
         }
 
         /* ----------------------------------------------------------
@@ -246,6 +282,35 @@
             letter-spacing: 0.5px;
         }
 
+        .cloud-badge {
+            display: inline-block;
+            padding: 3px 12px;
+            border-radius: 4px;
+            font-size: 10pt;
+            font-weight: 600;
+            letter-spacing: 0.3px;
+        }
+        .cloud-commercial {
+            background: #e8f0fe;
+            color: #1a73e8;
+            border: 1px solid #c5d9f7;
+        }
+        .cloud-gcc {
+            background: #e6f4ea;
+            color: #137333;
+            border: 1px solid #b7e1c5;
+        }
+        .cloud-gcchigh {
+            background: #fef3e0;
+            color: #c26401;
+            border: 1px solid #f5d9a8;
+        }
+        .cloud-dod {
+            background: #fce8e6;
+            color: #c5221f;
+            border: 1px solid #f5b7b1;
+        }
+
         .tenant-domains {
             margin-top: 15px;
             padding-top: 12px;
@@ -299,7 +364,7 @@
            Score Progress Bar
            ---------------------------------------------------------- */
         .score-bar-track {
-            background: #e9ecef;
+            background: var(--m365a-border);
             border-radius: 8px;
             height: 12px;
             margin: 0 0 20px 0;
@@ -310,6 +375,9 @@
             height: 100%;
             border-radius: 8px;
         }
+        .score-bar-fill.success { background: var(--m365a-success); }
+        .score-bar-fill.warning { background: var(--m365a-warning); }
+        .score-bar-fill.danger { background: var(--m365a-danger); }
 
         /* ----------------------------------------------------------
            Executive Summary
@@ -349,13 +417,19 @@
             margin-top: 3px;
         }
 
-        .stat-card.success { border-top-color: #2ecc71; }
-        .stat-card.warning { border-top-color: #f39c12; }
+        .stat-card .stat-value-sm { font-size: 18pt; }
+
+        .stat-card.success { border-top-color: var(--m365a-success); }
+        .stat-card.success .stat-value { color: var(--m365a-success); }
+        .stat-card.warning { border-top-color: var(--m365a-warning); }
+        .stat-card.warning .stat-value { color: var(--m365a-warning); }
+        .stat-card.danger { border-top-color: var(--m365a-danger); }
+        .stat-card.danger .stat-value { color: var(--m365a-danger); }
         .stat-card.error { border-top-color: var(--m365a-primary); }
         .stat-card.info { border-top-color: var(--m365a-accent); }
 
         .cis-disclaimer {
-            background: #f0f7ff;
+            background: var(--m365a-info-bg);
             border-left: 3px solid var(--m365a-accent);
             padding: 15px;
             margin: 15px 0;
@@ -365,6 +439,39 @@
         }
         .cis-disclaimer strong { color: var(--m365a-dark); }
         .cis-disclaimer p { margin: 8px 0 0 0; }
+
+        /* ----------------------------------------------------------
+           Section Advisory Blocks
+           ---------------------------------------------------------- */
+        .section-advisory {
+            background: var(--m365a-light-gray);
+            border-left: 3px solid var(--m365a-accent);
+            padding: 15px 18px;
+            margin: 12px 0 8px 0;
+            border-radius: 0 6px 6px 0;
+            font-size: 9.5pt;
+            color: var(--m365a-medium-gray);
+            line-height: 1.5;
+        }
+        .section-advisory strong { color: var(--m365a-dark); }
+        .section-advisory p { margin: 6px 0; }
+        .section-advisory code {
+            background: var(--m365a-border);
+            padding: 1px 5px;
+            border-radius: 3px;
+            font-size: 9pt;
+        }
+        .section-advisory .advisory-links {
+            margin-top: 10px;
+            padding-top: 8px;
+            border-top: 1px solid var(--m365a-border);
+            font-size: 8.5pt;
+        }
+        .section-advisory .advisory-links a {
+            color: var(--m365a-accent);
+            text-decoration: none;
+        }
+        .section-advisory .advisory-links a:hover { text-decoration: underline; }
 
         /* ----------------------------------------------------------
            Tables
@@ -402,7 +509,7 @@
         }
 
         tr:nth-child(even) { background: var(--m365a-light-gray); }
-        tr:hover { background: #e8f4f8; }
+        tr:hover { background: var(--m365a-hover-bg); }
 
         .num { text-align: right; font-variant-numeric: tabular-nums; }
         .notes { color: var(--m365a-medium-gray); font-size: 9pt; }
@@ -421,11 +528,12 @@
             letter-spacing: 0.5px;
         }
 
-        .badge-complete { background: #d4edda; color: #155724; }
+        .badge-complete { background: var(--m365a-success-bg); color: #155724; }
+        .badge-success { background: var(--m365a-success-bg); color: #155724; }
         .badge-skipped { background: #e2e3e5; color: #383d41; }
-        .badge-failed { background: #f8d7da; color: #721c24; }
-        .badge-warning { background: #fff3cd; color: #856404; }
-        .badge-info { background: #d1ecf1; color: #0c5460; }
+        .badge-failed { background: var(--m365a-danger-bg); color: #721c24; }
+        .badge-warning { background: var(--m365a-warning-bg); color: #856404; }
+        .badge-info { background: var(--m365a-info-bg); color: #0c5460; }
 
         /* ----------------------------------------------------------
            Section
@@ -486,7 +594,7 @@
             user-select: none;
         }
 
-        .data-table th:hover { background: #2a2a4e; }
+        .data-table th:hover { background: var(--m365a-dark-gray); }
 
         .data-table th::after {
             content: ' \2195';
@@ -582,10 +690,115 @@
             max-width: 350px;
         }
 
-        .cis-row-fail { border-left: 3px solid var(--m365a-primary); background-color: #fef2f2 !important; }
-        .cis-row-warning { border-left: 3px solid #f39c12; background-color: #fffbeb !important; }
-        .cis-row-review { border-left: 3px solid var(--m365a-accent); background-color: #f0f9ff !important; }
-        .cis-row-unknown { border-left: 3px solid var(--m365a-medium-gray); background-color: #f9fafb !important; }
+        .cis-row-fail { border-left: 3px solid var(--m365a-danger); background-color: var(--m365a-danger-bg); }
+        .cis-row-warning { border-left: 3px solid var(--m365a-warning); background-color: var(--m365a-warning-bg); }
+        .cis-row-review { border-left: 3px solid var(--m365a-accent); background-color: var(--m365a-info-bg); }
+        .cis-row-unknown { border-left: 3px solid var(--m365a-medium-gray); background-color: var(--m365a-light-gray); }
+
+        /* Framework cross-reference tags */
+        .framework-refs { white-space: normal; max-width: 260px; }
+        .fw-tag { display: inline-block; padding: 1px 5px; margin: 1px; border-radius: 3px; font-size: 0.72em; font-family: 'Consolas', 'Courier New', monospace; }
+        .fw-cis    { background: #e8f0fe; color: #1a56db; }
+        .fw-cis-l2 { background: #dbeafe; color: #1e40af; }
+        .fw-nist   { background: #e8f0fe; color: #1a56db; }
+        .fw-csf   { background: #fef3c7; color: #92400e; }
+        .fw-iso   { background: #ecfdf5; color: #065f46; }
+        .fw-stig  { background: #f3e8ff; color: #6b21a8; }
+        .fw-pci   { background: #fef2f2; color: #991b1b; }
+        .fw-cmmc  { background: #f0fdfa; color: #134e4a; }
+        .fw-hipaa { background: #fdf2f8; color: #9d174d; }
+        .fw-scuba { background: #fff7ed; color: #9a3412; }
+        .fw-unmapped { color: var(--m365a-border); font-size: 0.85em; }
+
+        /* Framework multi-selector */
+        .fw-selector { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; padding: 10px 14px; margin: 12px 0; background: var(--m365a-light-gray); border: 1px solid var(--m365a-border); border-radius: 6px; }
+        .fw-selector-label { font-weight: 600; font-size: 0.85em; color: var(--m365a-dark); margin-right: 4px; }
+        .fw-checkbox { display: inline-flex; align-items: center; gap: 4px; padding: 4px 10px; border: 1px solid var(--m365a-border); border-radius: 4px; font-size: 0.82em; cursor: pointer; transition: all 0.15s; background: var(--m365a-card-bg); user-select: none; }
+        .fw-checkbox:hover { background: var(--m365a-hover-bg); border-color: var(--m365a-accent); }
+        .fw-checkbox.active { background: var(--m365a-dark); color: #fff; border-color: var(--m365a-dark); }
+        .fw-checkbox input[type="checkbox"] { display: none; }
+        .fw-selector-actions { margin-left: auto; display: flex; gap: 4px; }
+        .fw-action-btn { padding: 3px 10px; border: 1px solid var(--m365a-border); border-radius: 3px; background: var(--m365a-card-bg); cursor: pointer; font-size: 0.78em; color: var(--m365a-medium-gray); }
+        .fw-action-btn:hover { background: var(--m365a-hover-bg); }
+
+        /* Status filter */
+        .status-filter { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; padding: 8px 14px; margin: 0 0 12px; background: var(--m365a-light-gray); border: 1px solid var(--m365a-border); border-radius: 6px; }
+        .status-filter-label { font-weight: 600; font-size: 0.85em; color: var(--m365a-dark); margin-right: 4px; }
+        .status-checkbox { display: inline-flex; align-items: center; gap: 4px; padding: 4px 10px; border: 1px solid var(--m365a-border); border-radius: 4px; font-size: 0.82em; cursor: pointer; transition: all 0.15s; background: var(--m365a-card-bg); user-select: none; }
+        .status-checkbox:hover { border-color: var(--m365a-accent); }
+        .status-checkbox input[type="checkbox"] { display: none; }
+        .status-fail.active { background: #fef2f2; color: #991b1b; border-color: #fca5a5; font-weight: 600; }
+        .status-warning.active { background: #fffbeb; color: #92400e; border-color: #fcd34d; font-weight: 600; }
+        .status-review.active { background: #f0f9ff; color: #1e40af; border-color: #93c5fd; font-weight: 600; }
+        .status-pass.active { background: #ecfdf5; color: #065f46; border-color: #6ee7b7; font-weight: 600; }
+        .status-unknown.active { background: #f9fafb; color: #6b7280; border-color: #d1d5db; font-weight: 600; }
+
+        /* Matrix table */
+        .matrix-table td { vertical-align: top; }
+        .matrix-table .framework-refs { max-width: 180px; }
+
+        /* ----------------------------------------------------------
+           Theme Toggle
+           ---------------------------------------------------------- */
+        .theme-toggle {
+            position: fixed; top: 16px; right: 16px; z-index: 1000;
+            background: var(--m365a-card-bg); border: 1px solid var(--m365a-border);
+            border-radius: 50%; width: 40px; height: 40px; cursor: pointer;
+            display: flex; align-items: center; justify-content: center;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.15); transition: all 0.3s ease;
+            font-size: 16px; line-height: 1; padding: 0;
+        }
+        .theme-toggle:hover { transform: scale(1.1); }
+        body:not(.dark-theme) .theme-icon-dark { display: none; }
+        body.dark-theme .theme-icon-light { display: none; }
+
+        /* ----------------------------------------------------------
+           Dark Theme Selector Overrides
+           (CSS variables handle most colors; these fix elements
+            with hardcoded colors or inverted semantics)
+           ---------------------------------------------------------- */
+        body.dark-theme th {
+            background: #1E3A5F;
+            color: #E2E8F0;
+            border-right: 1px solid rgba(255,255,255,0.15);
+        }
+        body.dark-theme th:last-child { border-right: none; }
+        body.dark-theme .data-table th:hover { background: #254E78; }
+
+        body.dark-theme .badge-complete,
+        body.dark-theme .badge-success { background: #065F46; color: #6EE7B7; }
+        body.dark-theme .badge-failed { background: #7F1D1D; color: #FCA5A5; }
+        body.dark-theme .badge-warning { background: #78350F; color: #FCD34D; }
+        body.dark-theme .badge-info { background: #1E3A5F; color: #93C5FD; }
+        body.dark-theme .badge-skipped { background: #334155; color: #94A3B8; }
+
+        body.dark-theme .fw-cis    { background: #1E3A5F; color: #93C5FD; }
+        body.dark-theme .fw-cis-l2 { background: #1E3A5F; color: #60A5FA; }
+        body.dark-theme .fw-nist   { background: #1E3A5F; color: #93C5FD; }
+        body.dark-theme .fw-csf    { background: #78350F; color: #FCD34D; }
+        body.dark-theme .fw-iso    { background: #064E3B; color: #6EE7B7; }
+        body.dark-theme .fw-stig   { background: #3B0764; color: #C4B5FD; }
+        body.dark-theme .fw-pci    { background: #7F1D1D; color: #FCA5A5; }
+        body.dark-theme .fw-cmmc   { background: #134E4A; color: #5EEAD4; }
+        body.dark-theme .fw-hipaa  { background: #831843; color: #F9A8D4; }
+        body.dark-theme .fw-scuba  { background: #7C2D12; color: #FDBA74; }
+
+        body.dark-theme .cloud-commercial { background: #1E3A5F; color: #93C5FD; border-color: #334155; }
+        body.dark-theme .cloud-gcc { background: #064E3B; color: #6EE7B7; border-color: #334155; }
+        body.dark-theme .cloud-gcchigh { background: #78350F; color: #FCD34D; border-color: #334155; }
+        body.dark-theme .cloud-dod { background: #7F1D1D; color: #FCA5A5; border-color: #334155; }
+
+        body.dark-theme .fw-checkbox.active { background: #3B82F6; color: #ffffff; border-color: #3B82F6; }
+        body.dark-theme .status-fail.active { background: #7F1D1D; color: #FCA5A5; border-color: #991B1B; }
+        body.dark-theme .status-warning.active { background: #78350F; color: #FCD34D; border-color: #92400E; }
+        body.dark-theme .status-review.active { background: #1E3A5F; color: #93C5FD; border-color: #1E40AF; }
+        body.dark-theme .status-pass.active { background: #064E3B; color: #6EE7B7; border-color: #065F46; }
+        body.dark-theme .status-unknown.active { background: #334155; color: #94A3B8; border-color: #475569; }
+
+        body.dark-theme .cis-disclaimer { background: #1E293B; }
+        body.dark-theme .section-advisory code { background: #334155; color: #E2E8F0; }
+
+        body.dark-theme .cover-tenant { color: #60A5FA; }
 
         /* ----------------------------------------------------------
            Footer
@@ -605,10 +818,20 @@
         }
 
         /* ----------------------------------------------------------
+           Focus Styles
+           ---------------------------------------------------------- */
+        a:focus-visible, .theme-toggle:focus-visible, .data-table th:focus-visible {
+            outline: 2px solid var(--m365a-accent);
+            outline-offset: 2px;
+        }
+
+        /* ----------------------------------------------------------
            Print Styles
            ---------------------------------------------------------- */
         @media print {
             body { font-size: 9pt; }
+            thead { display: table-header-group; }
+            .theme-toggle { display: none; }
 
             .cover-page {
                 min-height: auto;
@@ -645,6 +868,10 @@
             .data-table th::after { display: none; }
             .data-table { page-break-inside: auto; }
             tr { page-break-inside: avoid; }
+            .fw-selector { display: none; }
+            .status-filter { display: none; }
+            .matrix-table tr { display: table-row !important; }
+            .fw-col { display: table-cell !important; }
 
             @page {
                 size: letter;
@@ -658,23 +885,29 @@
     </style>
 </head>
 <body>
+    <!-- Theme Toggle -->
+    <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode" title="Toggle light/dark mode">
+        <span class="theme-icon-light">&#9788;</span>
+        <span class="theme-icon-dark">&#9790;</span>
+    </button>
+
     <!-- Cover Page -->
-    <div class="cover-page">
+    <header class="cover-page">
         <img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAyAAAADwCAYAAAD4pgDaAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAC0DSURBVHhe7d1tjFzXfd9xvzSKxOaLxJRQWMOZWaoryimYCkHkpG3YJ1doY4mSyN2ZXe7ejWQXtJXCiyCBWQUIiMaBAjsGWwOJ+qB6HZMEDRgVA7SIYMAwEagAgxgF0QAFY5rk7NPsLMnEW8VyllzFmuI/D8vZ/zn3zjn3ae/sfj/AD4HJuXPvDIXg/Oacc+8HPgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgV6Wg8cHq9MqxYZHX6WMBAAAAINThYPVoZaY5Xz21dq4ys3aleqrZqs4029s5NSTTzY3KqeaV8vTK65XplTOl6ZWn9TkAAAAA7FOloHWoMtM8U5ldu1ydWduozq61qzOD8SgfA6lMrz7M1OpmeWr1rU4hqTfH9TUAAAAA2MNkqVTl1OpcZbb5VqdwDCasfHgUkB3lw5ap1auVqdXTpaBxQF8bAAAAgD2iFNx5pDq7dm57pkNnR/mIN/thlI2oyMzIdHOhNNk6pK8VAAAAwIiSZVbV2dbr1Zm1TaN0hBaQjGY/bJlaaZfrKwulqdWj+toBAAAAjAhZ4lSdXXvNKBq25D37oQpIP50icrLxiP4sAAAAAAqsGjSPV2eaLaNohCVh+YhdQAbKx3bqKxuV2tK8/kwAAAAACkZmPcZmW2+NBS2zZIQlrHx4FBCjWLhGl48dRWT5Wmmywf4QAAAAoIgeD5rj1dnW9fjlI97sh1EqXKMLhy31lQ15yKH+rAAAAAB2UTVYe2ZstrUh5SN+Aclx9kMXjajUVzYrU0un9WcGAAAAsAvGguZ8v3jELx8FnP1QKdeXX9efHQAAAEBO5IGCY7NrC7HKh1FA/MtH7AJiKRcuKdeXJVd4gCEAAACQs94tdq8Olg+vAhJWPjwKiFEsXGMpF8PSKx/d1JavszkdRfXhR8ef+tDBI6986OCRL33o4JE3P3zwyI0PHzzS1vnQwSfelr+X13744JPHfvqnj/yEfq/dtP05PnLkjd7nMD5D93McebP3mlfkGP0+AABgD5CZj/TKR7zZD6NUuMZSLlyyo4B002AmJD8ysNQDT9986CNPvKrfN00/+VPjj+tzeifmAPrAR448K4Nw4/08I+8h76XfPy/yHUpx0tflGykj+r2Hkc+t3yerxLk+AAD2tbHZ9Uu6fMQvIDnOfliKhUss5WNwOdYH9feD9KVRQGQmQL9vmqTgWM7pF88C0p29sLxPwsjsiO+1JNErHqGzHL6R99LnGCar79IWCggAAB7GguYZXTzil4/iz35YSocOG9NzkFIBactSI/3eaQlb6uQVz0G/cXzK+cmPPHFKnzNtqRQ3FQoIAAB7ROdWu0nKh1FA/MtH7AJiKRcusRQOI6Uat+jNWloFRJb36PdOQyrLryQFKyCSrL6zv/NT4492Zlos50waCggAAHuAPGRw8DkfsQpIWPnwKCBGsXCNpVwMiy4aoZlc2ixNNjL7ZR3pFRCJfu80pPYrfgELiCTtmZDUCltIYhWQFPbQuIYCAgDAELLZemx2raGLR/zyEW/2wygVrrGUC5cYRSMstSXJBnfGyk6aBSSLZVipLL+SFLSASGTGQp8/jqzLhyRWAUlxD8qwUEAAABhibHbtii4eyQpIjrMflmLhEqNkhKVbPrqZXLpemmg8LbMhO8JG9cTSLCBpLymSQqPPETsFLiBpfG9yq1/9vlmEAgIAwAirBKs1XTqSlY/iz34YJUOntrxRri8vlOrLxzsF42Tjkf73Va4tv9YtI4u2bJQnFq+UJxffKp1snB48DtHSLCCSNJ95kcZtY7dT4AIiSToLktcgnwICAMCI6i29auni4VU+jALiXz5iFxBLuXCJUTi6acgdr0qTK5HLd2S2o1xbaljKhzWHJm5fK0005ksvNMb1e+GhtAtIms+60O+dKMkLyI3ufpQnj8lSJ+P1j44/Jfs54i4ZS/K9JdjkfaP/kEFdHLvLuZ48Jn8/uKE9TgGxnDezUEAAAAhRnW2d08XDu4CElQ+PAmIUC9dYysWwWIrH66WpxlH93UQpTTSO66Jhy6GJhsptWcI1z5Itk2sBcf0VWzYc63PE4bL8yvWaOolZQDqzMJ7H9oqIeQ0RifswR5k50e/lkBu+n6l7Z63uE+D13w1jOb8RXYAAAECKDgerR3XpSFY+4s1+GKXCNZZy4ZKHxWPpLd/iMag8uXhZFw4ds4D0cvJ2ozTRqOn33M+cC4jH3ajSGEy6LL/KsoDIeydZFuVbQuIM7IXL96TO86Uk/z5xjtXXYIs+BgAApGhsdm1BF49kBSTH2Q9LsXBJb3/HtWHLrFzI3hBdOJzKx84ZkWvc3rfLuYAcPPKm64A/yXIi4bKh2ud6OvEsIGkwriEicQqI712v0tjs7svl31KijwMAACkpBXceGZttberiEb98FH/2QzaWl+rLqc46lCcXr+ni4VdAtovIW/v9Fr+eBcRpr0HSZVhSYPR76nT3JhS7gPg8/yJOAfGZ/Uj6bxKX639f+jgAAJCSsL0fRsmISsLyEbuAWMrF0NRl1iP9AX7YXhCzYLjk9kbpxf07G+I6QOwO9ofvy+gnzlKdPqeB+6PjTxW+gDgWNolvQXCdWegnyb9HEi7/fcUpXwAAwEH3zldpzn7kuPQqRgEpT61cynLTd3li8Xry8tHZF9JJ6cTNeX2O/cBlgNgfJPoMeuM+4dv1HPJarztO7UYB8dg343v3Jp89JkmXxCXh8t8XBQQAgIyMBWundfGIXz7izX4YpcI1loIRlXJ95az+/GkrTTbOJC4gvfKxnRO3X8+yNBWRywBxcJA4eEvWqMjr9LlcOC2/6s0W6D+PzG4UEMfvKs71ebz3DX1snpz+PSkgAABkozq7dnWgdFztPAV9du1KJSTVmbXN8AKS4+yHpWCEpr6yUa0vH9efPQvysMFE5cNWQDol5NbV0nONA/p8e5VrAZHI631+1Y9zFymXZVX9X/T1n0fGc4CflO8GcX18FNdZIknc2/umxWUZ2m5sjgcAYM+SX9OrQfP44aA1Vw1ax/5e0PLaDyGb1uW4ykxzvjqzdql6qtkyCoilaNhiFAvX6JIRkbzKR588+Tx2AdHFQ5eQfTIT4ltAfJ474bsMy/W9+/sZ9J9HJscCItfnMUPhvfzKZy+O7aGJeXIsIF6fHwAAKFIyqkHr7I4Zj6CV2pKkw1OrRyszK/OVmeY1XTKiYhQLl1hKRmjqS2f0tWatNNmYM4qFa3TpMHNJn28v8i0gwnVw7bsMy2Vfw+Bmbf13kcmpgPS+T/e9KTE2iPvMQuljRecJ5x954lXbbJP8m8l3LP8WcWawNAoIAAAZKQUbB2SPR3V2/Zre49ErIJncZalUb45XT629Vp1utnThSFw+PAqIbDjX15YHucOWUSxcYpYNa0ov3Mq9VOUtTgFxKQr9+AxiXYrN4IZq/XeRyaiAdJdadQf0vsWjmye9/3+DrTjYMri3ojsrM7wM6MjyKJ9/Q83pjmYHj9yI+rfv3QL6S/Lf3W7P6AAAsOtkmc5YsD4/Nru+MRasG8Wjk9nWZtbLeTpLvaabZ6vTzY28y0fnVrsZf74o8nRzo2BExVI0QnNCSsj3c11Wlrc4BcR1qZTEdQ+C63sOzhbov4tMggLiOuD3Tdy7U+n3CUv/u+/tR4lRjh7GdzldX0bf3Q25Ht+ZIwAARl4laNXGZtcb3eIRUj46BWTtij42K6Wg8Uj11Nq5xAVEl4zwtLJ4zoePQxO3F4ySERVdMsJyopcXb22WTn7vqD7vXhGngAjHX7YlTndhcplV0ZuV9d9HpnAFxH/mQ3htQD945BXfzfBR0d+/i2y+u8HE+x4BABgpspyqOidLrfrFI7qAVGfXX9PvkbVS0DpUmV69bBQL15hFw5q8N53blE42ThslIyy6ZISlXz56eezFW9f0efeKuAXE5faq/bgsm3H7hX7nYNP8+4gUpIDIrESSX+59/r08SqJzfEtImt9dWHyvCQCAkSF3pBqbW78yNrfe7sShfEgqwWpNv1deSrJhfXrlulEwomIpGtbUlwsxKC9NNJ42ikZYdNEIy0D5KJ241cvefFChz4B28DivX+KHLMNy/ZVeH6f/PjK7WECkCEhhS1I8+nz+vbKL+6yDeWw2kT0kaXy/AAAUxuHgztGxufWGvXxEF5DDwequLt+RJ7CXp1bfMopGWHTRCImUG32u3SDP7DCKhi26ZIRFzX70C8hjL95s7eZel6z4DGj1sfLLs35NSCKXYbnc1cn2K7d+TWR2s4DIJurOZ3zyWNJBcpyN5FnE9XPo47KM7b8RAABGUjVYPz42t765XT6MAmKWjsFIAdDvuRvKU6vnjLKhYykatpSnVi7r999NhyZubxiFI075UAXk4ezHrXbpxVvt0vN7bxYkSQHxeR5FVAGIs/yqd5zldSGJOP8wSQuITpI7SxWlgLjeOlcfl3XibpYHAKAwOne4mrvzsHh4lo+x2bWWfs/dVJlaPV2ZWt00iodH+ajUVzaLMvvRd+jk7atG6YhTQMLKR6+APPbizQ15Ars+/yhLUkCEfk1Ywn6ddlx+ZZ1BsbwuPAUqIP3EGSwnKSDdGaudszDyvbjMQNmy88pMPsv00ozr7AwAAIXSub3u3N2F6PLhVEByuwOWq+r0yrHK1OpG3AIiMyn6PXdb5J2wdMkIS8jSq+3Zj14ee/FW4T5/EkkLiM/gVR8rXI4P20OiXxeZAhYQSVgxCxO/gJgzSINkRibqWRz2RL+nz39bacZ1dgYAgMLolo87V4zyYRQQS+HQKWABEaXJ1qHK1GrLt3xISvXGuH6/3ZZ2AbHNfjwsIDc39tJeEJ9Boj5WOM5g9GIOWM3XmAm7i5Z+XWQKWkAkPiUkXgExv3cb12ex9DPsurul5sgrnVssy39nvejX9XXO/+j4U/L6hHfwss6YAQBQWGNzdy51y0fC2Y9OAVnflSeEuyhNrzy9vRzLUjRCcl2/TxEcmrj9mlE8YpYPo4AMlI/tPP/9Z/Q1jKqkBUS47eEwB6yOe0hCB5OW14YnYuCbRFqDZtflWL4FRK5Jv0cUlxmp7fc++MTb+vg0dQqMx/UMJqy0AgBQOGNB64y1fBgFxFI2LKnOri3ocxRJpb5cs5SM0JSnVnN/pkmU4NLmoeD8e8c+/ut3v3b0M2vtnWm2j7y0bJYNW3zKh8yCvHDrdX0toyqNAuIzKFbHDb2LVtjyK6FfG5mMCogm+w98npEyGJe9Cz7fdTdusx99fjNa4f9NpCnO9xn3KfMAAOSqe7erfvmImv0wi0ZYqrOtwg9UpVToohEWmTXRx+clWHj3keDCg7m5C1uX5y4+uDp3cavtmhN/8KP2L//eX7d/4TfutMeDJbfyEVlAbhbq5gJJpFFA/JbuPBwQm39nJuqXbP3ayORUQPqkTPjuqXCZBfH595Lo413o94iKS2lKg2/xYh8IAKDwus/5uLM5vHy4F5Dq7FrhZ0D65La6umxY0tDHZS24eH88OH9/3rdwDIsUkn969q/aH3t5JbyAWIrHjjx/Y9fKWJp8BrT62EGug+3+jIbLL+3Dlvjo10cm5wIifO8CNezzCp9/L5f3s3FdUtdJTt+r93fpufQMAIBcdZ9wfqdhLR9GATGLhi298jEyBUQ2VcuTzS2lYzvl+kousznBQvtAcPHB2bkLW9d1ccgiU1+93/7EFzbah6cbXgXksRdvFmo5Wlw+A1p97KDORmPLMTr9QbHLL9rDZgT06yOT00BZc/1e+tHHaz4Dcdk8r4934bXpPsfv1ee64n52AAByUZ27c9Vt6ZV/AakU9C5YNqXJxiF5xocuHv1Ua8uZbrwOFtof7M12bOiSkEdmzz/ozIpU6w2jbNjy2Is3C7kh31daBcRnYNxdnjR8MDnsYX369ZHJcaA8yGWmx/c6jWNCEncGxOXfZjsO15sWn+uigAAACity34dRQMyiYcvA7MdIFRDReVq6pXxIsrz9bm9vR0OXgt3Iqa/db//i5++0yydvG6VjRwF54eam/hyjKK0CIpzvAuVwTpfBsz4mMjkOlDXjWqLicJ0+A3F9rAv9HlHRx2bJ53PrO64BAFAY1bn1a6EFJEb50AWkOrM2Ur+Sy1O+w2ZBSkHjgH59UsHXN5+Zu7h1TZeAIqT2XzbbP/e5llE8tvPCzXbpufS/k7y5lIF+9LGa692KXPaLDFt+JfQxkXEY2GfBb4O+23W6LF/zeb9Bvterj8+Sy383/bAJHQBQSGPB+mm38uFeQHaUj15G7aF1lfrSGV0+yrXl1H/t7y63Mgf+RcsnvvADe/no5C8ymxXKS5oFxGcZ1rAMW34l9DGR8RyIp8W1lPlcp8+/me9MgM/15rnMybcYcRteAEDhdJ92vt6ylg+jgJhFwxZdPB4WkOZIDVI7G9KnVlo7Ckh9ObU7YMlej7mLWwt6oF/kHP+PP2xXawN7Q/oF5MXvez1joYh8BrP6WBuXZ3sMi+vAVh8XGYeBfRZ8lg1J9PFh9HFRcSlzfV6zDBHPaEmb8/K+Xnw+MwAAuRgL1ufzmP3o5FTzuD5/0VVqS/MD5UOSyl4WucNV2rfUzSuyJOuJuaWB2Y9O5vRnHDVpFxDHp5tHxvXXa31cZBwLSKcwOL52mBhlLPSp75rPe7vektb3jl1Rz2gRaX2XPrMyvTh/jwAA5KJ72931DWv5MAqIWTRsMUrHQCozzTP6Gopu8La8nQJSW7qkX+MruPDgaFE2mseNbFD/2c+sPiwgx2+M3L+tlnYBEfo437g+3E4fFxnHgXD/9TITIANf12sZJL+++/5i3zmnx4yC7921pLBEfZYsBvkD537TtVQOivs9uuwfAgAgV2NB64zb7IdZNMKiS8eOAjK7dllfwyioTC2d7s1+SBI9A6RTPnbp9rpZ5KlfbXYLyPPfP6s/66jJooDIQFof6xrXX+uFPjYyngVkxzUdfOJt+UydQfqj40/ZBvLy5/L3PjMTOsNmFDTf5V1SGnSpkhmrOIN8l0Khj5HIuTqb6B8df8r2eeXPkn6Ptn8fAAB2VXXuzvXh5cO9gOjCYWRmbUNfwyiQu17J5vNeAYn9QMVg4d1HRn3mQ0eeGfLkS8sUkBC+v84PxmVg26ePjUyCApJHXPe9DPL5t0s5Q2c/hOW4zMPdrwAAhXM4uHPUWj6MAmIWDVuMshGSw8HqUX0to6BcW7qcZA9Id8P5aO75GBbZE/IzLy19Tn/mUeMziNXHRpFBqj7eJT6/XutjI1PwAmKbDXARZ/YicQr6Xbo8OwYAgNxV5+6+Zi0gWc1+9FKZac7raxkFpfpyrbsHZDnW80zmLmxd0gP3vZSpr97/P1Ky9OceJVkVEK9nVfTie8tYfXxkCjpoliT51b536+NYZS9OfPap6GOzTtwSBwBAph4+eDC/2Y/qjBSQ0Xoiel9nGVa3gHgvIwvO3z+jB+x7Mw8S7Y/ZbVkVEN/nNnTzpNdtjc3jI1LQAuJbumySLHnzie+16uOzDOUDAFBIpWDjwPDZD7NohMUoGmGZ6aYUtA7paxoF5dryNSkhPg9U7D3h3DJY35sJLmyd1t/BqMiqgAifZ0rEeX99fGQKWEB8B/RRsi4hca5Vv0dWoXwAAArrcNCaiy4f7gXEKBlh6ZWPbpojuWG5XF862ykgkw3nAjV3ceuaHqTv8bRGdSlWlgXE57kSmQ9wC1dA/GZ7XPRKSOrLseIuEdPvk3Zk477PniEAAHJXnbvzeq5Lr3QBObWa2tPE81SqLT/TLSArTgOm4Pz9ecsAfR/kvXP6uxgFWRaQ3v4E433s8R+Qm+8REccCkvWm7mHP40hK3jvJbZAHIwP8JLML+v1STOd2wvp8AAAUTnXuztXw8pFBAdk5+9HNCD4VvXSy8Uj3TlhLQ2dwune92mqZg/PRyr/7H++1/3Txx+3r6++3//fKj9u//a33jNeYebAptxzW30nRZVlAhOuAXh/nQr9HZBwLiOg+AO+JV32XkIVF3kdmg7IsHlrnM8R8lkZaTzCXz9t5pofjfwPDIu9D8QAAjJTu08/DCohZNGwxSkZYdpSPhwWkMtO8pq9rFMgmdNkLov9c2wuzH1/+znvtrb9tG77yJ39rvNbMaM6CIFx3M/2Tx2QZUu8hevLwv9BlTvL3vbwix8nx+j3z1J2FkocNSqGyP7iwd71fksF9ltcrpUaKWP9awq7H9j3mWd4AAEhFKbjzSNLyEb+A9GY/tmdBlp/R11d05fry1WH7QDoPHLz4YNMclI9OfuuP7eVD3Hv3feP1tshT3/V3AwAAgH1mLFh/2l4+3AuIUTLCEjL70VuC1a5Mr17W11d05drSpV4BOaP/rk9+/deD8VGKlI8fPdC1Y6fPftM8zsiFrZH79wUAAEDKqkHrmL2AmEXDFqNkRCWifGxn2m1Dd1GU68sL5dpSu1xbCn2eydyFrYYxGB+R/PofvdeZ4Ygi5UQfZ4/sBRnNO2IBAAAgJd1b8OrykUEBCSsfqoBUTjWv+TxXY7eVJ5fO9gpIWzal678Pzm89bQ7ERyOf++9bQ8uH+J//98fGsWEJLt4fuZsNAAAAIEX2AmIWDVuMkhGWIUuvdCrTK/P6OotqRwGpNYzrDi4+OKsH4aMQWVK19IPh5ePP195vf/ob5vERWdDfEQAAAPaRsWDttFP5mF27Ug1aZ3dkppk802Yq0ytnKlOrpwf/rDy94p963MgDBh0i5WMgpVrjtKT7vxud1N/YHLlb70qhuHlvePmQguK092MgM+fvb370+e+d7af03PdHaskdAAAAEurMgDgUECkc+tgsjU2vPF2dbm72NqfHy9SKd7rP9XCMzHxM7nwGiMyClCcX25InfmXFGIAXPVI+ZFZjmLV3/MtHP3//3yy3H3v+Ricffe57uf53BQAAgF22s4CYxWO3CoionFqtxS4glnLhEqNkhKW37MooIEHjg+XJxZYUkF/8/D1j8F30yEMGh5F9IbI5XR/rmn/yW39JAQEAANivqsH68aIWEFGeWn3NKBcusZSLYTFKRlj65aO77+O0vubSRKMmBeTZ//BDY/Bd5Lx9a3j5kDteJSkfkhO//263gByngAAAAOw7ndvwDikfu1lARHl69bJRMKJiKRcuMYpGWAYLyGRjTl+vKE8uXpv4z39jDL6Lmj/6c7fyIc8E0cf6Zvb8g075oIAAAADsQ48HzXFdNmzZzQIiy5oq0yvXjKJhi6VYuMQoGWEZKB+9GRDr09ufmF3+x3rgXdR881rII84HyFPQf/fbyctHP+MzDQoIAADAfjU229rUhUNnNwuIKE22DlWmVltG4dCxlIthMUpGVHQBsTz7QwQXHhzVg+4i5o2rbuXjy99Jr3xInnpllQICAACwX1VnW9d04dCRW+bq4/JWmlo9Wpla3TBKR4Ly4VVAVPko15Y29DX2BeffO6YH3S6Rh/9958aP29fX3+/syUhjyVNYvvInw8uHkJKij02an59fo4AAAADsV2Oz65d04dApQgERnZmQsOVYlnIxLEbJCItZPiRX9fX1BRcf1PSge1ikfMg+Cy2LAiAzGjKzMcwf/ln655b8o8+vtx87/j0KCAAAwH40FjTndeHYUT46TzMvRgERpaBxwNiYbikXLjGKRljM8iF/fk5fW19w4cGcHnQPS9RdqNIsITKr4lI+ZGO6Pjat/NJv3qWAAAAA7FfDNqIXrYD0bd+i11IsXGKUjLDo4tFL2AZ0EVzYOq0H3cMiD/eLkkYJkfJhm2XRvnU9u/Ih+aXfvEMBAQAA2M/GZtcaunhsl4+CFhBRqS/XKvWVTV0uhsUoGVGxlI/y5NKm3J1LX09fnBkQlyeQJykh8vwOeYjgMDITo49NOxQQAACAfW5sdm0htHwUuICI7ub0lZYuGVExSkZYdPF4mCv6OgbFKSCyL8NFnBIi+0tcyoeUIH1sFqGAAAAA7HPVYO2ZUS0gorMvZGr1nC4athglIyxm6dhO6aT5BPRBce+C5fJAQOFTQj77za320g/cysenv2Een0V+fr5JAQEAANjvxmbXWtbyMQIFpK80vfJ0pb58VZeOVAuILL96rnFAn3tQcH7raT3odk2aJUQKxc17w8uHFBQpKvr4rPJz/3a1/dhzFBAAAIB9rTrbOjfqBaSvMrU0V5lauZ56+egUkMXL+nxasNA+oAfdPkmjhEj5cNlXIpvf8ywfkiNzDQoIAADAfnc4WD1qLR8jWED6qvXl45X68jWv8hFVQCYX26WJxnF9Hpu5i1stPfD2SdIS8qeLw4+XfSGyOV0fm3UOvXCDAgIAAACZBVk7Z5SPES4gfbI0q1xfXijXljeMsqGjS4fn7Eff3MWtK3rg7Zu4JSTqmSJ9cjve3SgfE6//qFM+KCAAAAD4QCm480h1Zm1zrxWQPrl1bmlyaa5cX3rLWkZ04dCzHycbR/V7hjn19c0v6MF3nPiWEJfXS/mQZ4Loc+WRf/k7P6CAAAAA4CHrLMgeKSBaaapxtFRbmi/Xli6Xa8vXjNLhMftRqjfGSycazxyauP3aoZO3r37s06vG4DtuXEqF+O7S8NfJU9B/99u7Uz4kT312hQICAACAh2SWoDrTbO2HAmLTKRK1xjPlyaWz25lYfK08ufh6ebJxdmcW3ypPLl6T2RHJoYnGjtT+66YxAI8b1xISRcqHPG9Ev3demf36g+39H3upgFRfvnfs8Mv32kZeuvuqfi0AAAAsKjPN+f1aQGxKE435fsmIii4gn/idDWMQniRJS4jeK5J3Pvnld7bLx14qIGMv3/2SUT66uaFfCwAAAAtjFmQfFxD5LsqTiy1dNnR0+ZD8g19dMwbhSRO3hPzhn+1u+ZB8/NfW9lwBOfLZOz9hKR7bkdkRfQwAAAAsqkHr2PaG9H1cQMqTi5d02dDRxaOfSm2xPXv+gTEQTxrfEiKv1++xG3l86taeKyBjL987pUuHyhv6GAAAAISozKye3s8FpDTZOKPLhi26eAzmX33xHWMgnkZcS8i3rhejfLzwlR/uKB97qIC8bSkdOyKzJPo4AAAAhOjcFWsfFhB54KAuGrbowqGT5t2wdIaVEHkeiD5mtzJ496u9UkDGP3X3cV02ZMZD/5nMkuhjAQAAEKF6au0Z/Wd7mdwJqzyxuKnLhi26cNiS1SyI5LvL7+ve0dF6533jtbsV2+zHXiggts3nIXfEYjM6AACAD7krVilojus/34tKQeNAeWKxoYuGLbpohOXxmaVM9oL0879u/7g9WEOur7/f/vQ3zNftVo4EDaN87IUCYika7d6f39B/LrMl+ngAAACEkCVY1VOrDRmc67/bSzp3vJpYvKKLhi26ZAzLP//tdG/Ja8sXv737d7rS+ddf/H9G8dgLBaT60r1ndcnoP/dD/q/+O5kt0e8BAACAEJ0CMtNsV0+tXt+rMyGdmY/aklP5iFNAZBZk6qv3jQH6Xo48eHB85rZRPLYLyCevj2wBse316M9yhOwNYTM6AACAq+0C0ikhzY3q9MqeerZBZ89Hbclp2VWc8tHPPzxzxxik7+X8s7N/aZSOvVBAxj9991FdLvQ+D9syLJk1GXwNAAAAQqgC0kllavW0ft0oKtUbx8u1pQ1dMqKii4VTTt7u5Jd/76+NgfpejGw8P/TCDaN0bJePZ/9iZAvI45+694ouF/Jng6+xPR9k7OW7bw6+BgAAACEeLsEy8rp+7Sgp1Rrz5dpSuxNL0bDFKBau6RWQymSjfeIPfmQM2PdSpv7bpvHQQZ1RLiC22Q2ZFRl8TcgsifG6NMnSLylCUnRs19j78zfkNUk3xed5rj5ZwiazSLKfxvb8lc45X7r7ahZPn8/z8+Z5LgAACiuigLQrp5pXRm1zemezeW3pUt7lo5/xYKl96mt7cz+I7Pv42EuLRuEwyseIFpDqp+49ZQ4I772tXyd6A8Udr+1vVE9Tb0O8MVB1iPftgfM8V58UD9vG/iG5kcaStzw/b57nAgCg8Lp3wTLLx3amZV9I86wM7PWxRdOb9Whtl4+sC4gqH/0c/Uwz01vz7lY+/mtrRuGwlo8RLSC2Z3+EPWjQeqesFAeLvc3ucQas29HvGSbPcw0Kea6Kc6Qcxtn8n+fnzfNcAACMjKEF5GERaRV1b0hvr0djR/HIunxEFBDJL/zG3tqUPmzT+agXkM4v8ZbBX9gAN+z1aSwRCrvTlm/0+9rkea5Btr02ceJbQvL8vHmeCwCAkSKzG0bZsKQyvdrLyvVqffm4fp/dUJpcOVauLV01iodH+YhdQCylQ2ev3BnrX/z7vzLKhs6O8jGCBSRkRuMN/bpBthmTYccME7a/RCLnk4KjB9wy0O3MJnSXMm3/2j74Gps8zzUoasmV7bxyzt7Gf+tMgmsJyfPz5nkuAABGjn8B6WVq9UqlvlzT75eHUm35mXJt6bJROmIUEKNYuMZSOGw5ero5sntCZM/HsGVXe6WA2DY+D9tnELaESA8sfVj3lsi1fOreU/q1YeS1LnflyvNcfSFFr1MiXDbxh5Q+p/03eX7ePM8FAMDIcSkgRvnYWUQ2ytPNhayfH1Kaahwt15fPlevLrXJ92SwcBSwfh050c+RXltsT/+lvjAF+kTP11c2hG85Dy8eIFZCwX6v162z0MZKwfSPDhC3Z8Rm0usrzXH1h37PrDEZfWAmJKjB5ft48zwUAwEgaVkCMwhGVqdXN8tTqW5XplfnS9MrT+lw+pHCUakunu3e0Wt7olI7B6NKRVwHRJSMqvQIiqdYb7WfPjcZzQk78/rtDb7UbWT5GrIDYlgTJIFe/zsZ2bNzN6LZ9EWF34Uoqz3P12WYFfMtHn205VtS/WZ6fN89zAQAwkmTmolNCQlKeXvFP/WEqU0tzcg6Xu2iVJhpPl+rLtXJ96WxkJqPScErpZNzccsuL9nzyy++8HZy//54e9Bclz51757uVEze/8NHnvnfWKZ+8bs3ffe56pjNiadKDRYnrZvKwX7vlz/Vrh5H9I/p9XJYWxZHnuYTtFseSuLMCYUu59Ov68vy8eZ4LAADASbDw7iNzF7cW9OB/V3Nh63Jw8f64vta9LmQfh9cMhu+v8WFsMwRZDVzzPJewLZuK8x0N0u8nCSs0eX7ePM8FAADgRQb8MvA3ykCueXA1OP+e06/9e1Eav1bbltxIfJcW2Qfp2SzdyfNcobcsDikLrmz/dvJvoV8n8vy8eZ4LAAAgFikAcxe3rpjlIMNc2LoeXLxfiNsp75awTdG+y6fC3mfYXbS0sCKTdKBuk+e50phlsgn5DNbbIIe8NpPPm+e5AAAAEpGlWcGFrdPZzYrIbMf9+f241Mqm92wJPVCMNTC23cbX9xaqYftJOoNXxz0prvI8l22jftLlV8K2DyTsO8/z8+Z5LgAAgNQEC+0PBhcf1Lp7RR5smGXCJQ825i5sXQouPJgLFtoH9Dn2O/vejXi30LUNhiVRt4a1se4feJg3fGdnouR1Ltt5wpZK+QjZ2B5aIG3XkcXnFXmeCwAAIBOdQnL+vWOdMnHxwdnQXNg63XkdhSNSyODVuzD0he1z8N1PEracazAyuPVd3mWT17lsRS/L6PP35fV5RZ7nAgAAwAiwbxS2L99xZdsUHfWLfJioJTxGXrr7atzSJPI4l/E+GUeff1Aen7cvz3MBAACgwEJnKzJKnHX/MhgdsoxnR6RQxR3AZn0ufXzW0efXsv68g/I8FwAAAAoqbL9GVkmy4VqWivkMYH2XfA3K6lzGcRlHnz9MVp/XJs9zAQAAoGC8BoIpxfeZIFpvAGssG7NF7siV5Hxpn0sfIynSLWnT/rxR8jwXAAAACsBlc3AWiXt3LU0GpL3nTERu7E5j8JrWufTre8ek8n2kKa3P6yLPcwEAAGAX2Z5JkUeyeBJ2bylZ6AA2jVvd9iU5l23GKer1RZDk8/rK81wAAADImW2gl2SPhk1Yycnq2Q9RS3rS/vU8zrlC7g5mfWJ50cT5vHHleS4AAADkQO5GpQd2krSLQdgyr7SLzqCwwWsWey18z9VbamS8Xr+uqHw/bxJ5ngsAAAAZC/kl3vs5HS5kyZXlXJkNuuUXcn0uSRbLd3zPFfbQx1EZVPt+3iTyPBcAAAAyFDawy+p2p2G3+s3yydd57rXwPZd+rSTLGaG0+X7eJPI8FwAAADIid13SgzpJ2suv+sIKT9KnrUfJc+Dqe66wpUVZff9p8/28SeR5LgAAAGQkZElUJsuv+kIH3Rk96VqfRxLnKewu9HmGnSt8X0zy28x2yl5GM1l9+rqHfd4k9HmyPBcAAAAyIL+y6wFdb/Cb6bMowja9h/2aLYPouDMCYUu+wgb3eZ6rL6yQJSkh/e942MxSnp83z3MBAACggMIGvlnNRAyy3fY3bOalv/RGrtdnABtWsKJmBfI8V19vWZrt++h8Jz6b0ntPFN9eqjSsgOT5efM8FwAAAArIGNBl9GBAm7BngtiW1Oi1/3KNMlsig21dluR/y3uElSsZ0Ef9ap7nuQaFDrIHrkNmpnQZkfeXP5NrtC2ncy0gg+fJ6vPmeS4AAAAUTNiSlqyXX/WF730w7wClB65JMuyX9zzPpQ0rIXHiW0CSZNjnzfNcAAAAKJiwwWCevyrbfrG3XUPYtfpE3kP/ym6T57lsZGAd9r34xuU68vy8eZ4LAAAABRI2+yAPJNSvzZLrLExvKU6swasM5n2eMZLnuaL0vpuwfSGRkVkkvVQrTJ6fN89zAQAAAIl19gW8dO9ZGWCHDWR7f/6GlJgky3TyPFeUzt2sXrr7avg1yN6Qu2929lK8fO+Ynj1ylefnzfNcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADstv8PKlMEK8cS3/wAAAAASUVORK5CYII=' alt='M365 Assess' class='cover-logo' />
         <div class="cover-title">M365 Environment</div>
         <div class="cover-title" style="margin-top: 0;">Assessment Report</div>
         <div class="cover-divider"></div>
-        <div class="cover-tenant">Northwind Traders</div>
+        <div class="cover-tenant">Contoso Corporation</div>
         <div class="cover-subtitle">March 5, 2026</div>
         <div class="cover-date">v0.3.0</div>
-    </div>
+    </header>
 
     <!-- Content -->
-    <div class="content">
+    <main class="content">
         <!-- Executive Summary -->
         <h1>Executive Summary</h1>
         <p>This report summarizes the findings of the Microsoft 365 environment assessment
-        conducted for <strong>Northwind Traders</strong> on
+        conducted for <strong>Contoso Corporation</strong> on
         <strong>March 5, 2026</strong>. The assessment evaluated
         <strong>27</strong> configuration areas across
         <strong>8</strong> sections.</p>
@@ -700,9 +933,9 @@
         <p><strong>3 issue(s)</strong> were identified during the assessment:
         0 error(s) and 3 warning(s). See the
         <a href="#issues">Technical Issues</a> section for details.</p>
-        <p>Security configuration was evaluated against <strong>70 of 140 CIS Microsoft 365
-        Foundations Benchmark v6.0.1</strong> controls. <strong>21 finding(s)</strong> require
-        attention. See the <a href="#cis-compliance">CIS Compliance Summary</a> for details and remediation guidance.</p>
+        <p>Security configuration was evaluated against <strong>70</strong> controls across
+        <strong>12 compliance frameworks</strong>. <strong>21 finding(s)</strong> require
+        attention. See the <a href="#compliance-overview">Compliance Overview</a> for details and cross-framework mapping.</p>
         <nav class='report-toc'>
 <h2 class='toc-heading'>Table of Contents</h2>
 <ol class='toc-list'>
@@ -714,7 +947,7 @@
 <li><a href='#section-security'>Security</a></li>
 <li><a href='#section-collaboration'>Collaboration</a></li>
 <li><a href='#section-hybrid'>Hybrid</a></li>
-<li><a href='#cis-compliance'>CIS Compliance Summary</a></li>
+<li><a href='#compliance-overview'>Compliance Overview</a></li>
 <li><a href='#issues'>Technical Issues</a></li>
 </ol>
 </nav>
@@ -727,6 +960,7 @@
 <div class='tenant-org-name'>Northwind Traders</div>
 <div class='tenant-facts'>
 <div class='tenant-fact'><span class='fact-label'>Primary Domain</span><span class='fact-value'>northwindtraders.com</span></div>
+<div class='tenant-fact'><span class='fact-label'>Cloud</span><span class='cloud-badge cloud-commercial'>Commercial</span></div>
 <div class='tenant-fact'><span class='fact-label'>Established</span><span class='fact-value'>June 2019</span></div>
 <div class='tenant-fact'><span class='fact-label'>Security Defaults</span><span class='fact-value'>False</span></div>
 </div>
@@ -752,9 +986,9 @@
 </div>
 <details class='section' id='section-identity' open>
 <summary><h2>Identity</h2></summary>
-<p class='section-description'>User accounts, MFA enrollment, admin roles, conditional access policies, and password policies. Identity is the primary attack surface &mdash; these controls determine who can access your environment and how they authenticate.</p>
+<p class='section-description'>User accounts, MFA enrollment, admin roles, conditional access policies, and password policies. Identity is the primary attack surface &mdash; these controls determine who can access your environment and how they authenticate. Compromised credentials remain the leading cause of data breaches; strong identity controls (MFA, least-privilege roles, conditional access) are the single most effective defense. See <a href="https://learn.microsoft.com/en-us/entra/fundamentals/concept-secure-remote-workers" target="_blank">Microsoft Entra identity security guidance</a>.</p>
 <table class='summary-table'>
-<thead><tr><th>Collector</th><th>Status</th><th>Items</th><th>Duration</th><th>Notes</th></tr></thead>
+<thead><tr><th scope='col'>Collector</th><th scope='col'>Status</th><th scope='col'>Items</th><th scope='col'>Duration</th><th scope='col'>Notes</th></tr></thead>
 <tbody>
 <tr>
 <td>User Summary</td>
@@ -809,51 +1043,29 @@
 <div class='exec-summary'>
 <div class='stat-card info'><div class='stat-value'>182</div><div class='stat-label'>Total Users</div></div>
 <div class='stat-card info'><div class='stat-value'>145</div><div class='stat-label'>Licensed</div></div>
-<div class='stat-card' style='border-top-color: #f39c12;'><div class='stat-value' style='color: #f39c12;'>77.5%</div><div class='stat-label'>MFA Adoption</div><div class='stat-detail'>31 / 40 capable</div></div>
-<div class='stat-card' style='border-top-color: #f39c12;'><div class='stat-value' style='color: #f39c12;'>77.5%</div><div class='stat-label'>SSPR Enrolled</div><div class='stat-detail'>31 / 40 capable</div></div>
+<div class='stat-card warning'><div class='stat-value'>77.5%</div><div class='stat-label'>MFA Adoption</div><div class='stat-detail'>31 / 40 capable</div></div>
+<div class='stat-card warning'><div class='stat-value'>77.5%</div><div class='stat-label'>SSPR Enrolled</div><div class='stat-detail'>31 / 40 capable</div></div>
 <div class='stat-card info'><div class='stat-value'>12</div><div class='stat-label'>Guest Users</div></div>
+<div class='stat-card danger'><div class='stat-value'>25</div><div class='stat-label'>Disabled Users</div></div>
+<div class='stat-card info'><div class='stat-value'>98</div><div class='stat-label'>Synced From On-Prem</div></div>
+<div class='stat-card info'><div class='stat-value'>84</div><div class='stat-label'>Cloud Only</div></div>
+<div class='stat-card warning'><div class='stat-value'>131</div><div class='stat-label'>With MFA</div><div class='stat-detail'>72% of all users</div></div>
 </div>
-<details class='collector-detail'>
-<summary><h3>User Summary <span class='row-count'>(1 rows)</span></h3></summary>
-<div class='table-wrapper'>
-<table class='data-table'>
-<thead><tr>
-<th>Total Users</th>
-<th>Licensed</th>
-<th>Guest Users</th>
-<th>Disabled Users</th>
-<th>Synced From On Prem</th>
-<th>Cloud Only</th>
-<th>With MFA</th>
-</tr></thead>
-<tbody>
-<tr>
-<td>182</td>
-<td>145</td>
-<td>12</td>
-<td>25</td>
-<td>98</td>
-<td>84</td>
-<td>131</td>
-</tr>
-</tbody></table>
-</div>
-</details>
 <details class='collector-detail'>
 <summary><h3>MFA Report <span class='row-count'>(40 rows)</span></h3></summary>
 <div class='table-wrapper'>
 <table class='data-table'>
 <thead><tr>
-<th>User Principal Name</th>
-<th>User Display Name</th>
-<th>Is Mfa Registered</th>
-<th>Is Mfa Capable</th>
-<th>Is Passwordless Capable</th>
-<th>Is Sspr Registered</th>
-<th>Is Sspr Capable</th>
-<th>Methods Registered</th>
-<th>Default Mfa Method</th>
-<th>Is Admin</th>
+<th scope='col'>User Principal Name</th>
+<th scope='col'>User Display Name</th>
+<th scope='col'>Is Mfa Registered</th>
+<th scope='col'>Is Mfa Capable</th>
+<th scope='col'>Is Passwordless Capable</th>
+<th scope='col'>Is Sspr Registered</th>
+<th scope='col'>Is Sspr Capable</th>
+<th scope='col'>Methods Registered</th>
+<th scope='col'>Default Mfa Method</th>
+<th scope='col'>Is Admin</th>
 </tr></thead>
 <tbody>
 <tr>
@@ -1344,12 +1556,12 @@
 <div class='table-wrapper'>
 <table class='data-table'>
 <thead><tr>
-<th>Role Name</th>
-<th>Role Id</th>
-<th>Member Display Name</th>
-<th>Member UPN</th>
-<th>Member Type</th>
-<th>Member Id</th>
+<th scope='col'>Role Name</th>
+<th scope='col'>Role Id</th>
+<th scope='col'>Member Display Name</th>
+<th scope='col'>Member UPN</th>
+<th scope='col'>Member Type</th>
+<th scope='col'>Member Id</th>
 </tr></thead>
 <tbody>
 <tr>
@@ -1432,15 +1644,15 @@
 <div class='table-wrapper'>
 <table class='data-table'>
 <thead><tr>
-<th>Display Name</th>
-<th>State</th>
-<th>Created Date Time</th>
-<th>Modified Date Time</th>
-<th>Include Users</th>
-<th>Exclude Users</th>
-<th>Include Applications</th>
-<th>Grant Controls</th>
-<th>Session Controls</th>
+<th scope='col'>Display Name</th>
+<th scope='col'>State</th>
+<th scope='col'>Created Date Time</th>
+<th scope='col'>Modified Date Time</th>
+<th scope='col'>Include Users</th>
+<th scope='col'>Exclude Users</th>
+<th scope='col'>Include Applications</th>
+<th scope='col'>Grant Controls</th>
+<th scope='col'>Session Controls</th>
 </tr></thead>
 <tbody>
 <tr>
@@ -1528,14 +1740,14 @@
 <div class='table-wrapper'>
 <table class='data-table'>
 <thead><tr>
-<th>Display Name</th>
-<th>App Id</th>
-<th>Created Date Time</th>
-<th>Sign In Audience</th>
-<th>Password Credential Count</th>
-<th>Key Credential Count</th>
-<th>Earliest Expiry</th>
-<th>Expired Credentials</th>
+<th scope='col'>Display Name</th>
+<th scope='col'>App Id</th>
+<th scope='col'>Created Date Time</th>
+<th scope='col'>Sign In Audience</th>
+<th scope='col'>Password Credential Count</th>
+<th scope='col'>Key Credential Count</th>
+<th scope='col'>Earliest Expiry</th>
+<th scope='col'>Expired Credentials</th>
 </tr></thead>
 <tbody>
 <tr>
@@ -1606,12 +1818,12 @@
 <div class='table-wrapper'>
 <table class='data-table'>
 <thead><tr>
-<th>Domain</th>
-<th>Is Default</th>
-<th>Password Validity Period</th>
-<th>Password Notification Window In Days</th>
-<th>Allow Cloud Password Validation</th>
-<th>Allow Email Verified Users To Join Organization</th>
+<th scope='col'>Domain</th>
+<th scope='col'>Is Default</th>
+<th scope='col'>Password Validity Period</th>
+<th scope='col'>Password Notification Window In Days</th>
+<th scope='col'>Allow Cloud Password Validation</th>
+<th scope='col'>Allow Email Verified Users To Join Organization</th>
 </tr></thead>
 <tbody>
 <tr>
@@ -1638,13 +1850,13 @@
 <div class='table-wrapper'>
 <table class='data-table'>
 <thead><tr>
-<th>Category</th>
-<th>Setting</th>
-<th>Current Value</th>
-<th>Recommended Value</th>
-<th>Status</th>
-<th>Cis Control</th>
-<th>Remediation</th>
+<th scope='col'>Category</th>
+<th scope='col'>Setting</th>
+<th scope='col'>Current Value</th>
+<th scope='col'>Recommended Value</th>
+<th scope='col'>Status</th>
+<th scope='col'>Cis Control</th>
+<th scope='col'>Remediation</th>
 </tr></thead>
 <tbody>
 <tr class='cis-row-fail'>
@@ -1763,7 +1975,7 @@
 <summary><h2>Licensing</h2></summary>
 <p class='section-description'>Microsoft 365 license allocation and utilization. Understanding license distribution helps identify unused spend and ensures users have the entitlements needed for security features like Defender and Intune.</p>
 <table class='summary-table'>
-<thead><tr><th>Collector</th><th>Status</th><th>Items</th><th>Duration</th><th>Notes</th></tr></thead>
+<thead><tr><th scope='col'>Collector</th><th scope='col'>Status</th><th scope='col'>Items</th><th scope='col'>Duration</th><th scope='col'>Notes</th></tr></thead>
 <tbody>
 <tr>
 <td>License Summary</td>
@@ -1778,13 +1990,13 @@
 <div class='table-wrapper'>
 <table class='data-table'>
 <thead><tr>
-<th>License</th>
-<th>Sku Part Number</th>
-<th>Total</th>
-<th>Assigned</th>
-<th>Available</th>
-<th>Suspended</th>
-<th>Warning</th>
+<th scope='col'>License</th>
+<th scope='col'>Sku Part Number</th>
+<th scope='col'>Total</th>
+<th scope='col'>Assigned</th>
+<th scope='col'>Available</th>
+<th scope='col'>Suspended</th>
+<th scope='col'>Warning</th>
 </tr></thead>
 <tbody>
 <tr>
@@ -1874,29 +2086,15 @@
 </details>
 <details class='section' id='section-email' open>
 <summary><h2>Email</h2></summary>
-<p class='section-description'>Mailbox configuration, mail flow rules, email authentication (SPF/DKIM/DMARC), and Exchange Online security settings. Email remains the #1 attack vector &mdash; these controls protect against phishing, spoofing, and data exfiltration.</p>
+<p class='section-description'>Mailbox infrastructure, Exchange Online security configuration, email protection policies, mail flow, and DNS-based email authentication. Email remains the #1 attack vector &mdash; over 90% of cyberattacks begin with a phishing email, and business email compromise (BEC) accounts for billions in losses annually.</p>
 <table class='summary-table'>
-<thead><tr><th>Collector</th><th>Status</th><th>Items</th><th>Duration</th><th>Notes</th></tr></thead>
+<thead><tr><th scope='col'>Collector</th><th scope='col'>Status</th><th scope='col'>Items</th><th scope='col'>Duration</th><th scope='col'>Notes</th></tr></thead>
 <tbody>
 <tr>
 <td>Mailbox Summary</td>
 <td><span class="badge badge-complete">Complete</span></td>
 <td class='num'>8</td>
 <td class='num'>00:15</td>
-<td class='notes'></td>
-</tr>
-<tr>
-<td>Mail Flow</td>
-<td><span class="badge badge-complete">Complete</span></td>
-<td class='num'>8</td>
-<td class='num'>00:07</td>
-<td class='notes'></td>
-</tr>
-<tr>
-<td>Email Security</td>
-<td><span class="badge badge-complete">Complete</span></td>
-<td class='num'>7</td>
-<td class='num'>00:19</td>
 <td class='notes'></td>
 </tr>
 <tr>
@@ -1907,6 +2105,20 @@
 <td class='notes'></td>
 </tr>
 <tr>
+<td>Email Security</td>
+<td><span class="badge badge-complete">Complete</span></td>
+<td class='num'>7</td>
+<td class='num'>00:19</td>
+<td class='notes'></td>
+</tr>
+<tr>
+<td>Mail Flow</td>
+<td><span class="badge badge-complete">Complete</span></td>
+<td class='num'>8</td>
+<td class='num'>00:07</td>
+<td class='notes'></td>
+</tr>
+<tr>
 <td>DNS Authentication</td>
 <td><span class="badge badge-complete">Complete</span></td>
 <td class='num'>6</td>
@@ -1914,180 +2126,34 @@
 <td class='notes'></td>
 </tr>
 </tbody></table>
-<details class='collector-detail'>
-<summary><h3>Mailbox Summary <span class='row-count'>(8 rows)</span></h3></summary>
-<div class='table-wrapper'>
-<table class='data-table'>
-<thead><tr>
-<th>Metric</th>
-<th>Count</th>
-</tr></thead>
-<tbody>
-<tr>
-<td>Total Mailboxes</td>
-<td>158</td>
-</tr>
-<tr>
-<td>User Mailboxes</td>
-<td>145</td>
-</tr>
-<tr>
-<td>Shared Mailboxes</td>
-<td>10</td>
-</tr>
-<tr>
-<td>Room Mailboxes</td>
-<td>2</td>
-</tr>
-<tr>
-<td>Equipment Mailboxes</td>
-<td>1</td>
-</tr>
-<tr>
-<td>Archive Enabled</td>
-<td>42</td>
-</tr>
-<tr>
-<td>Litigation Hold</td>
-<td>8</td>
-</tr>
-<tr>
-<td>Inactive Mailboxes</td>
-<td>3</td>
-</tr>
-</tbody></table>
+<div class='exec-summary'>
+<div class='stat-card info'><div class='stat-value'>158</div><div class='stat-label'>Total Mailboxes</div></div>
+<div class='stat-card info'><div class='stat-value'>145</div><div class='stat-label'>User Mailboxes</div></div>
+<div class='stat-card info'><div class='stat-value'>10</div><div class='stat-label'>Shared Mailboxes</div></div>
+<div class='stat-card info'><div class='stat-value'>2</div><div class='stat-label'>Room Mailboxes</div></div>
+<div class='stat-card info'><div class='stat-value'>1</div><div class='stat-label'>Equipment Mailboxes</div></div>
+<div class='stat-card info'><div class='stat-value'>42</div><div class='stat-label'>Archive Enabled</div></div>
+<div class='stat-card info'><div class='stat-value'>8</div><div class='stat-label'>Litigation Hold</div></div>
+<div class='stat-card info'><div class='stat-value'>3</div><div class='stat-label'>Inactive Mailboxes</div></div>
 </div>
-</details>
-<details class='collector-detail'>
-<summary><h3>Mail Flow <span class='row-count'>(8 rows)</span></h3></summary>
-<div class='table-wrapper'>
-<table class='data-table'>
-<thead><tr>
-<th>Item Type</th>
-<th>Name</th>
-<th>Status</th>
-<th>Details</th>
-</tr></thead>
-<tbody>
-<tr>
-<td>Transport Rule</td>
-<td>Disclaimer - External Email Footer</td>
-<td>Enabled</td>
-<td>Appends HTML disclaimer to all outbound external messages</td>
-</tr>
-<tr>
-<td>Transport Rule</td>
-<td>Block Auto-Forward to External</td>
-<td>Enabled</td>
-<td>Rejects messages with auto-forward headers to external recipients</td>
-</tr>
-<tr>
-<td>Transport Rule</td>
-<td>Encrypt Sensitive Data</td>
-<td>Enabled</td>
-<td>Applies Office 365 Message Encryption when subject contains [Encrypt]</td>
-</tr>
-<tr>
-<td>Transport Rule</td>
-<td>Flag Large Attachments</td>
-<td>Disabled</td>
-<td>Generates incident report for attachments over 25 MB</td>
-</tr>
-<tr>
-<td>Accepted Domain</td>
-<td>northwindtraders.com</td>
-<td>Authoritative</td>
-<td>Primary SMTP domain</td>
-</tr>
-<tr>
-<td>Accepted Domain</td>
-<td>mail.northwindtraders.com</td>
-<td>Authoritative</td>
-<td>Secondary mail domain</td>
-</tr>
-<tr>
-<td>Remote Domain</td>
-<td>Default (*)</td>
-<td>AllowedOOFType: External</td>
-<td>Auto-forward disabled</td>
-</tr>
-<tr>
-<td>Connector</td>
-<td>Inbound from Barracuda Gateway</td>
-<td>Enabled</td>
-<td>Partner connector; TLS enforced; IP restricted to 198.51.100.0/24</td>
-</tr>
-</tbody></table>
+<div class='exec-summary'>
+<div class='stat-card info'><div class='stat-value'>14</div><div class='stat-label'>EXO Controls</div></div>
+<div class='stat-card success'><div class='stat-value'>10</div><div class='stat-label'>Pass</div></div>
+<div class='stat-card error'><div class='stat-value'>2</div><div class='stat-label'>Fail</div></div>
+<div class='stat-card warning'><div class='stat-value'>2</div><div class='stat-label'>Warning</div></div>
 </div>
-</details>
-<details class='collector-detail'>
-<summary><h3>Email Security <span class='row-count'>(7 rows)</span></h3></summary>
-<div class='table-wrapper'>
-<table class='data-table'>
-<thead><tr>
-<th>Policy Type</th>
-<th>Name</th>
-<th>Enabled</th>
-<th>Key Settings</th>
-</tr></thead>
-<tbody>
-<tr>
-<td>Anti-Phishing</td>
-<td>Office365 AntiPhish Default</td>
-<td>True</td>
-<td>PhishThresholdLevel: 2; EnableMailboxIntelligenceProtection: True</td>
-</tr>
-<tr>
-<td>Anti-Phishing</td>
-<td>Executives Anti-Phish Policy</td>
-<td>True</td>
-<td>PhishThresholdLevel: 3; EnableTargetedUserProtection: True; TargetedUsers: 4</td>
-</tr>
-<tr>
-<td>Anti-Spam</td>
-<td>Default Anti-Spam Inbound</td>
-<td>True</td>
-<td>BulkThreshold: 7; SpamAction: MoveToJmf; HighConfidenceSpamAction: Quarantine</td>
-</tr>
-<tr>
-<td>Anti-Spam</td>
-<td>Default Anti-Spam Outbound</td>
-<td>True</td>
-<td>AutoForwardingMode: Off; RecipientLimitPerDay: 500; BccSuspiciousOutbound: True</td>
-</tr>
-<tr>
-<td>Anti-Malware</td>
-<td>Default Anti-Malware</td>
-<td>True</td>
-<td>EnableFileFilter: True; FileFilterAction: Reject; ZapEnabled: True</td>
-</tr>
-<tr>
-<td>Safe Links</td>
-<td>Built-In Protection</td>
-<td>True</td>
-<td>EnableSafeLinksForEmail: True; ScanUrls: True; TrackClicks: True</td>
-</tr>
-<tr>
-<td>Safe Attachments</td>
-<td>Built-In Protection</td>
-<td>True</td>
-<td>Enable: True; Action: Block; Redirect: admin@northwindtraders.com</td>
-</tr>
-</tbody></table>
-</div>
-</details>
 <details class='collector-detail'>
 <summary><h3>EXO Security Config <span class='row-count'>(14 rows)</span></h3></summary>
 <div class='table-wrapper'>
 <table class='data-table'>
 <thead><tr>
-<th>Category</th>
-<th>Setting</th>
-<th>Current Value</th>
-<th>Recommended Value</th>
-<th>Status</th>
-<th>Cis Control</th>
-<th>Remediation</th>
+<th scope='col'>Category</th>
+<th scope='col'>Setting</th>
+<th scope='col'>Current Value</th>
+<th scope='col'>Recommended Value</th>
+<th scope='col'>Status</th>
+<th scope='col'>Cis Control</th>
+<th scope='col'>Remediation</th>
 </tr></thead>
 <tbody>
 <tr class='cis-row-fail'>
@@ -2219,52 +2285,230 @@
 </tbody></table>
 </div>
 </details>
+<div class='exec-summary'>
+<div class='stat-card success'><div class='stat-value stat-value-sm'>Enabled</div><div class='stat-label'>Anti-Phishing</div><div class='stat-detail'>Office365 AntiPhish Default</div></div>
+<div class='stat-card success'><div class='stat-value stat-value-sm'>Enabled</div><div class='stat-label'>Anti-Phishing</div><div class='stat-detail'>Executives Anti-Phish Policy</div></div>
+<div class='stat-card success'><div class='stat-value stat-value-sm'>Enabled</div><div class='stat-label'>Anti-Spam</div><div class='stat-detail'>Default Anti-Spam Inbound</div></div>
+<div class='stat-card success'><div class='stat-value stat-value-sm'>Enabled</div><div class='stat-label'>Anti-Spam</div><div class='stat-detail'>Default Anti-Spam Outbound</div></div>
+<div class='stat-card success'><div class='stat-value stat-value-sm'>Enabled</div><div class='stat-label'>Anti-Malware</div><div class='stat-detail'>Default Anti-Malware</div></div>
+<div class='stat-card success'><div class='stat-value stat-value-sm'>Enabled</div><div class='stat-label'>Safe Links</div><div class='stat-detail'>Built-In Protection</div></div>
+<div class='stat-card success'><div class='stat-value stat-value-sm'>Enabled</div><div class='stat-label'>Safe Attachments</div><div class='stat-detail'>Built-In Protection</div></div>
+</div>
 <details class='collector-detail'>
-<summary><h3>DNS Authentication <span class='row-count'>(6 rows)</span></h3></summary>
+<summary><h3>Email Policies <span class='row-count'>(7 rows)</span></h3></summary>
 <div class='table-wrapper'>
 <table class='data-table'>
 <thead><tr>
-<th>Policy Type</th>
-<th>Name</th>
-<th>Enabled</th>
-<th>Key Settings</th>
+<th scope='col'>Policy Type</th>
+<th scope='col'>Name</th>
+<th scope='col'>Enabled</th>
+<th scope='col'>Key Settings</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>SPF</td>
+<td>Anti-Phishing</td>
+<td>Office365 AntiPhish Default</td>
+<td>True</td>
+<td>PhishThresholdLevel: 2; EnableMailboxIntelligenceProtection: True</td>
+</tr>
+<tr>
+<td>Anti-Phishing</td>
+<td>Executives Anti-Phish Policy</td>
+<td>True</td>
+<td>PhishThresholdLevel: 3; EnableTargetedUserProtection: True; TargetedUsers: 4</td>
+</tr>
+<tr>
+<td>Anti-Spam</td>
+<td>Default Anti-Spam Inbound</td>
+<td>True</td>
+<td>BulkThreshold: 7; SpamAction: MoveToJmf; HighConfidenceSpamAction: Quarantine</td>
+</tr>
+<tr>
+<td>Anti-Spam</td>
+<td>Default Anti-Spam Outbound</td>
+<td>True</td>
+<td>AutoForwardingMode: Off; RecipientLimitPerDay: 500; BccSuspiciousOutbound: True</td>
+</tr>
+<tr>
+<td>Anti-Malware</td>
+<td>Default Anti-Malware</td>
+<td>True</td>
+<td>EnableFileFilter: True; FileFilterAction: Reject; ZapEnabled: True</td>
+</tr>
+<tr>
+<td>Safe Links</td>
+<td>Built-In Protection</td>
+<td>True</td>
+<td>EnableSafeLinksForEmail: True; ScanUrls: True; TrackClicks: True</td>
+</tr>
+<tr>
+<td>Safe Attachments</td>
+<td>Built-In Protection</td>
+<td>True</td>
+<td>Enable: True; Action: Block; Redirect: admin@northwindtraders.com</td>
+</tr>
+</tbody></table>
+</div>
+</details>
+<details class='collector-detail'>
+<summary><h3>Mail Flow <span class='row-count'>(8 rows)</span></h3></summary>
+<div class='table-wrapper'>
+<table class='data-table'>
+<thead><tr>
+<th scope='col'>Item Type</th>
+<th scope='col'>Name</th>
+<th scope='col'>Status</th>
+<th scope='col'>Details</th>
+</tr></thead>
+<tbody>
+<tr>
+<td>Transport Rule</td>
+<td>Disclaimer - External Email Footer</td>
+<td>Enabled</td>
+<td>Appends HTML disclaimer to all outbound external messages</td>
+</tr>
+<tr>
+<td>Transport Rule</td>
+<td>Block Auto-Forward to External</td>
+<td>Enabled</td>
+<td>Rejects messages with auto-forward headers to external recipients</td>
+</tr>
+<tr>
+<td>Transport Rule</td>
+<td>Encrypt Sensitive Data</td>
+<td>Enabled</td>
+<td>Applies Office 365 Message Encryption when subject contains [Encrypt]</td>
+</tr>
+<tr>
+<td>Transport Rule</td>
+<td>Flag Large Attachments</td>
+<td>Disabled</td>
+<td>Generates incident report for attachments over 25 MB</td>
+</tr>
+<tr>
+<td>Accepted Domain</td>
 <td>northwindtraders.com</td>
+<td>Authoritative</td>
+<td>Primary SMTP domain</td>
+</tr>
+<tr>
+<td>Accepted Domain</td>
+<td>mail.northwindtraders.com</td>
+<td>Authoritative</td>
+<td>Secondary mail domain</td>
+</tr>
+<tr>
+<td>Remote Domain</td>
+<td>Default (*)</td>
+<td>AllowedOOFType: External</td>
+<td>Auto-forward disabled</td>
+</tr>
+<tr>
+<td>Connector</td>
+<td>Inbound from Barracuda Gateway</td>
+<td>Enabled</td>
+<td>Partner connector; TLS enforced; IP restricted to 198.51.100.0/24</td>
+</tr>
+</tbody></table>
+</div>
+</details>
+<div class='section-advisory'>
+<strong>Email Authentication Protocols</strong>
+<p><strong>SPF</strong> (Sender Policy Framework) specifies which mail servers are authorized to send email on behalf of your domain. Without SPF, attackers can send emails that appear to come from your domain with no way for recipients to detect the forgery.</p>
+<p><strong>DKIM</strong> (DomainKeys Identified Mail) adds a cryptographic signature to outgoing messages, proving they haven't been tampered with in transit. DKIM protects message integrity and is essential for DMARC alignment.</p>
+<p><strong>DMARC</strong> (Domain-based Message Authentication, Reporting &amp; Conformance) ties SPF and DKIM together with a policy that tells receiving servers what to do with messages that fail authentication &mdash; monitor (<code>p=none</code>), quarantine, or reject. DMARC at <code>p=reject</code> is the gold standard and is required by <a href='https://www.cisa.gov/news-events/directives/bod-18-01-enhance-email-and-web-security' target='_blank'>CISA BOD 18-01</a> for federal agencies.</p>
+<p><strong>MTA-STS</strong> (RFC 8461) enforces TLS encryption for inbound email transport, preventing man-in-the-middle downgrade attacks. <strong>TLS-RPT</strong> (RFC 8460) provides daily reports on TLS delivery failures so you know when encrypted delivery is failing.</p>
+<p>This assessment queries both local and public DNS servers (Google 8.8.8.8, Cloudflare 1.1.1.1) to confirm records are live. SPF records are validated against the RFC 7208 10-DNS-lookup limit, and duplicate records that would cause PermError are flagged.</p>
+<p class='advisory-links'><strong>Official Resources:</strong> <a href='https://learn.microsoft.com/en-us/defender-office-365/email-authentication-about' target='_blank'>Microsoft Email Authentication</a> &middot; <a href='https://learn.microsoft.com/en-us/defender-office-365/email-authentication-dmarc-configure' target='_blank'>Configure DMARC</a> &middot; <a href='https://learn.microsoft.com/en-us/purview/enhancing-mail-flow-with-mta-sts' target='_blank'>MTA-STS for Exchange Online</a> &middot; <a href='https://csrc.nist.gov/pubs/sp/800/177/r1/final' target='_blank'>NIST SP 800-177</a> &middot; <a href='https://www.cisa.gov/news-events/directives/bod-18-01-enhance-email-and-web-security' target='_blank'>CISA BOD 18-01</a></p>
+</div>
+<div class='exec-summary'>
+<div class='stat-card success'><div class='stat-value'>3 / 3</div><div class='stat-label'>SPF Configured</div></div>
+<div class='stat-card warning'><div class='stat-value'>1 / 3</div><div class='stat-label'>DMARC Enforced</div><div class='stat-detail'>0 monitoring only</div></div>
+<div class='stat-card warning'><div class='stat-value'>2 / 3</div><div class='stat-label'>DKIM Configured</div></div>
+<div class='stat-card warning'><div class='stat-value'>1 / 3</div><div class='stat-label'>MTA-STS</div><div class='stat-detail'>Transport encryption</div></div>
+<div class='stat-card warning'><div class='stat-value'>1 / 3</div><div class='stat-label'>TLS-RPT</div><div class='stat-detail'>TLS failure reporting</div></div>
+<div class='stat-card success'><div class='stat-value'>3 / 3</div><div class='stat-label'>Public DNS</div><div class='stat-detail'>Confirmed live</div></div>
+</div>
+<details class='collector-detail'>
+<summary><h3>DNS Authentication <span class='row-count'>(3 rows)</span></h3></summary>
+<div class='table-wrapper'>
+<table class='data-table'>
+<thead><tr>
+<th scope='col'>Domain</th>
+<th scope='col'>Domain Type</th>
+<th scope='col'>Default</th>
+<th scope='col'>SPF</th>
+<th scope='col'>SPF Enforcement</th>
+<th scope='col'>SPF Lookup Count</th>
+<th scope='col'>SPF Duplicates</th>
+<th scope='col'>DMARC</th>
+<th scope='col'>DMARC Policy</th>
+<th scope='col'>DMARC Pct</th>
+<th scope='col'>DMARC Reporting</th>
+<th scope='col'>DMARC Duplicates</th>
+<th scope='col'>DKIM Selector1</th>
+<th scope='col'>DKIM Selector2</th>
+<th scope='col'>MTASTS</th>
+<th scope='col'>TLSRPT</th>
+<th scope='col'>Public DNS Confirm</th>
+</tr></thead>
+<tbody>
+<tr>
+<td>northwindtraders.com</td>
+<td>Authoritative</td>
 <td>True</td>
 <td>v=spf1 include:spf.protection.outlook.com include:spf.barracuda.com -all</td>
-</tr>
-<tr>
-<td>DKIM</td>
-<td>northwindtraders.com</td>
-<td>True</td>
-<td>selector1._domainkey.northwindtraders.com: CNAME configured; Status: Enabled</td>
-</tr>
-<tr>
-<td>DMARC</td>
-<td>northwindtraders.com</td>
-<td>True</td>
+<td>Hard Fail (-all)</td>
+<td>2 / 10</td>
+<td>No</td>
 <td>v=DMARC1; p=quarantine; rua=mailto:dmarc@northwindtraders.com; pct=100</td>
+<td>quarantine</td>
+<td>100% (default)</td>
+<td>rua=mailto:dmarc@northwindtraders.com</td>
+<td>No</td>
+<td>selector1-northwindtraders-com._domainkey.northwind.onmicrosoft.com</td>
+<td>selector2-northwindtraders-com._domainkey.northwind.onmicrosoft.com</td>
+<td>v=STSv1; id=20260101T000000Z</td>
+<td>v=TLSRPTv1; rua=mailto:tls-reports@northwindtraders.com</td>
+<td>Confirmed (Google + Cloudflare)</td>
 </tr>
 <tr>
-<td>SPF</td>
 <td>mail.northwindtraders.com</td>
-<td>True</td>
+<td>Authoritative</td>
+<td>False</td>
 <td>v=spf1 include:spf.protection.outlook.com -all</td>
+<td>Hard Fail (-all)</td>
+<td>1 / 10</td>
+<td>No</td>
+<td>Not configured</td>
+<td>N/A</td>
+<td>N/A</td>
+<td>N/A</td>
+<td>No</td>
+<td>Not configured</td>
+<td>Not configured</td>
+<td>Not configured</td>
+<td>Not configured</td>
+<td>Confirmed (Google + Cloudflare)</td>
 </tr>
 <tr>
-<td>DKIM</td>
-<td>mail.northwindtraders.com</td>
+<td>northwindtraders.onmicrosoft.com</td>
+<td>Authoritative</td>
 <td>False</td>
-<td>DKIM signing not enabled for secondary domain</td>
-</tr>
-<tr>
-<td>DMARC</td>
-<td>mail.northwindtraders.com</td>
-<td>False</td>
-<td>No DMARC record found</td>
+<td>v=spf1 include:spf.protection.outlook.com -all</td>
+<td>Hard Fail (-all)</td>
+<td>1 / 10</td>
+<td>No</td>
+<td>Not configured</td>
+<td>N/A</td>
+<td>N/A</td>
+<td>N/A</td>
+<td>No</td>
+<td>selector1-northwindtraders-onmicrosoft-com._domainkey.northwind.onmicrosoft.com</td>
+<td>selector2-northwindtraders-onmicrosoft-com._domainkey.northwind.onmicrosoft.com</td>
+<td>Not configured</td>
+<td>Not configured</td>
+<td>Confirmed (Google + Cloudflare)</td>
 </tr>
 </tbody></table>
 </div>
@@ -2274,7 +2518,7 @@
 <summary><h2>Intune</h2></summary>
 <p class='section-description'>Device enrollment, compliance policies, and configuration profiles. Intune controls ensure corporate devices meet security baselines and that non-compliant devices are restricted from accessing company data.</p>
 <table class='summary-table'>
-<thead><tr><th>Collector</th><th>Status</th><th>Items</th><th>Duration</th><th>Notes</th></tr></thead>
+<thead><tr><th scope='col'>Collector</th><th scope='col'>Status</th><th scope='col'>Items</th><th scope='col'>Duration</th><th scope='col'>Notes</th></tr></thead>
 <tbody>
 <tr>
 <td>Device Summary</td>
@@ -2303,18 +2547,18 @@
 <div class='table-wrapper'>
 <table class='data-table'>
 <thead><tr>
-<th>Device Name</th>
-<th>User Display Name</th>
-<th>User Principal Name</th>
-<th>Operating System</th>
-<th>Os Version</th>
-<th>Compliance State</th>
-<th>Management Agent</th>
-<th>Enrolled Date Time</th>
-<th>Last Sync Date Time</th>
-<th>Model</th>
-<th>Manufacturer</th>
-<th>Serial Number</th>
+<th scope='col'>Device Name</th>
+<th scope='col'>User Display Name</th>
+<th scope='col'>User Principal Name</th>
+<th scope='col'>Operating System</th>
+<th scope='col'>Os Version</th>
+<th scope='col'>Compliance State</th>
+<th scope='col'>Management Agent</th>
+<th scope='col'>Enrolled Date Time</th>
+<th scope='col'>Last Sync Date Time</th>
+<th scope='col'>Model</th>
+<th scope='col'>Manufacturer</th>
+<th scope='col'>Serial Number</th>
 </tr></thead>
 <tbody>
 <tr>
@@ -2465,13 +2709,13 @@
 <div class='table-wrapper'>
 <table class='data-table'>
 <thead><tr>
-<th>Display Name</th>
-<th>Id</th>
-<th>Created Date Time</th>
-<th>Last Modified Date Time</th>
-<th>Platform</th>
-<th>Version</th>
-<th>Description</th>
+<th scope='col'>Display Name</th>
+<th scope='col'>Id</th>
+<th scope='col'>Created Date Time</th>
+<th scope='col'>Last Modified Date Time</th>
+<th scope='col'>Platform</th>
+<th scope='col'>Version</th>
+<th scope='col'>Description</th>
 </tr></thead>
 <tbody>
 <tr>
@@ -2527,13 +2771,13 @@
 <div class='table-wrapper'>
 <table class='data-table'>
 <thead><tr>
-<th>Display Name</th>
-<th>Id</th>
-<th>Created Date Time</th>
-<th>Last Modified Date Time</th>
-<th>Platform</th>
-<th>Version</th>
-<th>Description</th>
+<th scope='col'>Display Name</th>
+<th scope='col'>Id</th>
+<th scope='col'>Created Date Time</th>
+<th scope='col'>Last Modified Date Time</th>
+<th scope='col'>Platform</th>
+<th scope='col'>Version</th>
+<th scope='col'>Description</th>
 </tr></thead>
 <tbody>
 <tr>
@@ -2596,9 +2840,9 @@
 </details>
 <details class='section' id='section-security' open>
 <summary><h2>Security</h2></summary>
-<p class='section-description'>Microsoft Secure Score, Defender for Office 365 policies, and Data Loss Prevention rules. These controls provide defense-in-depth against malware, ransomware, and accidental data leakage.</p>
+<p class='section-description'>Microsoft Secure Score, Defender for Office 365 policies, and Data Loss Prevention rules. These controls provide defense-in-depth against malware, ransomware, and accidental data leakage. Defender policies should be configured at <em>Standard</em> or <em>Strict</em> preset levels as defined in the <a href="https://learn.microsoft.com/en-us/defender-office-365/recommended-settings-for-eop-and-office365" target="_blank">Microsoft recommended security settings</a>. DLP rules prevent sensitive data (PII, financial records, health information) from leaving the organization via email, chat, or file sharing.</p>
 <table class='summary-table'>
-<thead><tr><th>Collector</th><th>Status</th><th>Items</th><th>Duration</th><th>Notes</th></tr></thead>
+<thead><tr><th scope='col'>Collector</th><th scope='col'>Status</th><th scope='col'>Items</th><th scope='col'>Duration</th><th scope='col'>Notes</th></tr></thead>
 <tbody>
 <tr>
 <td>Secure Score</td>
@@ -2637,22 +2881,22 @@
 </tr>
 </tbody></table>
 <div class='exec-summary'>
-<div class='stat-card' style='border-top-color: #f39c12;'><div class='stat-value' style='color: #f39c12;'>72.1%</div><div class='stat-label'>Secure Score</div></div>
+<div class='stat-card warning'><div class='stat-value'>72.1%</div><div class='stat-label'>Secure Score</div></div>
 <div class='stat-card info'><div class='stat-value'>287</div><div class='stat-label'>Points Earned</div></div>
 <div class='stat-card'><div class='stat-value'>398</div><div class='stat-label'>Points Possible</div></div>
-<div class='stat-card' style='border-top-color: #2ecc71;'><div class='stat-value' style='color: #2ecc71;'>68.4%</div><div class='stat-label'>M365 Average</div></div>
+<div class='stat-card success'><div class='stat-value'>68.4%</div><div class='stat-label'>M365 Average</div></div>
 </div>
-<div class='score-bar-track'><div class='score-bar-fill' style='width: 72.1%; background: #f39c12;'></div></div>
+<div class='score-bar-track'><div class='score-bar-fill warning' style='width: 72.1%;'></div></div>
 <details class='collector-detail'>
 <summary><h3>Secure Score <span class='row-count'>(1 rows)</span></h3></summary>
 <div class='table-wrapper'>
 <table class='data-table'>
 <thead><tr>
-<th>Current Score</th>
-<th>Max Score</th>
-<th>Percentage</th>
-<th>Created Date Time</th>
-<th>Average Comparative Score</th>
+<th scope='col'>Current Score</th>
+<th scope='col'>Max Score</th>
+<th scope='col'>Percentage</th>
+<th scope='col'>Created Date Time</th>
+<th scope='col'>Average Comparative Score</th>
 </tr></thead>
 <tbody>
 <tr>
@@ -2670,14 +2914,14 @@
 <div class='table-wrapper'>
 <table class='data-table'>
 <thead><tr>
-<th>Action Name</th>
-<th>Category</th>
-<th>Score Impact</th>
-<th>Current Score</th>
-<th>Max Score</th>
-<th>Implementation Status</th>
-<th>User Impact</th>
-<th>Threats</th>
+<th scope='col'>Action Name</th>
+<th scope='col'>Category</th>
+<th scope='col'>Score Impact</th>
+<th scope='col'>Current Score</th>
+<th scope='col'>Max Score</th>
+<th scope='col'>Implementation Status</th>
+<th scope='col'>User Impact</th>
+<th scope='col'>Threats</th>
 </tr></thead>
 <tbody>
 <tr>
@@ -2838,11 +3082,11 @@
 <div class='table-wrapper'>
 <table class='data-table'>
 <thead><tr>
-<th>Policy Type</th>
-<th>Name</th>
-<th>Enabled</th>
-<th>Priority</th>
-<th>Key Settings</th>
+<th scope='col'>Policy Type</th>
+<th scope='col'>Name</th>
+<th scope='col'>Enabled</th>
+<th scope='col'>Priority</th>
+<th scope='col'>Key Settings</th>
 </tr></thead>
 <tbody>
 <tr>
@@ -2902,13 +3146,13 @@
 <div class='table-wrapper'>
 <table class='data-table'>
 <thead><tr>
-<th>Category</th>
-<th>Setting</th>
-<th>Current Value</th>
-<th>Recommended Value</th>
-<th>Status</th>
-<th>Cis Control</th>
-<th>Remediation</th>
+<th scope='col'>Category</th>
+<th scope='col'>Setting</th>
+<th scope='col'>Current Value</th>
+<th scope='col'>Recommended Value</th>
+<th scope='col'>Status</th>
+<th scope='col'>Cis Control</th>
+<th scope='col'>Remediation</th>
 </tr></thead>
 <tbody>
 <tr class='cis-row-fail'>
@@ -3171,11 +3415,11 @@
 <div class='table-wrapper'>
 <table class='data-table'>
 <thead><tr>
-<th>Item Type</th>
-<th>Name</th>
-<th>Enabled</th>
-<th>Priority</th>
-<th>Details</th>
+<th scope='col'>Item Type</th>
+<th scope='col'>Name</th>
+<th scope='col'>Enabled</th>
+<th scope='col'>Priority</th>
+<th scope='col'>Details</th>
 </tr></thead>
 <tbody>
 <tr>
@@ -3226,9 +3470,9 @@
 </details>
 <details class='section' id='section-collaboration' open>
 <summary><h2>Collaboration</h2></summary>
-<p class='section-description'>SharePoint, OneDrive, and Microsoft Teams configuration and access settings. Collaboration tools are where sensitive data lives &mdash; these controls govern sharing, guest access, and external communication.</p>
+<p class='section-description'>SharePoint, OneDrive, and Microsoft Teams configuration and access settings. Collaboration tools are where sensitive data lives &mdash; these controls govern sharing, guest access, and external communication. Misconfigured sharing settings are a common source of data exposure; anonymous sharing links and unrestricted guest access should be reviewed carefully. See <a href="https://learn.microsoft.com/en-us/microsoft-365/solutions/setup-secure-collaboration-with-teams" target="_blank">Microsoft secure collaboration guidance</a>.</p>
 <table class='summary-table'>
-<thead><tr><th>Collector</th><th>Status</th><th>Items</th><th>Duration</th><th>Notes</th></tr></thead>
+<thead><tr><th scope='col'>Collector</th><th scope='col'>Status</th><th scope='col'>Items</th><th scope='col'>Duration</th><th scope='col'>Notes</th></tr></thead>
 <tbody>
 <tr>
 <td>SharePoint &amp; OneDrive</td>
@@ -3264,14 +3508,14 @@
 <div class='table-wrapper'>
 <table class='data-table'>
 <thead><tr>
-<th>Sharing Capability</th>
-<th>Sharing Domain Restriction Mode</th>
-<th>Is Resharing By External Users Enabled</th>
-<th>Is Unmanaged Sync Client Restricted</th>
-<th>Tenant Default Timezone</th>
-<th>One Drive Loop Sharing Capability</th>
-<th>Is Mac Sync App Enabled</th>
-<th>Is Loop Enabled</th>
+<th scope='col'>Sharing Capability</th>
+<th scope='col'>Sharing Domain Restriction Mode</th>
+<th scope='col'>Is Resharing By External Users Enabled</th>
+<th scope='col'>Is Unmanaged Sync Client Restricted</th>
+<th scope='col'>Tenant Default Timezone</th>
+<th scope='col'>One Drive Loop Sharing Capability</th>
+<th scope='col'>Is Mac Sync App Enabled</th>
+<th scope='col'>Is Loop Enabled</th>
 </tr></thead>
 <tbody>
 <tr>
@@ -3292,13 +3536,13 @@
 <div class='table-wrapper'>
 <table class='data-table'>
 <thead><tr>
-<th>Category</th>
-<th>Setting</th>
-<th>Current Value</th>
-<th>Recommended Value</th>
-<th>Status</th>
-<th>Cis Control</th>
-<th>Remediation</th>
+<th scope='col'>Category</th>
+<th scope='col'>Setting</th>
+<th scope='col'>Current Value</th>
+<th scope='col'>Recommended Value</th>
+<th scope='col'>Status</th>
+<th scope='col'>Cis Control</th>
+<th scope='col'>Remediation</th>
 </tr></thead>
 <tbody>
 <tr class='cis-row-fail'>
@@ -3390,11 +3634,11 @@
 <div class='table-wrapper'>
 <table class='data-table'>
 <thead><tr>
-<th>Allow Guest Access</th>
-<th>Allow Guest Create Update Channels</th>
-<th>Allow Third Party Apps</th>
-<th>Allow Side Loading</th>
-<th>Is User Personal Scope Resource Specific Consent Enabled</th>
+<th scope='col'>Allow Guest Access</th>
+<th scope='col'>Allow Guest Create Update Channels</th>
+<th scope='col'>Allow Third Party Apps</th>
+<th scope='col'>Allow Side Loading</th>
+<th scope='col'>Is User Personal Scope Resource Specific Consent Enabled</th>
 </tr></thead>
 <tbody>
 <tr>
@@ -3412,13 +3656,13 @@
 <div class='table-wrapper'>
 <table class='data-table'>
 <thead><tr>
-<th>Category</th>
-<th>Setting</th>
-<th>Current Value</th>
-<th>Recommended Value</th>
-<th>Status</th>
-<th>Cis Control</th>
-<th>Remediation</th>
+<th scope='col'>Category</th>
+<th scope='col'>Setting</th>
+<th scope='col'>Current Value</th>
+<th scope='col'>Recommended Value</th>
+<th scope='col'>Status</th>
+<th scope='col'>Cis Control</th>
+<th scope='col'>Remediation</th>
 </tr></thead>
 <tbody>
 <tr class='cis-row-fail'>
@@ -3492,7 +3736,7 @@
 <summary><h2>Hybrid</h2></summary>
 <p class='section-description'>On-premises Active Directory synchronization and hybrid identity configuration. Hybrid sync health directly impacts authentication reliability and determines which identities are managed in the cloud vs. on-premises.</p>
 <table class='summary-table'>
-<thead><tr><th>Collector</th><th>Status</th><th>Items</th><th>Duration</th><th>Notes</th></tr></thead>
+<thead><tr><th scope='col'>Collector</th><th scope='col'>Status</th><th scope='col'>Items</th><th scope='col'>Duration</th><th scope='col'>Notes</th></tr></thead>
 <tbody>
 <tr>
 <td>Hybrid Sync</td>
@@ -3507,16 +3751,16 @@
 <div class='table-wrapper'>
 <table class='data-table'>
 <thead><tr>
-<th>Tenant Display Name</th>
-<th>Tenant Id</th>
-<th>On Premises Sync Enabled</th>
-<th>Last Dir Sync Time</th>
-<th>Dir Sync Configured</th>
-<th>Password Hash Sync Enabled</th>
-<th>Last Password Sync Time</th>
-<th>Sync Type</th>
-<th>On Prem Domain Name</th>
-<th>On Prem Forest Name</th>
+<th scope='col'>Tenant Display Name</th>
+<th scope='col'>Tenant Id</th>
+<th scope='col'>On Premises Sync Enabled</th>
+<th scope='col'>Last Dir Sync Time</th>
+<th scope='col'>Dir Sync Configured</th>
+<th scope='col'>Password Hash Sync Enabled</th>
+<th scope='col'>Last Password Sync Time</th>
+<th scope='col'>Sync Type</th>
+<th scope='col'>On Prem Domain Name</th>
+<th scope='col'>On Prem Forest Name</th>
 </tr></thead>
 <tbody>
 <tr>
@@ -3536,203 +3780,1248 @@
 </details>
 </details>
 
-        <a id="cis-compliance"></a>
-        <h1>CIS Compliance Summary</h1>
+        <a id="compliance-overview"></a>
+        <h1>Compliance Overview</h1>
         <details class='section' open>
-<summary><h2>CIS Microsoft 365 Benchmark &mdash; Compliance Summary</h2></summary>
-<p>The following findings are mapped to the <strong>CIS Microsoft 365 Foundations Benchmark v6.0.1</strong>. This section highlights areas requiring attention, ordered by severity.</p>
+<summary><h2>Compliance Overview</h2></summary>
+<p>Security findings mapped across compliance frameworks. Use the selector below to choose which frameworks to display.</p>
 <div class='cis-disclaimer'>
 <strong>Informational Notice</strong>
-<p>This CIS benchmark assessment is provided for <strong>informational purposes only</strong> and does not constitute a comprehensive security assessment, audit, or certification. Results reflect a subset of the 140 CIS controls checked via automated methods at a point in time and should not be considered conclusive. For a thorough security evaluation, consider engaging a qualified security professional for penetration testing and full compliance review.</p>
+<p>This compliance assessment is provided for <strong>informational purposes only</strong> and does not constitute a comprehensive security assessment, audit, or certification. Results reflect automated checks at a point in time and should not be considered conclusive. For a thorough security evaluation, consider engaging a qualified security professional.</p>
 </div>
-<div class='exec-summary'>
-<div class='stat-card' style='border-top-color: #f39c12;'><div class='stat-value' style='color: #f39c12;'>70%</div><div class='stat-label'>Compliance Score</div></div>
-<div class='stat-card' style='border-top-color: var(--m365a-medium-gray);'><div class='stat-value'>140</div><div class='stat-label'>Benchmark Total</div></div>
-<div class='stat-card info'><div class='stat-value'>70</div><div class='stat-label'>Assessed</div></div>
-<div class='stat-card success'><div class='stat-value'>49</div><div class='stat-label'>Pass</div></div>
-<div class='stat-card error'><div class='stat-value'>17</div><div class='stat-label'>Fail</div></div>
-<div class='stat-card warning'><div class='stat-value'>4</div><div class='stat-label'>4 Warning</div></div>
+<div class='fw-selector' id='fwSelector'>
+<span class='fw-selector-label'>Frameworks:</span>
+<label class='fw-checkbox'><input type='checkbox' value='CisE3L1' checked> CIS E3 L1</label>
+<label class='fw-checkbox'><input type='checkbox' value='CisE3L2' checked> CIS E3 L2</label>
+<label class='fw-checkbox'><input type='checkbox' value='CisE5L1' checked> CIS E5 L1</label>
+<label class='fw-checkbox'><input type='checkbox' value='CisE5L2' checked> CIS E5 L2</label>
+<label class='fw-checkbox'><input type='checkbox' value='Nist80053' checked> NIST 800-53 Rev 5</label>
+<label class='fw-checkbox'><input type='checkbox' value='NistCsf' checked> NIST CSF 2.0</label>
+<label class='fw-checkbox'><input type='checkbox' value='Iso27001' checked> ISO 27001:2022</label>
+<label class='fw-checkbox'><input type='checkbox' value='Stig' checked> DISA STIG</label>
+<label class='fw-checkbox'><input type='checkbox' value='PciDss' checked> PCI DSS v4.0.1</label>
+<label class='fw-checkbox'><input type='checkbox' value='Cmmc' checked> CMMC 2.0</label>
+<label class='fw-checkbox'><input type='checkbox' value='Hipaa' checked> HIPAA</label>
+<label class='fw-checkbox'><input type='checkbox' value='CisaScuba' checked> CISA SCuBA</label>
+<span class='fw-selector-actions'><button type='button' id='fwSelectAll' class='fw-action-btn'>All</button><button type='button' id='fwSelectNone' class='fw-action-btn'>None</button></span>
 </div>
-<details class='collector-detail' open>
-<summary><h3>Areas of Improvement <span class='row-count'>(21 findings)</span></h3></summary>
+<div class='exec-summary' id='fwCards'>
+<div class='stat-card fw-card warning' data-fw='CisE3L1'><div class='stat-value'>77.8%</div><div class='stat-label'>CIS E3 L1<br><small>45 of 86 assessed</small></div></div>
+<div class='stat-card fw-card danger' data-fw='CisE3L2'><div class='stat-value'>30%</div><div class='stat-label'>CIS E3 L2<br><small>10 of 34 assessed</small></div></div>
+<div class='stat-card fw-card warning' data-fw='CisE5L1'><div class='stat-value'>77.8%</div><div class='stat-label'>CIS E5 L1<br><small>45 of 97 assessed</small></div></div>
+<div class='stat-card fw-card danger' data-fw='CisE5L2'><div class='stat-value'>56%</div><div class='stat-label'>CIS E5 L2<br><small>25 of 43 assessed</small></div></div>
+<div class='stat-card fw-card danger' data-fw='Nist80053'><div class='stat-value'>2%</div><div class='stat-label'>NIST 800-53 Rev 5<br><small>29 of 1189 mapped</small></div></div>
+<div class='stat-card fw-card danger' data-fw='NistCsf'><div class='stat-value'>8%</div><div class='stat-label'>NIST CSF 2.0<br><small>9 of 106 mapped</small></div></div>
+<div class='stat-card fw-card danger' data-fw='Iso27001'><div class='stat-value'>20%</div><div class='stat-label'>ISO 27001:2022<br><small>19 of 93 mapped</small></div></div>
+<div class='stat-card fw-card danger' data-fw='Stig'><div class='stat-value'>2%</div><div class='stat-label'>DISA STIG<br><small>3 of 148 mapped</small></div></div>
+<div class='stat-card fw-card danger' data-fw='PciDss'><div class='stat-value'>17%</div><div class='stat-label'>PCI DSS v4.0.1<br><small>11 of 63 mapped</small></div></div>
+<div class='stat-card fw-card danger' data-fw='Cmmc'><div class='stat-value'>25%</div><div class='stat-label'>CMMC 2.0<br><small>28 of 110 mapped</small></div></div>
+<div class='stat-card fw-card danger' data-fw='Hipaa'><div class='stat-value'>19%</div><div class='stat-label'>HIPAA<br><small>11 of 59 mapped</small></div></div>
+<div class='stat-card fw-card danger' data-fw='CisaScuba'><div class='stat-value'>14%</div><div class='stat-label'>CISA SCuBA<br><small>19 of 134 mapped</small></div></div>
+</div>
+<div class='status-filter' id='statusFilter'>
+<span class='status-filter-label'>Status:</span>
+<label class='status-checkbox status-fail'><input type='checkbox' value='fail' checked> Fail (17)</label>
+<label class='status-checkbox status-warning'><input type='checkbox' value='warning' checked> Warning (4)</label>
+<label class='status-checkbox status-pass'><input type='checkbox' value='pass' checked> Pass (49)</label>
+<span class='fw-selector-actions'><button type='button' id='statusSelectAll' class='fw-action-btn'>All</button><button type='button' id='statusSelectNone' class='fw-action-btn'>None</button></span>
+</div>
 <div class='table-wrapper'>
-<table class='data-table cis-table'>
-<thead><tr><th>CIS Control</th><th>Status</th><th>Setting</th><th>Current Value</th><th>Recommended</th><th>Remediation</th></tr></thead>
+<table class='data-table matrix-table' id='complianceTable'>
+<thead><tr><th scope='col'>Control</th><th scope='col'>Description</th><th scope='col'>Status</th><th scope='col' class='fw-col' data-fw='CisE3L1'>CIS E3 L1</th><th scope='col' class='fw-col' data-fw='CisE3L2'>CIS E3 L2</th><th scope='col' class='fw-col' data-fw='CisE5L1'>CIS E5 L1</th><th scope='col' class='fw-col' data-fw='CisE5L2'>CIS E5 L2</th><th scope='col' class='fw-col' data-fw='Nist80053'>NIST 800-53 Rev 5</th><th scope='col' class='fw-col' data-fw='NistCsf'>NIST CSF 2.0</th><th scope='col' class='fw-col' data-fw='Iso27001'>ISO 27001:2022</th><th scope='col' class='fw-col' data-fw='Stig'>DISA STIG</th><th scope='col' class='fw-col' data-fw='PciDss'>PCI DSS v4.0.1</th><th scope='col' class='fw-col' data-fw='Cmmc'>CMMC 2.0</th><th scope='col' class='fw-col' data-fw='Hipaa'>HIPAA</th><th scope='col' class='fw-col' data-fw='CisaScuba'>CISA SCuBA</th></tr></thead>
 <tbody>
-<tr class='cis-row-fail'>
-<td class='cis-id'>2.1.6</td>
-<td><span class='badge badge-failed'>Fail</span></td>
-<td>Bulk Complaint Level Threshold (Default)</td>
-<td>7</td>
-<td>6 or lower</td>
-<td class='remediation-cell'>Security admin center &gt; Anti-spam &gt; Set bulk threshold to 6 or lower.</td>
+<tr class='cis-row-pass'>
+<td class='cis-id'>1.1.3</td>
+<td>Global Administrator Count</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>1.1.3</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>1.1.3</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>AC-6(5)</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-05</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.5.15</span><span class='fw-tag fw-iso'>A.8.2</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-tag fw-stig'>V-260335</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>8.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.1.5</span><span class='fw-tag fw-cmmc'>3.1.6</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(a)(1)</span><span class='fw-tag fw-hipaa'>§164.308(a)(4)(i)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.AAD.7.1v1</span></td>
 </tr>
-<tr class='cis-row-fail'>
-<td class='cis-id'>2.1.7</td>
-<td><span class='badge badge-failed'>Fail</span></td>
-<td>Targeted Domain Protection (Default)</td>
-<td>False</td>
-<td>True</td>
-<td class='remediation-cell'>Security admin center &gt; Anti-phishing &gt; Add domains to protect.</td>
-</tr>
-<tr class='cis-row-fail'>
-<td class='cis-id'>2.1.7</td>
-<td><span class='badge badge-failed'>Fail</span></td>
-<td>First Contact Safety Tips (Default)</td>
-<td>False</td>
-<td>True</td>
-<td class='remediation-cell'>Security admin center &gt; Anti-phishing &gt; Enable first contact safety tips.</td>
-</tr>
-<tr class='cis-row-fail'>
-<td class='cis-id'>2.1.7</td>
-<td><span class='badge badge-failed'>Fail</span></td>
-<td>Targeted User Protection (Default)</td>
-<td>False</td>
-<td>True</td>
-<td class='remediation-cell'>Security admin center &gt; Anti-phishing &gt; Add users to protect.</td>
-</tr>
-<tr class='cis-row-fail'>
-<td class='cis-id'>5.1.3.2</td>
-<td><span class='badge badge-failed'>Fail</span></td>
-<td>Users Can Create Security Groups</td>
-<td>True</td>
-<td>False</td>
-<td class='remediation-cell'>Entra admin center &gt; Groups &gt; General &gt; Users can create security groups &gt; No.</td>
-</tr>
-<tr class='cis-row-fail'>
-<td class='cis-id'>5.1.5.1</td>
-<td><span class='badge badge-failed'>Fail</span></td>
-<td>User Consent for Applications</td>
-<td>Allow user consent for apps</td>
-<td>Do not allow user consent</td>
-<td class='remediation-cell'>Entra admin center &gt; Enterprise applications &gt; Consent and permissions &gt; User consent settings &gt; Do not allow user consent.</td>
-</tr>
-<tr class='cis-row-fail'>
-<td class='cis-id'>5.1.6.2</td>
-<td><span class='badge badge-failed'>Fail</span></td>
-<td>Guest User Access Restriction</td>
-<td>Same as member users</td>
-<td>Restricted access</td>
-<td class='remediation-cell'>Entra admin center &gt; External Identities &gt; External collaboration settings &gt; Guest user access &gt; Most restrictive.</td>
-</tr>
-<tr class='cis-row-fail'>
-<td class='cis-id'>5.1.6.3</td>
-<td><span class='badge badge-failed'>Fail</span></td>
-<td>Guest Invitation Policy</td>
-<td>Anyone in the organization can invite</td>
-<td>Admins and guest inviters only</td>
-<td class='remediation-cell'>Entra admin center &gt; External Identities &gt; External collaboration settings &gt; Guest invite settings.</td>
-</tr>
-<tr class='cis-row-fail'>
-<td class='cis-id'>5.2.3.4</td>
-<td><span class='badge badge-failed'>Fail</span></td>
-<td>Auth Method Registration Campaign</td>
-<td>disabled</td>
-<td>enabled</td>
-<td class='remediation-cell'>Entra admin center &gt; Protection &gt; Authentication methods &gt; Registration campaign &gt; State &gt; Enabled.</td>
-</tr>
-<tr class='cis-row-fail'>
-<td class='cis-id'>6.3.1</td>
-<td><span class='badge badge-failed'>Fail</span></td>
-<td>Outlook Add-ins Allowed (Default Role Assignment Policy)</td>
-<td>True</td>
-<td>Restricted</td>
-<td class='remediation-cell'>Remove MyMarketplaceApps and MyCustomApps roles from Default Role Assignment Policy.</td>
-</tr>
-<tr class='cis-row-fail'>
-<td class='cis-id'>6.5.3</td>
-<td><span class='badge badge-failed'>Fail</span></td>
-<td>OWA Additional Storage (OwaMailboxPolicy-Default)</td>
-<td>True</td>
-<td>False</td>
-<td class='remediation-cell'>Run: Set-OwaMailboxPolicy -Identity OwaMailboxPolicy-Default -AdditionalStorageProvidersAvailable $false</td>
-</tr>
-<tr class='cis-row-fail'>
-<td class='cis-id'>7.2.11</td>
-<td><span class='badge badge-failed'>Fail</span></td>
-<td>Default Sharing Link Permission</td>
-<td>Edit</td>
-<td>View (read-only)</td>
-<td class='remediation-cell'>SharePoint admin center &gt; Sharing &gt; Default permission &gt; View.</td>
-</tr>
-<tr class='cis-row-fail'>
-<td class='cis-id'>7.2.7</td>
-<td><span class='badge badge-failed'>Fail</span></td>
-<td>Default Sharing Link Type</td>
-<td>AnonymousAccess</td>
-<td>Specific people (direct)</td>
-<td class='remediation-cell'>SharePoint admin center &gt; Policies &gt; Sharing &gt; Default link type &gt; Specific people.</td>
-</tr>
-<tr class='cis-row-fail'>
-<td class='cis-id'>8.2.2</td>
-<td><span class='badge badge-failed'>Fail</span></td>
-<td>Communication with Unmanaged Teams Users</td>
-<td>True</td>
-<td>False</td>
-<td class='remediation-cell'>Teams admin center &gt; External access &gt; Unmanaged Teams users &gt; Off.</td>
-</tr>
-<tr class='cis-row-fail'>
-<td class='cis-id'>8.2.3</td>
-<td><span class='badge badge-failed'>Fail</span></td>
-<td>External Unmanaged Users Can Initiate Conversations</td>
-<td>True</td>
-<td>False</td>
-<td class='remediation-cell'>Teams admin center &gt; External access &gt; External users initiate conversations &gt; Off.</td>
-</tr>
-<tr class='cis-row-fail'>
-<td class='cis-id'>8.5.1</td>
-<td><span class='badge badge-failed'>Fail</span></td>
-<td>Anonymous Users Can Join Meeting</td>
-<td>True</td>
-<td>False</td>
-<td class='remediation-cell'>Teams admin center &gt; Meetings &gt; Anonymous users can join &gt; Off.</td>
-</tr>
-<tr class='cis-row-fail'>
-<td class='cis-id'>8.5.7</td>
-<td><span class='badge badge-failed'>Fail</span></td>
-<td>External Participants Can Give/Request Control</td>
-<td>True</td>
-<td>False</td>
-<td class='remediation-cell'>Teams admin center &gt; Meetings &gt; External participant control &gt; Off.</td>
+<tr class='cis-row-pass'>
+<td class='cis-id'>1.3.1</td>
+<td>Password Expiration: northwindtraders.com</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>1.3.1</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>1.3.1</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>IA-5(1)</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-01</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.5.17</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>8.3.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.5.7</span><span class='fw-tag fw-cmmc'>3.5.8</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(D)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.AAD.6.1v1</span></td>
 </tr>
 <tr class='cis-row-warning'>
 <td class='cis-id'>1.3.2</td>
-<td><span class='badge badge-warning'>Warning</span></td>
 <td>Idle Session Timeout Policy</td>
-<td>Not configured</td>
-<td>Configured</td>
-<td class='remediation-cell'>Entra admin center &gt; Conditional Access &gt; Session controls &gt; Sign-in frequency.</td>
+<td><span class='badge badge-warning'>Warning</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-tag fw-cis-l2'>1.3.2</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-tag fw-cis-l2'>1.3.2</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>AC-11</span><span class='fw-tag fw-nist'>AC-12</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-05</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.1</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>8.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.1.10</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(a)(2)(iii)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
 </tr>
 <tr class='cis-row-warning'>
 <td class='cis-id'>1.3.3</td>
-<td><span class='badge badge-warning'>Warning</span></td>
 <td>Default Calendar External Sharing</td>
-<td>CalendarSharingFreeBusySimple</td>
-<td>Restricted</td>
-<td class='remediation-cell'>Exchange admin center &gt; Organization &gt; Sharing &gt; Restrict to CalendarSharingFreeBusySimple.</td>
+<td><span class='badge badge-warning'>Warning</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-tag fw-cis-l2'>1.3.3</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-tag fw-cis-l2'>1.3.3</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>AC-3</span><span class='fw-tag fw-nist'>SC-7(10)</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-05</span><span class='fw-tag fw-csf'>PR.DS-01</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.5.15</span><span class='fw-tag fw-iso'>A.8.3</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>2.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.1.22</span><span class='fw-tag fw-cmmc'>3.13.1</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(a)(1)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
 </tr>
 <tr class='cis-row-warning'>
 <td class='cis-id'>1.3.6</td>
-<td><span class='badge badge-warning'>Warning</span></td>
 <td>Customer Lockbox Enabled</td>
-<td>False</td>
-<td>True (E5 license)</td>
-<td class='remediation-cell'>M365 admin center &gt; Settings &gt; Org settings &gt; Customer Lockbox &gt; Require approval. Requires E5.</td>
+<td><span class='badge badge-warning'>Warning</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-tag fw-cis-l2'>1.3.6</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>AC-3</span><span class='fw-tag fw-nist'>AC-6</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-05</span><span class='fw-tag fw-csf'>GV.SC-05</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.5.15</span><span class='fw-tag fw-iso'>A.5.19</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>2.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.1.1</span><span class='fw-tag fw-cmmc'>3.1.2</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(a)(1)</span><span class='fw-tag fw-hipaa'>§164.308(a)(4)(i)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>2.1.1</td>
+<td>Track User Clicks (Built-In Protection)</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-tag fw-cis-l2'>2.1.1</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>CM-6a</span><span class='fw-tag fw-nist'>SI-3a</span><span class='fw-tag fw-nist'>SI-8</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.CM-09</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.7</span><span class='fw-tag fw-iso'>A.8.23</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.2.x</span><span class='fw-tag fw-pci'>5.3.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.14.2</span><span class='fw-tag fw-cmmc'>3.14.5</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(B)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.EXO.15.1v1</span><span class='fw-tag fw-scuba'>MS.EXO.15.2v1</span><span class='fw-tag fw-scuba'>MS.EXO.15.3v1</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>2.1.1</td>
+<td>Enable for Internal Senders (Built-In Protection)</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-tag fw-cis-l2'>2.1.1</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>CM-6a</span><span class='fw-tag fw-nist'>SI-3a</span><span class='fw-tag fw-nist'>SI-8</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.CM-09</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.7</span><span class='fw-tag fw-iso'>A.8.23</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.2.x</span><span class='fw-tag fw-pci'>5.3.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.14.2</span><span class='fw-tag fw-cmmc'>3.14.5</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(B)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.EXO.15.1v1</span><span class='fw-tag fw-scuba'>MS.EXO.15.2v1</span><span class='fw-tag fw-scuba'>MS.EXO.15.3v1</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>2.1.1</td>
+<td>Real-time URL Scanning (Built-In Protection)</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-tag fw-cis-l2'>2.1.1</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>CM-6a</span><span class='fw-tag fw-nist'>SI-3a</span><span class='fw-tag fw-nist'>SI-8</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.CM-09</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.7</span><span class='fw-tag fw-iso'>A.8.23</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.2.x</span><span class='fw-tag fw-pci'>5.3.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.14.2</span><span class='fw-tag fw-cmmc'>3.14.5</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(B)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.EXO.15.1v1</span><span class='fw-tag fw-scuba'>MS.EXO.15.2v1</span><span class='fw-tag fw-scuba'>MS.EXO.15.3v1</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>2.1.1</td>
+<td>Wait for URL Scan (Built-In Protection)</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-tag fw-cis-l2'>2.1.1</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>CM-6a</span><span class='fw-tag fw-nist'>SI-3a</span><span class='fw-tag fw-nist'>SI-8</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.CM-09</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.7</span><span class='fw-tag fw-iso'>A.8.23</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.2.x</span><span class='fw-tag fw-pci'>5.3.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.14.2</span><span class='fw-tag fw-cmmc'>3.14.5</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(B)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.EXO.15.1v1</span><span class='fw-tag fw-scuba'>MS.EXO.15.2v1</span><span class='fw-tag fw-scuba'>MS.EXO.15.3v1</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>2.1.15</td>
+<td>BCC on Suspicious Outbound (Default)</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>2.1.15</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>2.1.15</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>SI-8</span><span class='fw-tag fw-nist'>CM-6a</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.CM-09</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.23</span><span class='fw-tag fw-iso'>A.8.9</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.4.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.14.5</span><span class='fw-tag fw-cmmc'>3.4.2</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(B)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>2.1.15</td>
+<td>Notify Admins of Outbound Spam (Default)</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>2.1.15</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>2.1.15</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>SI-8</span><span class='fw-tag fw-nist'>CM-6a</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.CM-09</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.23</span><span class='fw-tag fw-iso'>A.8.9</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.4.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.14.5</span><span class='fw-tag fw-cmmc'>3.4.2</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(B)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>2.1.2</td>
+<td>Malware ZAP (Default)</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>2.1.2</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>2.1.2</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>CM-6a</span><span class='fw-tag fw-nist'>SI-3a</span><span class='fw-tag fw-nist'>SI-8</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.CM-09</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.7</span><span class='fw-tag fw-iso'>A.8.23</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.2.x</span><span class='fw-tag fw-pci'>5.3.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.14.2</span><span class='fw-tag fw-cmmc'>3.14.5</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(B)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.EXO.9.1v2</span><span class='fw-tag fw-scuba'>MS.EXO.9.2v1</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>2.1.2</td>
+<td>Common Attachment Filter (Default)</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>2.1.2</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>2.1.2</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>CM-6a</span><span class='fw-tag fw-nist'>SI-3a</span><span class='fw-tag fw-nist'>SI-8</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.CM-09</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.7</span><span class='fw-tag fw-iso'>A.8.23</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.2.x</span><span class='fw-tag fw-pci'>5.3.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.14.2</span><span class='fw-tag fw-cmmc'>3.14.5</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(B)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.EXO.9.1v2</span><span class='fw-tag fw-scuba'>MS.EXO.9.2v1</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>2.1.3</td>
+<td>Internal Sender Admin Notifications (Default)</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>2.1.3</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>2.1.3</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>SI-3a</span><span class='fw-tag fw-nist'>SI-4(5)</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.CM-09</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.7</span><span class='fw-tag fw-iso'>A.8.16</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.2.x</span><span class='fw-tag fw-pci'>5.3.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.14.2</span><span class='fw-tag fw-cmmc'>3.14.6</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(B)</span><span class='fw-tag fw-hipaa'>§164.308(a)(6)(i)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>2.1.4</td>
+<td>Policy Enabled (Built-In Protection)</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-tag fw-cis-l2'>2.1.4</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>CM-6a</span><span class='fw-tag fw-nist'>SI-3a</span><span class='fw-tag fw-nist'>SI-8</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.CM-09</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.7</span><span class='fw-tag fw-iso'>A.8.23</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.2.x</span><span class='fw-tag fw-pci'>5.3.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.14.2</span><span class='fw-tag fw-cmmc'>3.14.5</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(B)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.EXO.14.1v2</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>2.1.4</td>
+<td>Action (Built-In Protection)</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-tag fw-cis-l2'>2.1.4</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>CM-6a</span><span class='fw-tag fw-nist'>SI-3a</span><span class='fw-tag fw-nist'>SI-8</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.CM-09</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.7</span><span class='fw-tag fw-iso'>A.8.23</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.2.x</span><span class='fw-tag fw-pci'>5.3.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.14.2</span><span class='fw-tag fw-cmmc'>3.14.5</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(B)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.EXO.14.1v2</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>2.1.4</td>
+<td>Redirect to Admin (Built-In Protection)</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-tag fw-cis-l2'>2.1.4</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>CM-6a</span><span class='fw-tag fw-nist'>SI-3a</span><span class='fw-tag fw-nist'>SI-8</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.CM-09</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.7</span><span class='fw-tag fw-iso'>A.8.23</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.2.x</span><span class='fw-tag fw-pci'>5.3.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.14.2</span><span class='fw-tag fw-cmmc'>3.14.5</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(B)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.EXO.14.1v2</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>2.1.6</td>
+<td>Phishing ZAP (Default)</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>2.1.6</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>2.1.6</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>CM-6a</span><span class='fw-tag fw-nist'>SI-3a</span><span class='fw-tag fw-nist'>SI-8</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.CM-09</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.7</span><span class='fw-tag fw-iso'>A.8.16</span><span class='fw-tag fw-iso'>A.8.23</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.2.x</span><span class='fw-tag fw-pci'>5.4.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.14.2</span><span class='fw-tag fw-cmmc'>3.14.6</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(B)</span><span class='fw-tag fw-hipaa'>§164.308(a)(6)(i)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>2.1.6</td>
+<td>Spam ZAP (Default)</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>2.1.6</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>2.1.6</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>CM-6a</span><span class='fw-tag fw-nist'>SI-3a</span><span class='fw-tag fw-nist'>SI-8</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.CM-09</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.7</span><span class='fw-tag fw-iso'>A.8.16</span><span class='fw-tag fw-iso'>A.8.23</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.2.x</span><span class='fw-tag fw-pci'>5.4.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.14.2</span><span class='fw-tag fw-cmmc'>3.14.6</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(B)</span><span class='fw-tag fw-hipaa'>§164.308(a)(6)(i)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>2.1.6</td>
+<td>Zero-Hour Auto Purge (Default)</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>2.1.6</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>2.1.6</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>CM-6a</span><span class='fw-tag fw-nist'>SI-3a</span><span class='fw-tag fw-nist'>SI-8</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.CM-09</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.7</span><span class='fw-tag fw-iso'>A.8.16</span><span class='fw-tag fw-iso'>A.8.23</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.2.x</span><span class='fw-tag fw-pci'>5.4.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.14.2</span><span class='fw-tag fw-cmmc'>3.14.6</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(B)</span><span class='fw-tag fw-hipaa'>§164.308(a)(6)(i)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>2.1.6</td>
+<td>Phishing Action (Default)</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>2.1.6</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>2.1.6</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>CM-6a</span><span class='fw-tag fw-nist'>SI-3a</span><span class='fw-tag fw-nist'>SI-8</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.CM-09</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.7</span><span class='fw-tag fw-iso'>A.8.16</span><span class='fw-tag fw-iso'>A.8.23</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.2.x</span><span class='fw-tag fw-pci'>5.4.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.14.2</span><span class='fw-tag fw-cmmc'>3.14.6</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(B)</span><span class='fw-tag fw-hipaa'>§164.308(a)(6)(i)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>2.1.6</td>
+<td>High Confidence Phish Action (Default)</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>2.1.6</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>2.1.6</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>CM-6a</span><span class='fw-tag fw-nist'>SI-3a</span><span class='fw-tag fw-nist'>SI-8</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.CM-09</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.7</span><span class='fw-tag fw-iso'>A.8.16</span><span class='fw-tag fw-iso'>A.8.23</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.2.x</span><span class='fw-tag fw-pci'>5.4.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.14.2</span><span class='fw-tag fw-cmmc'>3.14.6</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(B)</span><span class='fw-tag fw-hipaa'>§164.308(a)(6)(i)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>2.1.6</td>
+<td>High Confidence Spam Action (Default)</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>2.1.6</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>2.1.6</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>CM-6a</span><span class='fw-tag fw-nist'>SI-3a</span><span class='fw-tag fw-nist'>SI-8</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.CM-09</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.7</span><span class='fw-tag fw-iso'>A.8.16</span><span class='fw-tag fw-iso'>A.8.23</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.2.x</span><span class='fw-tag fw-pci'>5.4.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.14.2</span><span class='fw-tag fw-cmmc'>3.14.6</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(B)</span><span class='fw-tag fw-hipaa'>§164.308(a)(6)(i)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-fail'>
+<td class='cis-id'>2.1.6</td>
+<td>Bulk Complaint Level Threshold (Default)</td>
+<td><span class='badge badge-failed'>Fail</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>2.1.6</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>2.1.6</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>CM-6a</span><span class='fw-tag fw-nist'>SI-3a</span><span class='fw-tag fw-nist'>SI-8</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.CM-09</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.7</span><span class='fw-tag fw-iso'>A.8.16</span><span class='fw-tag fw-iso'>A.8.23</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.2.x</span><span class='fw-tag fw-pci'>5.4.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.14.2</span><span class='fw-tag fw-cmmc'>3.14.6</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(B)</span><span class='fw-tag fw-hipaa'>§164.308(a)(6)(i)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>2.1.6</td>
+<td>Spam Action (Default)</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>2.1.6</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>2.1.6</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>CM-6a</span><span class='fw-tag fw-nist'>SI-3a</span><span class='fw-tag fw-nist'>SI-8</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.CM-09</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.7</span><span class='fw-tag fw-iso'>A.8.16</span><span class='fw-tag fw-iso'>A.8.23</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.2.x</span><span class='fw-tag fw-pci'>5.4.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.14.2</span><span class='fw-tag fw-cmmc'>3.14.6</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(B)</span><span class='fw-tag fw-hipaa'>§164.308(a)(6)(i)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>2.1.7</td>
+<td>Phishing Threshold (Default)</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-tag fw-cis-l2'>2.1.7</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>SI-8</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.CM-09</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.23</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.4.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.14.5</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(B)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.EXO.11.1v1</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>2.1.7</td>
+<td>Mailbox Intelligence Protection (Default)</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-tag fw-cis-l2'>2.1.7</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>SI-8</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.CM-09</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.23</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.4.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.14.5</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(B)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.EXO.11.1v1</span></td>
+</tr>
+<tr class='cis-row-fail'>
+<td class='cis-id'>2.1.7</td>
+<td>Targeted User Protection (Default)</td>
+<td><span class='badge badge-failed'>Fail</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-tag fw-cis-l2'>2.1.7</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>SI-8</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.CM-09</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.23</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.4.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.14.5</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(B)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.EXO.11.1v1</span></td>
+</tr>
+<tr class='cis-row-fail'>
+<td class='cis-id'>2.1.7</td>
+<td>Targeted Domain Protection (Default)</td>
+<td><span class='badge badge-failed'>Fail</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-tag fw-cis-l2'>2.1.7</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>SI-8</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.CM-09</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.23</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.4.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.14.5</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(B)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.EXO.11.1v1</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>2.1.7</td>
+<td>Honor DMARC Policy (Default)</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-tag fw-cis-l2'>2.1.7</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>SI-8</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.CM-09</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.23</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.4.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.14.5</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(B)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.EXO.11.1v1</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>2.1.7</td>
+<td>Spoof Intelligence (Default)</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-tag fw-cis-l2'>2.1.7</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>SI-8</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.CM-09</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.23</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.4.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.14.5</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(B)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.EXO.11.1v1</span></td>
+</tr>
+<tr class='cis-row-fail'>
+<td class='cis-id'>2.1.7</td>
+<td>First Contact Safety Tips (Default)</td>
+<td><span class='badge badge-failed'>Fail</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-tag fw-cis-l2'>2.1.7</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>SI-8</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.CM-09</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.23</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.4.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.14.5</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(B)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.EXO.11.1v1</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>5.1.2.3</td>
+<td>Non-Admin Tenant Creation Restricted</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>5.1.2.3</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>5.1.2.3</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>AC-6(10)</span><span class='fw-tag fw-nist'>CM-5</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-05</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.5.15</span><span class='fw-tag fw-iso'>A.8.2</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>2.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.1.5</span><span class='fw-tag fw-cmmc'>3.4.5</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(a)(1)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-fail'>
+<td class='cis-id'>5.1.3.2</td>
+<td>Users Can Create Security Groups</td>
+<td><span class='badge badge-failed'>Fail</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>5.1.3.2</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>5.1.3.2</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>AC-6(10)</span><span class='fw-tag fw-nist'>CM-5</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-05</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.5.15</span><span class='fw-tag fw-iso'>A.8.2</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>7.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.1.5</span><span class='fw-tag fw-cmmc'>3.4.5</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(a)(1)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-fail'>
+<td class='cis-id'>5.1.5.1</td>
+<td>User Consent for Applications</td>
+<td><span class='badge badge-failed'>Fail</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-tag fw-cis-l2'>5.1.5.1</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-tag fw-cis-l2'>5.1.5.1</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>AC-6(10)</span><span class='fw-tag fw-nist'>CM-5</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-05</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.5.15</span><span class='fw-tag fw-iso'>A.8.26</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>7.2.x</span><span class='fw-tag fw-pci'>2.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.1.5</span><span class='fw-tag fw-cmmc'>3.4.5</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(a)(1)</span><span class='fw-tag fw-hipaa'>§164.308(a)(4)(i)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.AAD.5.1v1</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>5.1.5.2</td>
+<td>Admin Consent Workflow Enabled</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>5.1.5.2</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>5.1.5.2</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>CM-4</span><span class='fw-tag fw-nist'>AC-6(10)</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-05</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.5.15</span><span class='fw-tag fw-iso'>A.8.9</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>7.2.x</span><span class='fw-tag fw-pci'>2.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.1.5</span><span class='fw-tag fw-cmmc'>3.4.5</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(a)(1)</span><span class='fw-tag fw-hipaa'>§164.308(a)(4)(i)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.AAD.5.2v1</span></td>
+</tr>
+<tr class='cis-row-fail'>
+<td class='cis-id'>5.1.6.2</td>
+<td>Guest User Access Restriction</td>
+<td><span class='badge badge-failed'>Fail</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>5.1.6.2</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>5.1.6.2</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>AC-6</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-05</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.5.15</span><span class='fw-tag fw-iso'>A.5.18</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-tag fw-stig'>V-260342</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>7.2.x</span><span class='fw-tag fw-pci'>8.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.1.5</span><span class='fw-tag fw-cmmc'>3.1.6</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(a)(1)</span><span class='fw-tag fw-hipaa'>§164.308(a)(4)(i)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.AAD.8.1v1</span></td>
+</tr>
+<tr class='cis-row-fail'>
+<td class='cis-id'>5.1.6.3</td>
+<td>Guest Invitation Policy</td>
+<td><span class='badge badge-failed'>Fail</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-tag fw-cis-l2'>5.1.6.3</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-tag fw-cis-l2'>5.1.6.3</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>AC-6(10)</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-05</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.5.15</span><span class='fw-tag fw-iso'>A.5.18</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>7.2.x</span><span class='fw-tag fw-pci'>8.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.1.5</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(a)(1)</span><span class='fw-tag fw-hipaa'>§164.308(a)(4)(i)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.AAD.8.3v1</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>5.2.2.3</td>
+<td>CA Policy Blocks Legacy Authentication</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>5.2.2.3</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>5.2.2.3</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>CM-7</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-03</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.5</span><span class='fw-tag fw-iso'>A.8.20</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-tag fw-stig'>V-260338</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>2.2.x</span><span class='fw-tag fw-pci'>8.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.4.6</span><span class='fw-tag fw-cmmc'>3.5.2</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(d)</span><span class='fw-tag fw-hipaa'>§164.312(a)(1)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.AAD.1.1v1</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>5.2.3.2</td>
+<td>Custom Banned Password List Enforced</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>5.2.3.2</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>5.2.3.2</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>IA-5(1)</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-01</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.5.17</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>8.3.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.5.7</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(D)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>5.2.3.2</td>
+<td>Custom Banned Password Count</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>5.2.3.2</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>5.2.3.2</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>IA-5(1)</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-01</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.5.17</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>8.3.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.5.7</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(ii)(D)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-fail'>
+<td class='cis-id'>5.2.3.4</td>
+<td>Auth Method Registration Campaign</td>
+<td><span class='badge badge-failed'>Fail</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>5.2.3.4</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>5.2.3.4</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>IA-2(1)</span><span class='fw-tag fw-nist'>IA-2(2)</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-03</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.5</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>8.4.1</span><span class='fw-tag fw-pci'>8.4.2</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.5.3</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(d)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>6.1.1</td>
+<td>Org-Level Audit Enabled</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>6.1.1</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>6.1.1</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>AU-12</span><span class='fw-tag fw-nist'>AU-12c</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.AE-03</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.15</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>10.2.x</span><span class='fw-tag fw-pci'>10.3.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.3.1</span><span class='fw-tag fw-cmmc'>3.3.2</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(b)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.EXO.16.1v1</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>6.1.3</td>
+<td>Mailboxes with Audit Bypass</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>6.1.3</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>6.1.3</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>AU-12</span><span class='fw-tag fw-nist'>AU-12c</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.AE-03</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.15</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>10.2.x</span><span class='fw-tag fw-pci'>10.3.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.3.1</span><span class='fw-tag fw-cmmc'>3.3.2</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(b)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.EXO.17.3v1</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>6.2.1</td>
+<td>Auto-Forward to External (Default Domain)</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>6.2.1</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>6.2.1</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>AC-4</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.DS-02</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.20</span><span class='fw-tag fw-iso'>A.5.14</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.4.x</span><span class='fw-tag fw-pci'>10.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.1.22</span><span class='fw-tag fw-cmmc'>3.13.1</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(e)(1)</span><span class='fw-tag fw-hipaa'>§164.312(b)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.EXO.1.1v1</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>6.2.1</td>
+<td>Auto-Forwarding Mode (Default)</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>6.2.1</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>6.2.1</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>AC-4</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.DS-02</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.20</span><span class='fw-tag fw-iso'>A.5.14</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.4.x</span><span class='fw-tag fw-pci'>10.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.1.22</span><span class='fw-tag fw-cmmc'>3.13.1</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(e)(1)</span><span class='fw-tag fw-hipaa'>§164.312(b)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.EXO.1.1v1</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>6.2.3</td>
+<td>External Sender Tagging</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>6.2.3</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>6.2.3</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>SI-8</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>DE.CM-09</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.23</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>5.4.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.14.5</span><span class='fw-tag fw-cmmc'>3.2.1</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(i)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.EXO.7.1v1</span></td>
+</tr>
+<tr class='cis-row-fail'>
+<td class='cis-id'>6.3.1</td>
+<td>Outlook Add-ins Allowed (Default Role Assignment Policy)</td>
+<td><span class='badge badge-failed'>Fail</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-tag fw-cis-l2'>6.3.1</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-tag fw-cis-l2'>6.3.1</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>CM-11</span><span class='fw-tag fw-nist'>CM-7</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-05</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.19</span><span class='fw-tag fw-iso'>A.8.26</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>2.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.4.9</span><span class='fw-tag fw-cmmc'>3.4.6</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(a)(1)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>6.5.1</td>
+<td>Modern Authentication Enabled</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>6.5.1</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>6.5.1</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>CM-7</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-03</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.5</span><span class='fw-tag fw-iso'>A.8.20</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>2.2.x</span><span class='fw-tag fw-pci'>8.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.4.6</span><span class='fw-tag fw-cmmc'>3.5.2</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(d)</span><span class='fw-tag fw-hipaa'>§164.312(a)(1)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>6.5.2</td>
+<td>All MailTips Enabled</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>6.5.2</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>6.5.2</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>AT-2b</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AT-01</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.6.3</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(i)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>6.5.2</td>
+<td>External Recipients Tips Enabled</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>6.5.2</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>6.5.2</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>AT-2b</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AT-01</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.6.3</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(i)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>6.5.2</td>
+<td>Group Metrics Enabled</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>6.5.2</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>6.5.2</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>AT-2b</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AT-01</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.6.3</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(i)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>6.5.2</td>
+<td>Large Audience Threshold</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>6.5.2</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>6.5.2</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>AT-2b</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AT-01</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.6.3</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.308(a)(5)(i)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-fail'>
+<td class='cis-id'>6.5.3</td>
+<td>OWA Additional Storage (OwaMailboxPolicy-Default)</td>
+<td><span class='badge badge-failed'>Fail</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-tag fw-cis-l2'>6.5.3</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-tag fw-cis-l2'>6.5.3</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>CM-7</span><span class='fw-tag fw-nist'>SC-7(10)</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.DS-01</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.19</span><span class='fw-tag fw-iso'>A.8.26</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>2.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.4.6</span><span class='fw-tag fw-cmmc'>3.13.1</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(a)(1)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>6.5.4</td>
+<td>SMTP AUTH Disabled (Org-Wide)</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>6.5.4</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>6.5.4</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>CM-7</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-03</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.5</span><span class='fw-tag fw-iso'>A.8.20</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>2.2.x</span><span class='fw-tag fw-pci'>8.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.4.6</span><span class='fw-tag fw-cmmc'>3.5.2</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(d)</span><span class='fw-tag fw-hipaa'>§164.312(a)(1)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-tag fw-scuba'>MS.EXO.5.1v1</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>7.2.10</td>
+<td>Reauthentication with Verification Code</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>7.2.10</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>7.2.10</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>IA-11</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-03</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.5</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>8.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.5.1</span><span class='fw-tag fw-cmmc'>3.5.2</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(d)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-fail'>
+<td class='cis-id'>7.2.11</td>
+<td>Default Sharing Link Permission</td>
+<td><span class='badge badge-failed'>Fail</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>7.2.11</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>7.2.11</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>AC-6</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-05</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.5.15</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>7.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.1.5</span><span class='fw-tag fw-cmmc'>3.1.22</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(a)(1)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>7.2.3</td>
+<td>SharePoint External Sharing Level</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>7.2.3</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>7.2.3</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>AC-2</span><span class='fw-tag fw-nist'>AC-3</span><span class='fw-tag fw-nist'>IA-8</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-05</span><span class='fw-tag fw-csf'>PR.DS-01</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.5.15</span><span class='fw-tag fw-iso'>A.5.18</span><span class='fw-tag fw-iso'>A.8.3</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>7.2.x</span><span class='fw-tag fw-pci'>2.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.1.2</span><span class='fw-tag fw-cmmc'>3.1.22</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(a)(1)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>7.2.5</td>
+<td>Resharing by External Users</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-tag fw-cis-l2'>7.2.5</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-tag fw-cis-l2'>7.2.5</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>AC-3</span><span class='fw-tag fw-nist'>AC-6(10)</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-05</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.5.15</span><span class='fw-tag fw-iso'>A.8.3</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>7.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.1.2</span><span class='fw-tag fw-cmmc'>3.1.5</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(a)(1)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>7.2.6</td>
+<td>Sharing Domain Restriction</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-tag fw-cis-l2'>7.2.6</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-tag fw-cis-l2'>7.2.6</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>AC-3</span><span class='fw-tag fw-nist'>AC-6(10)</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-05</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.5.15</span><span class='fw-tag fw-iso'>A.5.19</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>7.2.x</span><span class='fw-tag fw-pci'>2.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.1.2</span><span class='fw-tag fw-cmmc'>3.1.20</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(a)(1)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-fail'>
+<td class='cis-id'>7.2.7</td>
+<td>Default Sharing Link Type</td>
+<td><span class='badge badge-failed'>Fail</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>7.2.7</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>7.2.7</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>AC-6</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-05</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.5.15</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>7.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.1.5</span><span class='fw-tag fw-cmmc'>3.1.22</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(a)(1)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
 </tr>
 <tr class='cis-row-warning'>
 <td class='cis-id'>7.2.9</td>
-<td><span class='badge badge-warning'>Warning</span></td>
 <td>Guest Access Expiration</td>
-<td>Enabled (90 days)</td>
-<td>Enabled (30 days or less)</td>
-<td class='remediation-cell'>Set guest expiration to 30 days or less.</td>
+<td><span class='badge badge-warning'>Warning</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>7.2.9</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>7.2.9</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>AC-3</span><span class='fw-tag fw-nist'>AC-21b</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-05</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.5.15</span><span class='fw-tag fw-iso'>A.5.18</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>7.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.1.1</span><span class='fw-tag fw-cmmc'>3.1.20</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(a)(1)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>7.3.2</td>
+<td>Block Sync from Unmanaged Devices</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-tag fw-cis-l2'>7.3.2</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-tag fw-cis-l2'>7.3.2</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>AC-19a</span><span class='fw-tag fw-nist'>CM-7</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-05</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.6.7</span><span class='fw-tag fw-iso'>A.8.1</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>2.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.1.18</span><span class='fw-tag fw-cmmc'>3.1.19</span><span class='fw-tag fw-cmmc'>3.4.6</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.310(b)</span><span class='fw-tag fw-hipaa'>§164.312(a)(1)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-fail'>
+<td class='cis-id'>8.2.2</td>
+<td>Communication with Unmanaged Teams Users</td>
+<td><span class='badge badge-failed'>Fail</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>8.2.2</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>8.2.2</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>CM-7</span><span class='fw-tag fw-nist'>SC-7(10)</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-05</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.19</span><span class='fw-tag fw-iso'>A.8.20</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>2.2.x</span><span class='fw-tag fw-pci'>7.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.4.6</span><span class='fw-tag fw-cmmc'>3.13.1</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(a)(1)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-fail'>
+<td class='cis-id'>8.2.3</td>
+<td>External Unmanaged Users Can Initiate Conversations</td>
+<td><span class='badge badge-failed'>Fail</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>8.2.3</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>8.2.3</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>CM-7</span><span class='fw-tag fw-nist'>SI-8</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-05</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.8.19</span><span class='fw-tag fw-iso'>A.8.23</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>2.2.x</span><span class='fw-tag fw-pci'>7.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.4.6</span><span class='fw-tag fw-cmmc'>3.14.5</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(a)(1)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-fail'>
+<td class='cis-id'>8.5.1</td>
+<td>Anonymous Users Can Join Meeting</td>
+<td><span class='badge badge-failed'>Fail</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-tag fw-cis-l2'>8.5.1</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-tag fw-cis-l2'>8.5.1</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>SC-15a</span><span class='fw-tag fw-nist'>AC-3</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-03</span><span class='fw-tag fw-csf'>PR.AA-05</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.5.15</span><span class='fw-tag fw-iso'>A.8.5</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>7.2.x</span><span class='fw-tag fw-pci'>2.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.1.2</span><span class='fw-tag fw-cmmc'>3.13.12</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(a)(1)</span><span class='fw-tag fw-hipaa'>§164.312(d)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>8.5.2</td>
+<td>Anonymous Users Can Start Meeting</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>8.5.2</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>8.5.2</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>SC-15a</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-03</span><span class='fw-tag fw-csf'>PR.AA-05</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.5.15</span><span class='fw-tag fw-iso'>A.8.5</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>7.2.x</span><span class='fw-tag fw-pci'>2.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.1.2</span><span class='fw-tag fw-cmmc'>3.13.12</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(a)(1)</span><span class='fw-tag fw-hipaa'>§164.312(d)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>8.5.3</td>
+<td>Auto-Admitted Users (Lobby Bypass)</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>8.5.3</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>8.5.3</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>AC-3</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-05</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.5.15</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>7.2.x</span><span class='fw-tag fw-pci'>2.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.1.2</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(a)(1)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-pass'>
+<td class='cis-id'>8.5.4</td>
+<td>Dial-in Users Bypass Lobby</td>
+<td><span class='badge badge-success'>Pass</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>8.5.4</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>8.5.4</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>SC-15a</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-05</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.5.15</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>7.2.x</span><span class='fw-tag fw-pci'>2.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.1.2</span><span class='fw-tag fw-cmmc'>3.13.12</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(a)(1)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
+</tr>
+<tr class='cis-row-fail'>
+<td class='cis-id'>8.5.7</td>
+<td>External Participants Can Give/Request Control</td>
+<td><span class='badge badge-failed'>Fail</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L1'><span class='fw-tag fw-cis'>8.5.7</span></td>
+<td class='fw-col framework-refs' data-fw='CisE3L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L1'><span class='fw-tag fw-cis'>8.5.7</span></td>
+<td class='fw-col framework-refs' data-fw='CisE5L2'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='Nist80053'><span class='fw-tag fw-nist'>AC-17a</span></td>
+<td class='fw-col framework-refs' data-fw='NistCsf'><span class='fw-tag fw-csf'>PR.AA-05</span></td>
+<td class='fw-col framework-refs' data-fw='Iso27001'><span class='fw-tag fw-iso'>A.5.15</span><span class='fw-tag fw-iso'>A.8.20</span></td>
+<td class='fw-col framework-refs' data-fw='Stig'><span class='fw-unmapped'>&mdash;</span></td>
+<td class='fw-col framework-refs' data-fw='PciDss'><span class='fw-tag fw-pci'>7.2.x</span><span class='fw-tag fw-pci'>2.2.x</span></td>
+<td class='fw-col framework-refs' data-fw='Cmmc'><span class='fw-tag fw-cmmc'>3.1.12</span><span class='fw-tag fw-cmmc'>3.1.14</span></td>
+<td class='fw-col framework-refs' data-fw='Hipaa'><span class='fw-tag fw-hipaa'>§164.312(a)(1)</span></td>
+<td class='fw-col framework-refs' data-fw='CisaScuba'><span class='fw-unmapped'>&mdash;</span></td>
 </tr>
 </tbody></table>
 </div>
-</details>
-<h3>Passing Controls (49)</h3>
-<p class='truncated'>49 controls meet CIS benchmark recommendations. See the detailed section data tables above for full configuration details.</p>
-<p class='truncated'>Reference: <a href='https://www.cisecurity.org/benchmark/microsoft_365'>CIS Microsoft 365 Foundations Benchmark v6.0.1</a></p>
 </details>
 
         <a id="issues"></a>
@@ -3740,7 +5029,7 @@
         <details class='section' open>
 <summary><h2>Technical Issues</h2></summary>
 <table class='data-table'>
-<thead><tr><th>Severity</th><th>Section</th><th>Collector</th><th>Description</th><th>Recommended Action</th></tr></thead>
+<thead><tr><th scope='col'>Severity</th><th scope='col'>Section</th><th scope='col'>Collector</th><th scope='col'>Description</th><th scope='col'>Recommended Action</th></tr></thead>
 <tbody>
 <tr>
 <td><span class="badge badge-warning">WARNING</span></td>
@@ -3767,13 +5056,28 @@
 </details>
 
         <!-- Footer -->
-        <div class="report-footer">
+        <footer class="report-footer">
             <p>Generated by <span class="m365a-name">M365 Assess</span>
             M365 Assessment Tool v0.3.0</p>
-            <p>March 7, 2026 2:59 PM</p>
-        </div>
-    </div>
+            <p>March 9, 2026 5:38 PM</p>
+        </footer>
+    </main>
     <script>
+    // Theme toggle
+    (function() {
+        var toggle = document.getElementById('themeToggle');
+        var stored = localStorage.getItem('m365a-theme');
+        if (stored === 'dark' || (!stored && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+            document.body.classList.add('dark-theme');
+        }
+        if (toggle) {
+            toggle.addEventListener('click', function() {
+                document.body.classList.toggle('dark-theme');
+                localStorage.setItem('m365a-theme', document.body.classList.contains('dark-theme') ? 'dark' : 'light');
+            });
+        }
+    })();
+
     document.addEventListener('DOMContentLoaded', function() {
         document.querySelectorAll('.data-table').forEach(function(table) {
             var headers = table.querySelectorAll('thead th');
@@ -3783,6 +5087,96 @@
                 });
             });
         });
+
+        // --- Framework multi-selector ---
+        var selector = document.getElementById('fwSelector');
+        if (selector) {
+            var checkboxes = selector.querySelectorAll('input[type="checkbox"]');
+            var table = document.getElementById('complianceTable');
+            var cards = document.querySelectorAll('.fw-card');
+            function applyFrameworkFilter() {
+                var active = [];
+                checkboxes.forEach(function(cb) {
+                    var lbl = cb.closest('.fw-checkbox');
+                    if (cb.checked) { lbl.classList.add('active'); active.push(cb.value); }
+                    else { lbl.classList.remove('active'); }
+                });
+                // Toggle table columns
+                if (table) {
+                    var allCols = table.querySelectorAll('.fw-col');
+                    allCols.forEach(function(el) {
+                        var fw = el.getAttribute('data-fw');
+                        el.style.display = active.indexOf(fw) !== -1 ? '' : 'none';
+                    });
+                }
+                // Toggle coverage cards
+                cards.forEach(function(card) {
+                    var fw = card.getAttribute('data-fw');
+                    card.style.display = active.indexOf(fw) !== -1 ? '' : 'none';
+                });
+            }
+
+            checkboxes.forEach(function(cb) {
+                cb.addEventListener('change', applyFrameworkFilter);
+            });
+
+            var btnAll = document.getElementById('fwSelectAll');
+            var btnNone = document.getElementById('fwSelectNone');
+            if (btnAll) btnAll.addEventListener('click', function() {
+                checkboxes.forEach(function(cb) { cb.checked = true; });
+                applyFrameworkFilter();
+            });
+            if (btnNone) btnNone.addEventListener('click', function() {
+                checkboxes.forEach(function(cb) { cb.checked = false; });
+                applyFrameworkFilter();
+            });
+
+            // Initialize visual state
+            applyFrameworkFilter();
+        }
+
+        // --- Status filter (multi-select) ---
+        var statusFilter = document.getElementById('statusFilter');
+        if (statusFilter) {
+            var statusCbs = statusFilter.querySelectorAll('input[type="checkbox"]');
+            var compTable = document.getElementById('complianceTable');
+            if (compTable) {
+                var compRows = compTable.querySelectorAll('tbody tr');
+
+                function applyStatusFilter() {
+                    var active = [];
+                    statusCbs.forEach(function(cb) {
+                        var lbl = cb.closest('.status-checkbox');
+                        if (cb.checked) { lbl.classList.add('active'); active.push(cb.value); }
+                        else { lbl.classList.remove('active'); }
+                    });
+                    compRows.forEach(function(row) {
+                        var show = false;
+                        for (var i = 0; i < active.length; i++) {
+                            if ((row.className || '').indexOf('cis-row-' + active[i]) !== -1) { show = true; break; }
+                        }
+                        row.style.display = active.length === 0 || show ? '' : 'none';
+                    });
+                }
+
+                statusCbs.forEach(function(cb) {
+                    cb.addEventListener('change', applyStatusFilter);
+                });
+
+                var sAll = document.getElementById('statusSelectAll');
+                var sNone = document.getElementById('statusSelectNone');
+                if (sAll) sAll.addEventListener('click', function() {
+                    statusCbs.forEach(function(cb) { cb.checked = true; });
+                    applyStatusFilter();
+                });
+                if (sNone) sNone.addEventListener('click', function() {
+                    statusCbs.forEach(function(cb) { cb.checked = false; });
+                    applyStatusFilter();
+                });
+
+                applyStatusFilter();
+            }
+        }
     });
 
     function sortTable(table, colIndex, th) {


### PR DESCRIPTION
Add light/dark mode and accessibility to the HTML report feature list, regenerate the sample report with the latest CSS variables, dark theme toggle, and semantic landmarks.