### PR TITLE
test: add Pester regression test for backtick-free collectors

### DIFF
--- a/tests/Smoke/Script-Validation.Tests.ps1
+++ b/tests/Smoke/Script-Validation.Tests.ps1
@@ -30,6 +30,18 @@ BeforeDiscovery {
                 FullName = $_.FullName
             }
         }
+
+    $collectorFiles = Get-ChildItem -Path $repoRoot -Recurse -Include '*SecurityConfig.ps1', '*RetentionConfig.ps1' |
+        Where-Object {
+            $_.FullName -notmatch '[\\/]tests[\\/]' -and
+            $_.FullName -notmatch '[\\/]\.claude[\\/]'
+        } |
+        ForEach-Object {
+            @{
+                Name     = $_.FullName.Replace($repoRoot.Path, '').TrimStart('\', '/')
+                FullName = $_.FullName
+            }
+        }
 }
 
 Describe 'Script Syntax Validation' {
@@ -45,5 +57,12 @@ Describe 'Script Help Validation' {
     It '<Name> has a non-empty synopsis' -ForEach $helpScripts {
         $help = Get-Help $FullName -ErrorAction SilentlyContinue
         $help.Synopsis | Should -Not -BeNullOrEmpty -Because "$Name should have help documentation"
+    }
+}
+
+Describe 'Backtick Line Continuations' {
+    It '<Name> has no backtick line continuations' -ForEach $collectorFiles {
+        $violations = Select-String -Path $FullName -Pattern '`\s*$'
+        $violations | Should -BeNullOrEmpty -Because "backtick line continuations are prohibited; use splatting instead"
     }
 }


### PR DESCRIPTION
## Summary
- Add a new `Describe 'Backtick Line Continuations'` block to `tests/Smoke/Script-Validation.Tests.ps1`
- Scans all `*SecurityConfig.ps1` and `*RetentionConfig.ps1` files for trailing backtick line continuations
- Each collector gets its own `It` block for specific failure reporting
- Prevents re-introduction of backtick continuations after PRs #141-#143

## Test plan
- [x] Full Pester suite passes: 137 tests, 0 failures (verified locally)
- [x] All 12 collectors detected and tested
- [x] Test correctly flags backtick continuations (pattern: `` `\s*$ ``)

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)