### PR TITLE
chore: bump version to 0.9.1

### DIFF
--- a/.claude/rules/versions.md
+++ b/.claude/rules/versions.md
@@ -5,7 +5,7 @@
 
 ## Assessment Suite Version
 
-Current: **0.9.0**
+Current: **0.9.1**
 
 ### Version Locations (3 total)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to M365 Assess are documented here. This project uses [Conventional Commits](https://www.conventionalcommits.org/).
 
+## [0.9.1] - 2026-03-15
+
+### Changed
+- **Breaking:** `-ClientSecret` parameter now requires `[SecureString]` instead of plain text (#111)
+- EXO/Purview explicitly reject ClientSecret auth instead of silent fallthrough (#112)
+- Framework count in exec summary uses dynamic `$allFrameworkKeys.Count` instead of hardcoded 12 (#100)
+
+### Fixed
+- PowerBI 404/403 error parsing with actionable messages (#106)
+- SharePoint 401/403 guides users to consent `SharePointTenantSettings.Read.All` (#116)
+- Teams beta endpoint errors use try/catch + Write-Warning instead of SilentlyContinue (#115)
+- Null-safe `['value']` array access across 5 collector files (47 insertions) (#114)
+- PIM license vs config detection distinguishes "not configured" from "missing P2 license" (#117)
+- SOC2 SharePoint dependency probe with module-missing vs not-connected messaging (#110)
+- DeviceCodeCredential stray errors no longer crash Entra and Teams collectors
+- PowerBI child process no longer prompts for Service parameter
+
+### Added
+- 5 new Pester tests for PowerBI disconnected, 403, and 404 scenarios (#113)
+- COMPLIANCE.md updated to 149 automated checks, 233 registry entries (#99)
+- CONTRIBUTING.md with Pester testing guidance and PR template checklist (#101)
+- Registry README documenting CSV-to-JSON build pipeline (#102)
+
 ## [0.9.0] - 2026-03-14
 
 ### Added

--- a/M365-Assess.psd1
+++ b/M365-Assess.psd1
@@ -3,7 +3,7 @@
     # Generated: 2026-03-08
 
     RootModule        = 'Invoke-M365Assessment.ps1'
-    ModuleVersion     = '0.9.0'
+    ModuleVersion     = '0.9.1'
     GUID              = 'f7e3b2a1-4c5d-6e8f-9a0b-1c2d3e4f5a6b'
     Author            = 'SelvageLabs'
     CompanyName       = 'Community'
@@ -98,7 +98,7 @@
             Tags         = @('Microsoft365', 'M365', 'Security', 'Assessment', 'EntraID', 'Exchange', 'Intune', 'Defender', 'SharePoint', 'Teams', 'PowerBI', 'ScubaGear', 'CIS')
             LicenseUri   = 'https://github.com/SelvageLabs/M365-Assess/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/SelvageLabs/M365-Assess'
-            ReleaseNotes = 'v0.9.0 - Power BI collector (11 CIS 9.x checks), -ManagedIdentity and -ClientSecret auth, section reorder for optimal connections, validated issue fixes'
+            ReleaseNotes = 'v0.9.1 - Hardening and polish: SecureString for ClientSecret, null-safe array access, PIM license detection, improved error messages across PowerBI/SharePoint/Teams/EXO collectors'
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 [![PowerShell 7.x](https://img.shields.io/badge/PowerShell-7.x-blue?logo=powershell&logoColor=white)](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows)
 [![Read-Only](https://img.shields.io/badge/Operations-Read--Only-brightgreen)](.)
-[![Version](https://img.shields.io/badge/version-0.9.0-blue)](.)
+[![Version](https://img.shields.io/badge/version-0.9.1-blue)](.)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 </div>


### PR DESCRIPTION
## Summary

- Bump `ModuleVersion` to `0.9.1` in manifest
- Update README badge
- Add v0.9.1 CHANGELOG section (13 issues closed: #99-#102, #106, #110-#117)
- Update versions.md reference

This was missed when PR #118 (v0.9.1 hardening) was merged. GitHub release will be created after merge.

## Test plan

- [x] Version bump is correct in all 3 locations
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)