### PR TITLE
feat: Restyle Security dashboard to match report layout pattern

### DIFF
--- a/Common/Export-AssessmentReport.ps1
+++ b/Common/Export-AssessmentReport.ps1
@@ -2668,6 +2668,21 @@ $html = @"
             margin-top: 1px;
         }
 
+        /* Dashboard card hover — subtle highlight for presentations */
+        .email-metric-card,
+        .id-donut-item,
+        .policy-card,
+        .dns-stat {
+            transition: background 0.15s ease, border-color 0.15s ease;
+        }
+        .email-metric-card:hover,
+        .id-donut-item:hover,
+        .policy-card:hover,
+        .dns-stat:hover {
+            background: var(--m365a-hover-bg);
+            border-color: var(--m365a-accent);
+        }
+
         /* EXO donut panel within dashboard */
         .email-dash-col .dash-panel {
             border: none;


### PR DESCRIPTION
## Summary
- Replaces the unique 2-column `security-dashboard` layout with the standard 3-column `email-dashboard` > `email-dash-top` grid used by all other report sections (Identity, Email, Collaboration, Hybrid)
- Adds left-column icon metric cards showing Secure Score %, Points Earned, M365 Average, Comparison delta, Defender Policies (enabled/total), and DLP Policies (enabled/total)
- Moves Secure Score donut to middle column using `id-donut-stack` pattern and Defender Config donut to right column using `dash-panel` pattern
- Removes unused `.security-dashboard` CSS class and its print media query

## Test plan
- [x] Run assessment against a tenant with Secure Score, Defender Policies, Defender Security Config, and DLP Policies data
- [x] Verify the Security section dashboard renders as a 3-column layout with rounded container matching other sections
- [x] Confirm metric cards display correct values with color-coded left borders
- [x] Verify Secure Score donut and Defender Config donut render at correct sizes (130px)
- [x] Check print/PDF output renders correctly without the removed `.security-dashboard` print rule
- [x] Test with missing data (e.g., no DLP Policies CSV) to ensure cards are conditionally hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)