### PR TITLE
chore: bump version to v0.9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to M365 Assess are documented here. This project uses [Conventional Commits](https://www.conventionalcommits.org/).
 
+## [0.9.6] - 2026-03-19
+
+### Added
+- JSON-driven framework rendering: auto-discover frameworks from `controls/frameworks/*.json` via `Import-FrameworkDefinitions.ps1` (#67)
+- `Export-ComplianceOverview.ps1`: extracted compliance overview into standalone function (~230 lines)
+- `Frameworks` hashtable on each finding object for dynamic framework access
+- Wizard Report Options step: toggle Compliance Overview, Cover Page, Executive Summary, Remove Branding, and Limit Frameworks interactively
+- Numbered framework sub-selector with all 13 families and Select All/None shortcuts
+- `-AcceptedDomains` parameter on `Get-DnsSecurityConfig.ps1` for cached domain passthrough
+- CSS classes for new framework tags: `.fw-fedramp`, `.fw-essential8`, `.fw-mitre`, `.fw-cisv8`, `.fw-default`, `.fw-profile-tag` (light + dark theme)
+- 13 Pester tests for `Import-FrameworkDefinitions`
+- `FedRAMP`, `Essential8`, `MITRE`, `CISv8` added to `-FrameworkFilter` ValidateSet
+
+### Changed
+- Compliance overview now renders 14 framework-level columns (down from 16 profile-level columns) with inline profile tags
+- CI consolidated from 5 jobs to 3: single "Quality Gates" job (lint + smoke + version), full Pester, and push-only CheckID sync
+- Branch protection enabled on `main` requiring Quality Gates to pass before merge
+- Public group owner check uses client-side visibility filter (avoids `Directory.Read.All` requirement)
+- Orchestrator passes cached accepted domains to deferred DNS collector (avoids EXO session timeout)
+- Framework JSON fixes: `displayOrder`/`description` added to cis-m365-v6 and nist-800-53, `soc2-tsc` frameworkId corrected to `soc2`, Unicode corruption fixed in hipaa/stig/cmmc
+
+### Removed
+- 12 catalog CSV files in `assets/frameworks/` (replaced by `totalControls` in framework JSONs, -2,833 lines)
+- Hardcoded `$frameworkLookup`, `$allFrameworkKeys`, `$cisProfileKeys`, `$nistProfileKeys` from report script
+
 ## [0.9.5] - 2026-03-17
 
 ### Changed

--- a/M365-Assess.psd1
+++ b/M365-Assess.psd1
@@ -3,7 +3,7 @@
     # Generated: 2026-03-08
 
     RootModule        = 'Invoke-M365Assessment.ps1'
-    ModuleVersion     = '0.9.5'
+    ModuleVersion     = '0.9.6'
     GUID              = 'f7e3b2a1-4c5d-6e8f-9a0b-1c2d3e4f5a6b'
     Author            = 'Galvnyz'
     CompanyName       = 'Community'
@@ -100,7 +100,7 @@
             Tags         = @('Microsoft365', 'M365', 'Security', 'Assessment', 'EntraID', 'Exchange', 'Intune', 'Defender', 'SharePoint', 'Teams', 'PowerBI', 'ScubaGear', 'CIS')
             LicenseUri   = 'https://github.com/Galvnyz/M365-Assess/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/Galvnyz/M365-Assess'
-            ReleaseNotes = 'v0.9.5 - Code Quality: remove backtick continuations from all collectors, add robustness improvements, Pester regression guard'
+            ReleaseNotes = 'v0.9.6 - Report Refactor: JSON-driven framework rendering, wizard report options, CI quality gates, bug fixes'
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 [![PowerShell 7.x](https://img.shields.io/badge/PowerShell-7.x-blue?logo=powershell&logoColor=white)](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows)
 [![Read-Only](https://img.shields.io/badge/Operations-Read--Only-brightgreen)](.)
-[![Version](https://img.shields.io/badge/version-0.9.5-blue)](.)
+[![Version](https://img.shields.io/badge/version-0.9.6-blue)](.)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 </div>


### PR DESCRIPTION
## Summary

- Bump version to 0.9.6 across manifest, README badge, and CHANGELOG
- CHANGELOG documents all changes since v0.9.5: report refactor, wizard report options, CI consolidation, bug fixes

## Test plan

- [x] Version consistency check will validate manifest + README badge alignment
- [x] Quality Gates CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)