### PR TITLE
release: v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to M365 Assess are documented here. This project uses [Conventional Commits](https://www.conventionalcommits.org/).
 
+## [0.8.1] - 2026-03-14
+
+### Added
+- 6 CIS quick-win checks: admin center restriction (5.1.2.4), emergency access accounts (1.1.2), password hash sync (5.1.8.1), external sharing by security group (7.2.8), custom script on personal sites (7.3.3), custom script on site collections (7.3.4)
+- Authentication capability matrix with auth method support, license requirements, and platform requirements
+
+### Changed
+- Registry expanded to 233 entries with 138 automated checks
+- Synced version numbers across all 23 scripts to 0.8.1
+- CheckId Guide rewritten with current counts, sub-numbering docs, supersededBy pattern, and new-check checklist
+- Added Show-CheckProgress and Export-ComplianceMatrix to version tracking list
+
+### Fixed
+- Dashboard card coloring inconsistency in Collaboration section (switch statement semicolons)
+- Added ActiveDirectory and SOC2 sections to README Available Sections table
+
 ## [0.8.0] - 2026-03-14
 
 ### Added

--- a/Collaboration/Get-SharePointSecurityConfig.ps1
+++ b/Collaboration/Get-SharePointSecurityConfig.ps1
@@ -21,7 +21,7 @@
 
     Exports the security configuration to CSV.
 .NOTES
-    Version: 0.8.0
+    Version: 0.8.1
     Author:  Daren9m
     Settings checked are aligned with CIS Microsoft 365 Foundations Benchmark v6.0.1 recommendations.
 #>

--- a/Collaboration/Get-TeamsSecurityConfig.ps1
+++ b/Collaboration/Get-TeamsSecurityConfig.ps1
@@ -18,7 +18,7 @@
 
     Displays Teams security configuration settings.
 .NOTES
-    Version: 0.8.0
+    Version: 0.8.1
     Author:  Daren9m
     Settings checked are aligned with CIS Microsoft 365 Foundations Benchmark v6.0.1 recommendations.
 #>

--- a/Common/Export-AssessmentReport.ps1
+++ b/Common/Export-AssessmentReport.ps1
@@ -37,7 +37,7 @@
 
     Generates a report with the specified tenant name on the cover page.
 .NOTES
-    Version: 0.8.0
+    Version: 0.8.1
     Author:  Daren9m
 #>
 [CmdletBinding()]
@@ -153,7 +153,7 @@ if (-not $TenantName) {
 # (avoids fragile CSV-scanning; the main script already resolved it from TenantId or Graph)
 
 # Read assessment version and cloud environment from log if available
-$assessmentVersion = '0.8.0'
+$assessmentVersion = '0.8.1'
 $cloudEnvironment = 'commercial'
 # Find the log file (may have domain suffix, e.g., _Assessment-Log_contoso.txt)
 $logFile = Get-ChildItem -Path $AssessmentFolder -Filter '_Assessment-Log*.txt' -ErrorAction SilentlyContinue | Select-Object -First 1

--- a/Common/Export-ComplianceMatrix.ps1
+++ b/Common/Export-ComplianceMatrix.ps1
@@ -15,7 +15,7 @@
 .EXAMPLE
     .\Common\Export-ComplianceMatrix.ps1 -AssessmentFolder .\M365-Assessment\Assessment_20260311_033912_dzmlab
 .NOTES
-    Version: 0.8.0
+    Version: 0.8.1
     Requires: ImportExcel module (Install-Module ImportExcel -Scope CurrentUser)
 #>
 [CmdletBinding()]

--- a/Common/Show-CheckProgress.ps1
+++ b/Common/Show-CheckProgress.ps1
@@ -13,7 +13,7 @@
     global functions (Update-CheckProgress, Update-ProgressStatus) that
     collectors call from Add-Setting to drive real-time updates.
 .NOTES
-    Version: 0.8.0
+    Version: 0.8.1
     Author:  Daren9m
 #>
 

--- a/Entra/Get-CASecurityConfig.ps1
+++ b/Entra/Get-CASecurityConfig.ps1
@@ -20,7 +20,7 @@
 
     Exports the CA evaluation to CSV.
 .NOTES
-    Version: 0.8.0
+    Version: 0.8.1
     Author:  Daren9m
     Settings checked are aligned with CIS Microsoft 365 Foundations Benchmark v6.0.1 recommendations.
 #>

--- a/Entra/Get-EntraSecurityConfig.ps1
+++ b/Entra/Get-EntraSecurityConfig.ps1
@@ -23,7 +23,7 @@
 
     Exports the security configuration to CSV.
 .NOTES
-    Version: 0.8.0
+    Version: 0.8.1
     Author:  Daren9m
     Settings checked are aligned with CIS Microsoft 365 Foundations Benchmark v6.0.1 recommendations.
 #>

--- a/Entra/Get-UserSummary.ps1
+++ b/Entra/Get-UserSummary.ps1
@@ -27,7 +27,7 @@
 
     Exports user summary counts to CSV for reporting.
 .NOTES
-    Version: 0.8.0
+    Version: 0.8.1
     M365 Assess
 #>
 [CmdletBinding()]

--- a/Exchange-Online/Get-DnsSecurityConfig.ps1
+++ b/Exchange-Online/Get-DnsSecurityConfig.ps1
@@ -20,7 +20,7 @@
 
     Exports the DNS evaluation to CSV.
 .NOTES
-    Version: 0.8.0
+    Version: 0.8.1
     Author:  Daren9m
     Settings checked are aligned with CIS Microsoft 365 Foundations Benchmark v6.0.1 recommendations.
 #>

--- a/Exchange-Online/Get-ExoSecurityConfig.ps1
+++ b/Exchange-Online/Get-ExoSecurityConfig.ps1
@@ -17,7 +17,7 @@
 
     Displays Exchange Online security configuration settings.
 .NOTES
-    Version: 0.8.0
+    Version: 0.8.1
     Author:  Daren9m
     Settings checked are aligned with CIS Microsoft 365 Foundations Benchmark v6.0.1 recommendations.
 #>

--- a/Intune/Get-IntuneSecurityConfig.ps1
+++ b/Intune/Get-IntuneSecurityConfig.ps1
@@ -20,7 +20,7 @@
 
     Exports the Intune evaluation to CSV.
 .NOTES
-    Version: 0.8.0
+    Version: 0.8.1
     Author:  Daren9m
     Settings checked are aligned with CIS Microsoft 365 Foundations Benchmark v6.0.1 recommendations.
 #>

--- a/Inventory/Get-GroupInventory.ps1
+++ b/Inventory/Get-GroupInventory.ps1
@@ -29,7 +29,7 @@
 
     Exports group inventory without per-DL member counts (faster on large tenants).
 .NOTES
-    Version: 0.8.0
+    Version: 0.8.1
     M365 Assess — M&A Inventory
 #>
 [CmdletBinding()]

--- a/Inventory/Get-MailboxInventory.ps1
+++ b/Inventory/Get-MailboxInventory.ps1
@@ -22,7 +22,7 @@
 
     Exports the full mailbox inventory to CSV.
 .NOTES
-    Version: 0.8.0
+    Version: 0.8.1
     M365 Assess — M&A Inventory
 #>
 [CmdletBinding()]

--- a/Inventory/Get-OneDriveInventory.ps1
+++ b/Inventory/Get-OneDriveInventory.ps1
@@ -32,7 +32,7 @@
 
     Exports the OneDrive inventory to CSV.
 .NOTES
-    Version: 0.8.0
+    Version: 0.8.1
     M365 Assess — M&A Inventory
 #>
 [CmdletBinding()]

--- a/Inventory/Get-SharePointInventory.ps1
+++ b/Inventory/Get-SharePointInventory.ps1
@@ -32,7 +32,7 @@
 
     Exports the SharePoint site inventory to CSV.
 .NOTES
-    Version: 0.8.0
+    Version: 0.8.1
     M365 Assess — M&A Inventory
 #>
 [CmdletBinding()]

--- a/Inventory/Get-TeamsInventory.ps1
+++ b/Inventory/Get-TeamsInventory.ps1
@@ -27,7 +27,7 @@
 
     Exports the Teams inventory to CSV.
 .NOTES
-    Version: 0.8.0
+    Version: 0.8.1
     M365 Assess — M&A Inventory
 #>
 [CmdletBinding()]

--- a/Invoke-M365Assessment.ps1
+++ b/Invoke-M365Assessment.ps1
@@ -10,7 +10,7 @@
     Designed for IT consultants assessing SMB clients (10-500 users) with
     Microsoft-based cloud environments.
 .NOTES
-    Version: 0.8.0
+    Version: 0.8.1
     Author:  Daren9m
 .PARAMETER Section
     One or more assessment sections to run. Valid values: Tenant, Identity,
@@ -131,7 +131,7 @@ $ErrorActionPreference = 'Stop'
 # ------------------------------------------------------------------
 # Version
 # ------------------------------------------------------------------
-$script:AssessmentVersion = '0.8.0'
+$script:AssessmentVersion = '0.8.1'
 
 # Resolve project root for collector and helper paths
 $projectRoot = Split-Path -Parent $PSCommandPath

--- a/M365-Assess.psd1
+++ b/M365-Assess.psd1
@@ -3,7 +3,7 @@
     # Generated: 2026-03-08
 
     RootModule        = 'Invoke-M365Assessment.ps1'
-    ModuleVersion     = '0.8.0'
+    ModuleVersion     = '0.8.1'
     GUID              = 'f7e3b2a1-4c5d-6e8f-9a0b-1c2d3e4f5a6b'
     Author            = 'Daren9m'
     CompanyName       = 'Community'
@@ -84,7 +84,7 @@
             Tags         = @('Microsoft365', 'M365', 'Security', 'Assessment', 'EntraID', 'Exchange', 'Intune', 'Defender', 'SharePoint', 'Teams', 'ScubaGear', 'CIS')
             LicenseUri   = 'https://github.com/Daren9m/M365-Assess/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/Daren9m/M365-Assess'
-            ReleaseNotes = 'v0.8.0 - CIS gap closure: CA Policy Evaluator, DNS Security, Intune collectors; 68 to 119 CIS automated coverage'
+            ReleaseNotes = 'v0.8.1 - Polish: version sync across all scripts, CheckId Guide rewrite, dashboard fix, auth matrix, 6 CIS quick-win checks (138 automated)'
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 [![PowerShell 7.x](https://img.shields.io/badge/PowerShell-7.x-blue?logo=powershell&logoColor=white)](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows)
 [![Read-Only](https://img.shields.io/badge/Operations-Read--Only-brightgreen)](.)
-[![Version](https://img.shields.io/badge/version-0.8.0-blue)](.)
+[![Version](https://img.shields.io/badge/version-0.8.1-blue)](.)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 </div>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,6 +11,7 @@ M365 Assess is a **read-only** assessment tool. It connects to Microsoft 365 ser
 | 0.8.x   | Yes       |
 | < 0.8   | No        |
 
+
 ## Reporting a Vulnerability
 
 If you discover a security issue in this project, please report it responsibly:

--- a/SOC2/Get-SOC2AuditEvidence.ps1
+++ b/SOC2/Get-SOC2AuditEvidence.ps1
@@ -33,7 +33,7 @@
 
     Exports 60-day evidence window to CSV.
 .NOTES
-    Version: 0.8.0
+    Version: 0.8.1
     Author:  Daren9m
 #>
 [CmdletBinding()]

--- a/SOC2/Get-SOC2ConfidentialityControls.ps1
+++ b/SOC2/Get-SOC2ConfidentialityControls.ps1
@@ -29,7 +29,7 @@
 
     Exports SOC 2 Confidentiality control results to CSV.
 .NOTES
-    Version: 0.8.0
+    Version: 0.8.1
     Author:  Daren9m
 #>
 [CmdletBinding()]

--- a/SOC2/Get-SOC2ReadinessChecklist.ps1
+++ b/SOC2/Get-SOC2ReadinessChecklist.ps1
@@ -30,7 +30,7 @@
 
     Exports the checklist to CSV for tracking.
 .NOTES
-    Version: 0.8.0
+    Version: 0.8.1
     Author:  Daren9m
 #>
 [CmdletBinding()]

--- a/SOC2/Get-SOC2SecurityControls.ps1
+++ b/SOC2/Get-SOC2SecurityControls.ps1
@@ -29,7 +29,7 @@
 
     Exports SOC 2 Security control results to CSV.
 .NOTES
-    Version: 0.8.0
+    Version: 0.8.1
     Author:  Daren9m
 #>
 [CmdletBinding()]

--- a/Security/Get-ComplianceSecurityConfig.ps1
+++ b/Security/Get-ComplianceSecurityConfig.ps1
@@ -20,7 +20,7 @@
 
     Exports the security configuration to CSV.
 .NOTES
-    Version: 0.8.0
+    Version: 0.8.1
     Author:  Daren9m
     Settings checked are aligned with CIS Microsoft 365 Foundations Benchmark v6.0.1 recommendations.
 #>

--- a/Security/Get-DefenderSecurityConfig.ps1
+++ b/Security/Get-DefenderSecurityConfig.ps1
@@ -25,7 +25,7 @@
 
     Exports the security configuration to CSV.
 .NOTES
-    Version: 0.8.0
+    Version: 0.8.1
     Author:  Daren9m
     Settings checked are aligned with CIS Microsoft 365 Foundations Benchmark v6.0.1 recommendations.
     Some checks require Defender for Office 365 Plan 1 or Plan 2 licensing.


### PR DESCRIPTION
## Summary
- Bump all 27 version locations across 25 files from 0.8.0 to 0.8.1
- Add CHANGELOG entry for v0.8.1
- Update module manifest release notes

## What's in v0.8.1

### Added
- 6 CIS quick-win checks: admin center restriction (5.1.2.4), emergency access accounts (1.1.2), password hash sync (5.1.8.1), external sharing by security group (7.2.8), custom script on personal sites (7.3.3), custom script on site collections (7.3.4)
- Authentication capability matrix with auth method support, license requirements, and platform requirements

### Changed
- Registry expanded to 233 entries with 138 automated checks
- Synced version numbers across all 23 scripts
- CheckId Guide rewritten with current counts and patterns

### Fixed
- Dashboard card coloring inconsistency in Collaboration section

## Post-merge
After merging, create a GitHub Release with tag `v0.8.1` and close milestone "v0.8.1 - Polish & Foundation"

🤖 Generated with [Claude Code](https://claude.com/claude-code)