### PR TITLE
feat: Collaboration & Hybrid dashboards, dark mode link fix

### DIFF
--- a/Common/Export-AssessmentReport.ps1
+++ b/Common/Export-AssessmentReport.ps1
@@ -994,7 +994,8 @@ foreach ($sectionName in $sections) {
             $null = $sectionHtml.AppendLine("</div>") # end email-dash-col
 
             # Middle column: Sync health donut + timing
-            $healthPct = switch ($syncHealthClass) { 'success' { 100 }; 'warning' { 60 }; 'danger' { 25 }; default { 50 } }
+            $healthPct = switch ($syncHealthClass) { 'success' { 100 }; 'warning' { 60 }; 'danger' { 25 }; default { 0 } }
+            if ($syncHealthLabel -eq 'Cloud Only') { $syncHealthLabel = 'OFF' }
             $healthDonut = Get-SvgDonut -Percentage $healthPct -CssClass $syncHealthClass -Size 130 -StrokeWidth 12
 
             $null = $sectionHtml.AppendLine("<div class='email-dash-col'>")


### PR DESCRIPTION
## Summary
- **Dark mode link color**: Add explicit `a` tag color using CSS variables — links were invisible on dark backgrounds
- **Collaboration dashboard**: Icon metric cards for SharePoint/Teams settings + security config donuts for both services
- **Hybrid dashboard**: Sync config cards, health donut with age-based status, on-premises environment info
- **Section reorder**: Move Hybrid right after Identity for logical flow
- **Hybrid sync OFF state**: Show 0% donut with "OFF" label when directory sync is disabled

## Test plan
- [x] Dark mode: verify links are readable on dark background
- [x] Collaboration section: dashboard renders with SharePoint & Teams cards + donuts
- [x] Hybrid section: appears after Identity, shows sync health donut
- [x] Hybrid with sync disabled: donut shows 0% / "OFF"
- [x] Light mode: no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)