### PR TITLE
fix: Detect missing modules based on selected sections

### DIFF
--- a/Invoke-M365Assessment.ps1
+++ b/Invoke-M365Assessment.ps1
@@ -1085,30 +1085,41 @@ if (-not $SkipConnection) {
         }
     }
 
-    if ($exoModule -and -not $graphModule) {
-        $needsGraph = $false
-        foreach ($s in $Section) {
-            if ($s -notin @('Email', 'ScubaGear')) { $needsGraph = $true; break }
-        }
-        if ($needsGraph) {
-            $compatErrors += "Microsoft.Graph.Authentication module is not installed. Run: Install-Module Microsoft.Graph.Authentication -Scope CurrentUser"
-        }
+    # Determine which modules the selected sections actually require
+    $needsGraph = $false
+    $needsExo   = $false
+    foreach ($s in $Section) {
+        $svcList = $sectionServiceMap[$s]
+        if ($svcList -contains 'Graph')                                    { $needsGraph = $true }
+        if ($svcList -contains 'ExchangeOnline' -or $svcList -contains 'Purview') { $needsExo = $true }
+    }
+
+    $missingModules = @()
+    if ($needsGraph -and -not $graphModule) {
+        $missingModules += "Microsoft.Graph.Authentication — Install-Module Microsoft.Graph.Authentication -Scope CurrentUser"
+    }
+    if ($needsExo -and -not $exoModule) {
+        $missingModules += "ExchangeOnlineManagement — Install-Module ExchangeOnlineManagement -RequiredVersion 3.7.1 -Scope CurrentUser"
+    }
+
+    if ($missingModules.Count -gt 0) {
+        $compatErrors += $missingModules
     }
 
     if ($compatErrors.Count -gt 0) {
         Write-Host ''
         Write-Host '  ╔══════════════════════════════════════════════════════════╗' -ForegroundColor Magenta
-        Write-Host '  ║  Module Compatibility Issue                              ║' -ForegroundColor Magenta
+        Write-Host '  ║  Module Issue                                            ║' -ForegroundColor Magenta
         Write-Host '  ╚══════════════════════════════════════════════════════════╝' -ForegroundColor Magenta
         foreach ($err in $compatErrors) {
-            Write-Host "    $err" -ForegroundColor Yellow
+            Write-Host "    • $err" -ForegroundColor Yellow
         }
         Write-Host ''
         Write-Host '  Known compatible combo: Graph SDK 2.35.x + EXO 3.7.1' -ForegroundColor DarkGray
         Write-Host '  Also: Always connect Graph BEFORE EXO in the same session.' -ForegroundColor DarkGray
         Write-Host ''
-        Write-AssessmentLog -Level ERROR -Message "Module compatibility check failed: $($compatErrors -join '; ')"
-        Write-Error "Module compatibility issue detected. See above for details."
+        Write-AssessmentLog -Level ERROR -Message "Module check failed: $($compatErrors -join '; ')"
+        Write-Error "Required modules are missing or incompatible. See above for details."
         return
     }
 


### PR DESCRIPTION
## Summary
- Replaces the flawed module detection that only caught "Graph missing when EXO installed"
- Now uses `$sectionServiceMap` to determine which modules the selected sections actually need
- Detects all missing combinations: both missing, Graph-only missing, EXO-only missing
- Stops assessment early with actionable `Install-Module` commands instead of silently skipping every collector

## Root cause
The guard clause `if ($exoModule -and -not $graphModule)` required EXO to be present before checking for Graph. When neither module was installed, `$exoModule` was `$null`, so the entire check was skipped — the assessment proceeded and every collector was skipped with WARN logs.

## Test plan

Tested on macOS with Graph 2.35.1 installed, EXO not installed:

- [x] `-Section Email` (needs EXO) — blocked with "Module Issue" banner listing missing EXO ✅
- [x] `-Section Tenant` (needs Graph) — passed module check, proceeded to auth ✅
- [x] `-Section ActiveDirectory` (no M365 modules needed) — passed module check, ran collectors ✅
- [ ] Run with no modules installed — should show both missing modules and stop
- [ ] Run with both installed — should pass check and proceed normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)