### PR TITLE
fix: v1.0.0 backlog cleanup (#175-#179)

### DIFF
--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -1,6 +1,6 @@
 # Multi-Framework Compliance
 
-The HTML report includes a **Compliance Overview** section that maps all assessed security controls across 13 compliance frameworks simultaneously. No parameters needed; all framework data is always included.
+The HTML report includes a **Compliance Overview** section that maps all assessed security controls across 14 compliance frameworks simultaneously. No parameters needed; all framework data is always included.
 
 ## Supported Frameworks
 
@@ -19,6 +19,10 @@ The HTML report includes a **Compliance Overview** section that maps all assesse
 | HIPAA Security Rule | 45 | Coverage mapping |
 | CISA SCuBA | 80 | Coverage mapping |
 | SOC 2 TSC | varies | Coverage mapping |
+| FedRAMP | varies | Coverage mapping |
+| Essential Eight | 8 | Coverage mapping |
+| CIS Controls v8 | 153 | Coverage mapping |
+| MITRE ATT&CK | varies | Coverage mapping |
 
 **CIS profiles** show a compliance score (pass rate against benchmarked controls). Other frameworks show coverage mapping, indicating which of your assessed findings align to that framework's controls.
 
@@ -48,11 +52,11 @@ ENTRA-ADMIN-001.1    First setting assessed under ENTRA-ADMIN-001
 ENTRA-ADMIN-001.2    Second setting assessed under ENTRA-ADMIN-001
 ```
 
-The assessment suite includes **160 automated security checks** across 12 security config collectors (Entra, CA Evaluator, EXO, DNS, Defender, Compliance, Intune, SharePoint, Teams, Power BI, Forms, Purview Retention), each mapped to one or more compliance frameworks.
+The assessment suite includes **160 automated security checks** across 13 security config collectors (Entra, CA Evaluator, EXO, DNS, Defender, Compliance, Intune, SharePoint, Teams, Power BI, Forms, Purview Retention), each mapped to one or more compliance frameworks.
 
 ## Control Registry
 
-Framework mappings are defined in `controls/registry.json`, which contains **244 control entries** (160 automated, 163 active). Each entry specifies the check ID, description, and mappings to all applicable frameworks.
+Framework mappings are defined in `controls/registry.json`, which contains **244 control entries** (160 automated, 163 active, 81 manual-only). Each entry specifies the check ID, description, and mappings to all applicable frameworks.
 
 To view or edit mappings:
 

--- a/Invoke-M365Assessment.ps1
+++ b/Invoke-M365Assessment.ps1
@@ -64,6 +64,8 @@
     Omit the branded cover page from the HTML report.
 .PARAMETER SkipExecutiveSummary
     Omit the executive summary hero panel from the HTML report.
+.PARAMETER SkipPdf
+    Skip PDF generation even when wkhtmltopdf is available.
 .PARAMETER FrameworkFilter
     Limit the compliance overview to specific framework families.
 .PARAMETER CustomBranding
@@ -162,6 +164,9 @@ param(
 
     [Parameter()]
     [switch]$SkipExecutiveSummary,
+
+    [Parameter()]
+    [switch]$SkipPdf,
 
     [Parameter()]
     [ValidateSet('CIS','NIST','ISO','STIG','PCI','CMMC','HIPAA','CISA','SOC2','FedRAMP','Essential8','MITRE','CISv8')]
@@ -1916,7 +1921,7 @@ foreach ($sectionName in $Section) {
                 $scriptLines.Add("try { & '$connectServicePath' @connectParams } catch { Write-Error `$_; exit 1 }")
                 $scriptLines.Add("& '$scriptPath' -OutputPath '$childCsvPath'")
 
-                $childScriptFile = Join-Path -Path $assessmentFolder -ChildPath '_powerbi_child.ps1'
+                $childScriptFile = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "m365assess_pbi_$([System.IO.Path]::GetRandomFileName()).ps1"
                 Set-Content -Path $childScriptFile -Value ($scriptLines -join "`n") -Encoding UTF8
                 try {
                     $childOutput = & pwsh -NoProfile -File $childScriptFile 2>&1
@@ -2416,6 +2421,7 @@ if (Test-Path -Path $reportScriptPath) {
         if ($SkipComplianceOverview) { $reportParams['SkipComplianceOverview'] = $true }
         if ($SkipCoverPage) { $reportParams['SkipCoverPage'] = $true }
         if ($SkipExecutiveSummary) { $reportParams['SkipExecutiveSummary'] = $true }
+        if ($SkipPdf) { $reportParams['SkipPdf'] = $true }
         if ($FrameworkFilter) { $reportParams['FrameworkFilter'] = $FrameworkFilter }
         if ($CustomBranding) { $reportParams['CustomBranding'] = $CustomBranding }
         $reportParams['CisFrameworkId'] = "cis-m365-$CisBenchmarkVersion"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ---
 
-Run a single command to produce CSV reports, a branded HTML assessment report, and an XLSX compliance matrix covering identity, email, security, devices, collaboration, and compliance baselines. **149 automated security checks** mapped across **13 compliance frameworks**.
+Run a single command to produce CSV reports, a branded HTML assessment report, and an XLSX compliance matrix covering identity, email, security, devices, collaboration, and compliance baselines. **160 automated security checks** mapped across **14 compliance frameworks**.
 
 ## Quick Start
 
@@ -109,7 +109,7 @@ During execution, the console displays real-time streaming progress for each sec
 | **Email** | Mailbox Summary, Mail Flow, Email Security, EXO Security Config, DNS Authentication | Mailbox types, transport rules, anti-spam/phishing, modern auth, audit settings, external sender tagging, SPF/DKIM/DMARC |
 | **Intune** | Device Summary, Compliance Policies, Config Profiles | Managed devices, compliance state, configuration profiles |
 | **Security** | Secure Score, Improvement Actions, Defender Policies, Defender Security Config, DLP Policies | Microsoft Secure Score, Defender for Office 365, anti-phishing/spam/malware, Safe Links/Attachments, data loss prevention |
-| **Collaboration** | SharePoint & OneDrive, SharePoint Security Config, Teams Access, Teams Security Config | Sharing settings, external sharing controls, sync restrictions, Teams meeting policies, third-party app restrictions |
+| **Collaboration** | SharePoint & OneDrive, SharePoint Security Config, Teams Access, Teams Security Config, Forms Security Config | Sharing settings, external sharing controls, sync restrictions, Teams meeting policies, third-party app restrictions, Forms phishing/data sharing settings |
 | **Hybrid** | Hybrid Sync | Azure AD Connect sync status and domain configuration |
 | **PowerBI** | Power BI Security Config | 11 CIS 9.1.x tenant setting checks: guest access, external sharing, publish to web, sensitivity labels, service principal restrictions. Requires MicrosoftPowerBIMgmt module. |
 | **Inventory** *(opt-in)* | Mailbox, Group, Teams, SharePoint, OneDrive Inventory | Per-object M&A inventory: mailboxes, distribution lists, M365 groups, Teams, SharePoint sites, OneDrive accounts |
@@ -145,6 +145,11 @@ During execution, the console displays real-time streaming progress for each sec
 | `-SkipComplianceOverview` | switch | | Omit Compliance Overview section from report |
 | `-SkipCoverPage` | switch | | Omit branded cover page from report |
 | `-SkipExecutiveSummary` | switch | | Omit executive summary, show compact scan header instead |
+| `-SkipPdf` | switch | | Skip PDF generation even when wkhtmltopdf is available |
+| `-FrameworkFilter` | string[] | *(all)* | Limit compliance overview to specific framework families (e.g., `CIS`, `NIST`) |
+| `-CustomBranding` | hashtable | | White-label reports. Keys: `CompanyName`, `LogoPath`, `AccentColor` |
+| `-CisBenchmarkVersion` | string | `v6` | CIS benchmark version (`v6` for v6.0.1). Set to `v7` when available |
+| `-ClientSecret` | SecureString | | App Registration client secret for app-only auth |
 
 ### Interactive Wizard
 
@@ -174,15 +179,19 @@ M365-Assessment/
     13-Device-Summary.csv
     14-Compliance-Policies.csv
     15-Config-Profiles.csv
+    15b-Intune-Security-Config.csv
     16-Secure-Score.csv
     17-Improvement-Actions.csv
     18-Defender-Policies.csv
     18b-Defender-Security-Config.csv
     19-DLP-Policies.csv
+    19b-Compliance-Security-Config.csv
+    19c-Purview-Retention-Config.csv
     20-SharePoint-OneDrive.csv
     20b-SharePoint-Security-Config.csv
     21-Teams-Access.csv
     21b-Teams-Security-Config.csv
+    21c-Forms-Security-Config.csv
     22-PowerBI-Security-Config.csv
     23-Hybrid-Sync.csv
     _Assessment-Summary_<tenant>.csv     # Status of every collector
@@ -194,7 +203,7 @@ M365-Assessment/
 
 ## Report Preview
 
-The self-contained HTML report opens in any browser with no dependencies. Click through from the cover page to the executive summary, drill into each security domain, and review compliance posture across 13 frameworks.
+The self-contained HTML report opens in any browser with no dependencies. Click through from the cover page to the executive summary, drill into each security domain, and review compliance posture across 14 frameworks.
 
 <div align="center">
 
@@ -230,7 +239,7 @@ M365-Assess/
     Export-ComplianceMatrix.ps1   # XLSX compliance matrix export
     Show-CheckProgress.ps1       # Real-time progress display
   controls/                       # Control registry and framework mappings
-    registry.json                 # Master registry (233 entries, 149 automated)
+    registry.json                 # Master registry (244 entries, 160 automated)
     frameworks/                   # Per-framework mapping files
   Entra/                          # Users, MFA, admin roles, CA, apps, licensing, security config
   Exchange-Online/                # Mailboxes, mail flow, email security, EXO config
@@ -250,7 +259,7 @@ M365-Assess/
 |-------|-------------|
 | [Authentication](AUTHENTICATION.md) | Interactive, certificate, device code, managed identity, and pre-existing connection methods |
 | [HTML Report](REPORT.md) | Report features, custom branding, `-NoBranding`, standalone generation |
-| [Compliance](COMPLIANCE.md) | 13 frameworks, XLSX export, CheckId system, control registry |
+| [Compliance](COMPLIANCE.md) | 14 frameworks, XLSX export, CheckId system, control registry |
 | [Compatibility](docs/COMPATIBILITY.md) | Module versions, dependency matrix, known incompatibilities |
 | [ScubaGear](docs/SCUBAGEAR.md) | CISA baseline integration, first run, products, GCC support |
 | [CheckId Guide](docs/CheckId-Guide.md) | CheckId naming convention and mapping reference |

--- a/controls/registry.json
+++ b/controls/registry.json
@@ -6542,7 +6542,7 @@
       "name": "Enable Conditional Access policies to block legacy authentication",
       "category": "CA",
       "collector": "Entra",
-      "hasAutomatedCheck": true,
+      "hasAutomatedCheck": false,
       "licensing": {
         "minimum": "E3"
       },


### PR DESCRIPTION
## Summary

Resolves 5 v1.0.0 backlog items in a single pass:

- **#175**: PowerBI child process now writes temp script to randomized path in system temp dir instead of predictable `_powerbi_child.ps1` in assessment output folder
- **#176**: README updated with accurate stats (14 frameworks, 160 checks, 244/160 registry), 5 missing parameters, 4 missing CSV outputs, Forms in Collaboration section
- **#177**: COMPLIANCE.md updated with correct framework count (14), collector count (13), and 4 missing framework table rows (FedRAMP, Essential Eight, CIS Controls v8, MITRE ATT&CK)
- **#178**: `ENTRA-CA-001` registry entry marked `hasAutomatedCheck: false` (superseded by `CA-LEGACYAUTH-001`)
- **#179**: `-SkipPdf` switch surfaced through orchestrator param block, help text, and reportParams passthrough

## Test plan

- [x] 480/480 Pester tests pass
- [x] PSScriptAnalyzer: 0 warnings/errors
- [x] Registry automated count (160) matches unique collector CheckIds (160)

Closes #175, closes #176, closes #177, closes #178, closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)