### PR TITLE
fix: Validate wizard output folder to reject UPN and invalid paths

### DIFF
--- a/Invoke-M365Assessment.ps1
+++ b/Invoke-M365Assessment.ps1
@@ -347,8 +347,27 @@ function Show-InteractiveWizard {
     Write-Host "    $defaultOutput\" -ForegroundColor $cSuccess
     Write-Host ''
     Write-Host '  Press ENTER to accept, or type a custom path:' -ForegroundColor $cMuted
-    Write-Host '  > ' -ForegroundColor $cPrompt -NoNewline
-    $outputInput = Read-Host
+    do {
+        $outputValid = $true
+        Write-Host '  > ' -ForegroundColor $cPrompt -NoNewline
+        $outputInput = Read-Host
+        if ($outputInput.Trim()) {
+            # Reject values that look like email/UPN rather than a folder path
+            if ($outputInput.Trim() -match '@') {
+                Write-Host ''
+                Write-Host '  That looks like an email address or UPN, not a folder path.' -ForegroundColor $cError
+                Write-Host "  Press ENTER to use the default ($defaultOutput), or type a valid path:" -ForegroundColor $cMuted
+                $outputValid = $false
+            }
+            # Reject paths containing characters invalid on Windows
+            elseif ($outputInput.Trim() -match '[<>"|?*]') {
+                Write-Host ''
+                Write-Host '  Path contains invalid characters ( < > " | ? * ).' -ForegroundColor $cError
+                Write-Host "  Press ENTER to use the default ($defaultOutput), or type a valid path:" -ForegroundColor $cMuted
+                $outputValid = $false
+            }
+        }
+    } while (-not $outputValid)
     $wizOutputFolder = if ($outputInput.Trim()) { $outputInput.Trim() } else { $defaultOutput }
 
     # ================================================================


### PR DESCRIPTION
## Summary
- Adds input validation to the interactive wizard Step 4 (Output Folder) to reject email addresses, UPNs, and invalid path characters
- Prevents assessment results from landing outside the gitignored `M365-Assessment/` directory when a UPN is accidentally entered as the output path
- Re-prompts the user with a helpful message and allows pressing Enter to accept the default

## Test plan
- [ ] Run wizard, paste a UPN (e.g. `admin@contoso.onmicrosoft.com`) at Step 4 — should reject with message
- [ ] Enter path with invalid chars (e.g. `out|put`) — should reject with message
- [ ] Press Enter at Step 4 — should accept default `.\M365-Assessment`
- [ ] Type a valid custom path — should accept it

🤖 Generated with [Claude Code](https://claude.com/claude-code)