### PR TITLE
chore: release v0.9.5

### DIFF
--- a/.claude/rules/versions.md
+++ b/.claude/rules/versions.md
@@ -5,7 +5,7 @@
 
 ## Assessment Suite Version
 
-Current: **0.9.4**
+Current: **0.9.5**
 
 ### Version Locations (3 total)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to M365 Assess are documented here. This project uses [Conventional Commits](https://www.conventionalcommits.org/).
 
+## [0.9.5] - 2026-03-17
+
+### Changed
+- Remove all backtick line continuations from 10 security collectors (1,216 total), replacing with splatting (@params) pattern (#130, #131, #132)
+- Document ErrorActionPreference strategy with inline comments across all 12 collectors (#135)
+
+### Added
+- Write-Warning when progress display helpers (Show-CheckProgress.ps1, Import-ControlRegistry.ps1) are missing (#133)
+- `-CheckOnly` staleness detection switch for Build-Registry.ps1 (#134)
+- Pester regression test scanning collectors for backtick line continuations (#136)
+- CONTRIBUTING.md with error handling convention documentation (#135)
+
 ## [0.9.4] - 2026-03-15
 
 ### Added

--- a/M365-Assess.psd1
+++ b/M365-Assess.psd1
@@ -3,7 +3,7 @@
     # Generated: 2026-03-08
 
     RootModule        = 'Invoke-M365Assessment.ps1'
-    ModuleVersion     = '0.9.4'
+    ModuleVersion     = '0.9.5'
     GUID              = 'f7e3b2a1-4c5d-6e8f-9a0b-1c2d3e4f5a6b'
     Author            = 'SelvageLabs'
     CompanyName       = 'Community'
@@ -100,7 +100,7 @@
             Tags         = @('Microsoft365', 'M365', 'Security', 'Assessment', 'EntraID', 'Exchange', 'Intune', 'Defender', 'SharePoint', 'Teams', 'PowerBI', 'ScubaGear', 'CIS')
             LicenseUri   = 'https://github.com/SelvageLabs/M365-Assess/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/SelvageLabs/M365-Assess'
-            ReleaseNotes = 'v0.9.4 - Infrastructure: cross-platform CI (Linux/macOS smoke tests), PSGallery feasibility evaluation'
+            ReleaseNotes = 'v0.9.5 - Code Quality: remove backtick continuations from all collectors, add robustness improvements, Pester regression guard'
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 [![PowerShell 7.x](https://img.shields.io/badge/PowerShell-7.x-blue?logo=powershell&logoColor=white)](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows)
 [![Read-Only](https://img.shields.io/badge/Operations-Read--Only-brightgreen)](.)
-[![Version](https://img.shields.io/badge/version-0.9.4-blue)](.)
+[![Version](https://img.shields.io/badge/version-0.9.5-blue)](.)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 </div>


### PR DESCRIPTION
## Summary
Version bump, changelog, and GitHub release for the **v0.9.5 - Code Quality** milestone.

### What's in v0.9.5
- **Backtick cleanup**: Removed 1,216 backtick line continuations from 10 security collectors, replaced with splatting (#130, #131, #132)
- **Robustness**: Write-Warning for missing progress helpers (#133), Build-Registry staleness detection (#134), ErrorActionPreference documentation (#135)
- **Guard rail**: Pester regression test preventing backtick re-introduction (#136)

### Version locations updated
- [x] `M365-Assess.psd1` - ModuleVersion + ReleaseNotes
- [x] `README.md` - Badge `version-0.9.5-blue`
- [x] `CHANGELOG.md` - New `[0.9.5]` section
- [x] `.claude/rules/versions.md` - Current version reference

## Test plan
- [ ] `(Import-PowerShellDataFile ./M365-Assess.psd1).ModuleVersion` returns `0.9.5`
- [ ] README badge shows 0.9.5
- [ ] CHANGELOG has complete 0.9.5 section

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)