### PR TITLE
feat: Padlock ASCII banner with M365 Assess

### DIFF
--- a/Invoke-M365Assessment.ps1
+++ b/Invoke-M365Assessment.ps1
@@ -168,22 +168,22 @@ function Show-InteractiveWizard {
     function Show-Header {
         Clear-Host
         Write-Host ''
-        Write-Host '      ███╗   ███╗ ██████╗  ██████╗ ███████╗' -ForegroundColor Cyan
-        Write-Host '      ████╗ ████║ ╚════██╗ ██╔════╝ ██╔════╝' -ForegroundColor Cyan
-        Write-Host '      ██╔████╔██║  █████╔╝ ██████╗  ███████╗' -ForegroundColor Cyan
-        Write-Host '      ██║╚██╔╝██║  ╚═══██╗ ██╔══██╗ ╚════██║' -ForegroundColor Cyan
-        Write-Host '      ██║ ╚═╝ ██║ ██████╔╝ ╚█████╔╝ ███████║' -ForegroundColor Cyan
-        Write-Host '      ╚═╝     ╚═╝ ╚═════╝   ╚════╝  ╚══════╝' -ForegroundColor Cyan
-        Write-Host '     ─────────────────────────────────────────' -ForegroundColor DarkCyan
-        Write-Host '       █████╗ ███████╗███████╗███████╗███████╗███████╗' -ForegroundColor DarkCyan
-        Write-Host '      ██╔══██╗██╔════╝██╔════╝██╔════╝██╔════╝██╔════╝' -ForegroundColor DarkCyan
-        Write-Host '      ███████║███████╗███████╗█████╗  ███████╗███████╗' -ForegroundColor DarkCyan
-        Write-Host '      ██╔══██║╚════██║╚════██║██╔══╝  ╚════██║╚════██║' -ForegroundColor DarkCyan
-        Write-Host '      ██║  ██║███████║███████║███████╗███████║███████║' -ForegroundColor DarkCyan
-        Write-Host '      ╚═╝  ╚═╝╚══════╝╚══════╝╚══════╝╚══════╝╚══════╝' -ForegroundColor DarkCyan
+        Write-Host '                  .--------.                ' -ForegroundColor DarkCyan
+        Write-Host '                / .--------. \              ' -ForegroundColor DarkCyan
+        Write-Host '               / /          \ \             ' -ForegroundColor DarkCyan
+        Write-Host '               | |          | |             ' -ForegroundColor DarkCyan
+        Write-Host '              _| |__________| |_            ' -ForegroundColor DarkCyan
+        Write-Host '            .''  |_|        |_|  ''.          ' -ForegroundColor Cyan
+        Write-Host '            ''._____  ____  _____.''          ' -ForegroundColor Cyan
+        Write-Host '            |    .''  M365  ''.    |          ' -ForegroundColor Cyan
+        Write-Host '            ''.__.''. Assess .''.__.''          ' -ForegroundColor Cyan
+        Write-Host '            ''.__  |________|  __.''          ' -ForegroundColor Cyan
+        Write-Host '            |  ''.''..____..''.''.  |           ' -ForegroundColor Cyan
+        Write-Host '            ''.____''..__..''.____.''.          ' -ForegroundColor Cyan
+        Write-Host '            ''.________________.''            ' -ForegroundColor Cyan
         Write-Host ''
-        Write-Host '        ░▒▓█  M365 Environment Assessment  █▓▒░' -ForegroundColor DarkGray
-        Write-Host '        ░▒▓█  by  D A R E N 9 M            █▓▒░' -ForegroundColor DarkCyan
+        Write-Host '       ░▒▓█  M365 Environment Assessment  █▓▒░' -ForegroundColor DarkGray
+        Write-Host '       ░▒▓█  by  D A R E N 9 M            █▓▒░' -ForegroundColor DarkCyan
         Write-Host ''
     }
 


### PR DESCRIPTION
## Summary
- Replace block-letter ASCII banner with padlock art
- Shackle in DarkCyan, lock body in Cyan
- "M365 Assess" centered in the lock body

## Test plan
- [x] Run `Invoke-M365Assessment.ps1` and verify banner renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)