### PR TITLE
chore: update GitHub URLs from Daren9m to SelvageLabs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for your interest in contributing! This project often benefits from commu
 
 ### Reporting Issues
 
-- Use [GitHub Issues](https://github.com/Daren9m/M365-Assess/issues) to report bugs or request features
+- Use [GitHub Issues](https://github.com/SelvageLabs/M365-Assess/issues) to report bugs or request features
 - Include the PowerShell version (`$PSVersionTable.PSVersion`), OS, and relevant module versions
 - Paste error messages and steps to reproduce
 

--- a/Common/Export-AssessmentReport.ps1
+++ b/Common/Export-AssessmentReport.ps1
@@ -3606,7 +3606,7 @@ $html = @"
 $(if (-not $NoBranding) {
 @'
         <div class="cover-branding">
-            <a href="https://github.com/Daren9m/M365-Assess" target="_blank" rel="noopener" class="cover-branding-link">
+            <a href="https://github.com/SelvageLabs/M365-Assess" target="_blank" rel="noopener" class="cover-branding-link">
                 <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor" class="cover-branding-icon"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
                 <span>Open-source &mdash; M365-Assess on GitHub</span>
             </a>

--- a/M365-Assess.psd1
+++ b/M365-Assess.psd1
@@ -88,8 +88,8 @@
     PrivateData       = @{
         PSData = @{
             Tags         = @('Microsoft365', 'M365', 'Security', 'Assessment', 'EntraID', 'Exchange', 'Intune', 'Defender', 'SharePoint', 'Teams', 'ScubaGear', 'CIS')
-            LicenseUri   = 'https://github.com/Daren9m/M365-Assess/blob/main/LICENSE'
-            ProjectUri   = 'https://github.com/Daren9m/M365-Assess'
+            LicenseUri   = 'https://github.com/SelvageLabs/M365-Assess/blob/main/LICENSE'
+            ProjectUri   = 'https://github.com/SelvageLabs/M365-Assess'
             ReleaseNotes = 'v0.8.1 - Polish: version sync across all scripts, CheckId Guide rewrite, dashboard fix, auth matrix, 6 CIS quick-win checks (138 automated)'
         }
     }

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Run a single command to produce CSV reports, a branded HTML assessment report, a
 
 ```powershell
 # 1. Clone the repository
-git clone https://github.com/Daren9m/M365-Assess.git
+git clone https://github.com/SelvageLabs/M365-Assess.git
 cd M365-Assess
 
 # 2. Install required modules
@@ -63,7 +63,7 @@ Install-Module Microsoft.Graph, ExchangeOnlineManagement -Scope CurrentUser
 | **macOS** | Experimental |
 | **Linux** | Experimental |
 
-macOS and Linux are supported by PowerShell 7 but have not been fully tested. If you run into issues, please [open an issue](https://github.com/Daren9m/M365-Assess/issues/new) with your OS version, PowerShell version, terminal app, and the assessment log file.
+macOS and Linux are supported by PowerShell 7 but have not been fully tested. If you run into issues, please [open an issue](https://github.com/SelvageLabs/M365-Assess/issues/new) with your OS version, PowerShell version, terminal app, and the assessment log file.
 
 ## Interactive Console
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,7 +17,7 @@ M365 Assess is a **read-only** assessment tool. It connects to Microsoft 365 ser
 If you discover a security issue in this project, please report it responsibly:
 
 1. **Do not** open a public GitHub issue for security vulnerabilities
-2. Email the maintainer directly or use [GitHub Security Advisories](https://github.com/Daren9m/M365-Assess/security/advisories/new)
+2. Email the maintainer directly or use [GitHub Security Advisories](https://github.com/SelvageLabs/M365-Assess/security/advisories/new)
 3. Include steps to reproduce and any relevant logs (with tenant PII redacted)
 
 You should receive a response within 72 hours. We will work with you to understand the issue and coordinate a fix before any public disclosure.

--- a/docs/sample-report/_Example-Report.html
+++ b/docs/sample-report/_Example-Report.html
@@ -1617,7 +1617,7 @@
         <div class="cover-subtitle">March 13, 2026</div>
         <div class="cover-date">v0.8.0</div>
         <div class="cover-branding">
-            <a href="https://github.com/Daren9m/M365-Assess" target="_blank" rel="noopener" class="cover-branding-link">
+            <a href="https://github.com/SelvageLabs/M365-Assess" target="_blank" rel="noopener" class="cover-branding-link">
                 <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor" class="cover-branding-icon"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
                 <span>Open-source &mdash; M365-Assess on GitHub</span>
             </a>


### PR DESCRIPTION
## Summary
- Replaced all `github.com/Daren9m/M365-Assess` URLs with `github.com/SelvageLabs/M365-Assess` across 6 files
- Author attribution fields (`.NOTES Author:`, CODEOWNERS, Copyright, personal profile links) left unchanged

### Files changed
| File | Change |
|------|--------|
| `M365-Assess.psd1` | LicenseUri + ProjectUri |
| `README.md` | Clone URL + issue link |
| `CONTRIBUTING.md` | Issues link |
| `SECURITY.md` | Security advisories link |
| `Common/Export-AssessmentReport.ps1` | HTML report branding link |
| `docs/sample-report/_Example-Report.html` | Sample report branding link |

## Test plan
- [x] Verify all links in README resolve to the new org URL
- [x] Generate a fresh HTML report and confirm the cover page branding link points to SelvageLabs
- [x] Confirm `Test-ModuleManifest M365-Assess.psd1` passes with updated URIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)