### PR TITLE
fix: Null-safe compliance policy lookup and ScubaGear error hints

### DIFF
--- a/Intune/Get-CompliancePolicyReport.ps1
+++ b/Intune/Get-CompliancePolicyReport.ps1
@@ -85,9 +85,9 @@ Write-Verbose "Processing $($policies.Count) compliance policies..."
 
 $results = foreach ($policy in $policies) {
     $odataType = $policy.AdditionalProperties.'@odata.type'
-    $platform = $platformMap[$odataType]
+    $platform = if ($odataType) { $platformMap[$odataType] } else { $null }
     if (-not $platform) {
-        $platform = $odataType
+        $platform = if ($odataType) { $odataType } else { 'Unknown' }
     }
 
     [PSCustomObject]@{

--- a/Security/Invoke-ScubaGearScan.ps1
+++ b/Security/Invoke-ScubaGearScan.ps1
@@ -122,7 +122,19 @@ function Invoke-PS5Command {
             $errorText = if ($errorLines) { ($errorLines | ForEach-Object { $_.ToString() }) -join "`n" } else { ($output | ForEach-Object { $_.ToString() }) -join "`n" }
             $actionableHint = if ($Description -eq 'module setup') {
                 " Try running 'powershell.exe -Command Install-Module ScubaGear -Scope CurrentUser -Force' manually to diagnose."
-            } else { '' }
+            }
+            elseif ($errorText -match 'unknown escape character|unable to parse input.*yaml') {
+                " This is a known ScubaGear/OPA issue where backslash characters in tenant" +
+                " data cause YAML parsing failures. Try updating ScubaGear to the latest" +
+                " version: powershell.exe -Command 'Update-Module ScubaGear -Force'." +
+                " If the issue persists, report it at https://github.com/cisagov/ScubaGear/issues"
+            }
+            elseif ($errorText -match 'Invalid JSON primitive') {
+                " ScubaGear report generation failed, likely due to upstream OPA evaluation" +
+                " errors. Check for a newer ScubaGear version or run with fewer ProductNames" +
+                " to isolate the failing baseline."
+            }
+            else { '' }
             throw "PS5 $Description failed (exit code $exitCode): $errorText$actionableHint"
         }
         return $output


### PR DESCRIPTION
## Summary
Fixes both collector errors reported in #27:

- **Compliance Policies**: `$platformMap[$null]` throws "Index operation failed" when newer policy types (Settings Catalog) don't populate `@odata.type` in `AdditionalProperties`. Fixed with null-safe conditional lookup, falls back to `'Unknown'` platform.
- **ScubaGear YAML error**: Upstream ScubaGear v1.7.1 / OPA bug where backslash characters in tenant data cause YAML parsing failures. Added pattern-matched actionable hints suggesting version update and upstream issue link.

## Test plan
- [ ] Run assessment against tenant with Settings Catalog compliance policies — verify no crash
- [ ] Verify `Platform` column shows `'Unknown'` for policies without `@odata.type`
- [ ] Trigger ScubaGear YAML failure — verify error message includes update suggestion and cisagov link

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)