### PR TITLE
fix: correct docs references (scripts/ -> Setup/)

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ M365-Assess/
   Networking/                     # Port scanning, DNS, connectivity
   Purview/                        # DLP policies, audit retention
   Security/                       # Secure Score, Defender, DLP, ScubaGear
-  scripts/                        # App Registration provisioning scripts
+  Setup/                          # App Registration provisioning scripts
   docs/                           # Detailed documentation
 ```
 

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -56,7 +56,7 @@ The App Registration needs these Microsoft Graph **application** permissions:
 
 For Exchange Online, add the **Exchange.ManageAsApp** application role and assign the **Exchange Administrator** or **Global Reader** directory role to the service principal.
 
-See [`scripts/`](../scripts/) for App Registration provisioning scripts.
+See [`Setup/`](../Setup/) for App Registration provisioning scripts.
 
 ## Pre-Existing Connections
 

--- a/docs/COMPLIANCE.md
+++ b/docs/COMPLIANCE.md
@@ -61,23 +61,17 @@ To view or edit mappings:
 Get-Content .\controls\registry.json | ConvertFrom-Json | Where-Object { $_.checkId -eq 'ENTRA-ADMIN-001' }
 ```
 
-Individual framework mapping files live in `controls/frameworks/`:
+Framework mappings are stored in two locations:
 
 ```
 controls/
-  registry.json              # Master registry (151 entries)
+  registry.json              # Master registry (151 entries) — contains all framework mappings inline
   frameworks/
-    cis-m365-v6.json         # CIS M365 v6.0.1 benchmark
-    nist-800-53.json         # NIST 800-53 Rev 5
-    nist-csf.json            # NIST CSF 2.0
-    iso-27001.json           # ISO 27001:2022
-    stig.json                # DISA STIG
-    pci-dss.json             # PCI DSS v4.0.1
-    cmmc.json                # CMMC 2.0
-    hipaa.json               # HIPAA Security Rule
-    cisa-scuba.json          # CISA SCuBA
+    cis-m365-v6.json         # CIS M365 v6.0.1 benchmark profiles
     soc2-tsc.json            # SOC 2 Trust Services Criteria
 ```
+
+The master `registry.json` contains all framework mappings embedded in each control entry. The `frameworks/` directory holds supplemental profile definitions for frameworks that need additional metadata (CIS license/level profiles, SOC 2 audit evidence mappings).
 
 ## XLSX Compliance Matrix
 


### PR DESCRIPTION
## Summary
- Fix three doc references that were lost during PR #48 merge (fix commit didn't make it in)
- `scripts/` -> `Setup/` in AUTHENTICATION.md and README project structure
- COMPLIANCE.md: list only actual framework files in `controls/frameworks/`

Closes automatically -- trivial doc fix.

## Test plan
- [x] Verified `Setup/` directory exists
- [x] Verified only `cis-m365-v6.json` and `soc2-tsc.json` exist in `controls/frameworks/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)