### PR TITLE
chore: remove PSGallery CheckID dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,8 +144,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Fetch CheckID data
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          TAG="v1.2.0"
+          TAG=$(gh api repos/Galvnyz/CheckID/tags --jq '.[0].name')
+          echo "Syncing from CheckID $TAG"
           BASE="https://raw.githubusercontent.com/Galvnyz/CheckID/$TAG/data"
           curl -sL "$BASE/registry.json" -o controls/registry.json
           for f in cis-controls-v8 cis-m365-v6 cisa-scuba cmmc essential-eight fedramp hipaa iso-27001 mitre-attack nist-800-53-r5 nist-csf pci-dss-v4 soc2-tsc stig; do

--- a/Common/Import-ControlRegistry.ps1
+++ b/Common/Import-ControlRegistry.ps1
@@ -2,15 +2,15 @@
 .SYNOPSIS
     Loads the control registry and builds lookup tables for the report layer.
 .DESCRIPTION
-    Loads check data from the CheckID PSGallery module (primary) or falls back
-    to the local controls/registry.json file (offline/air-gapped). Returns a
-    hashtable keyed by CheckId with framework mappings and risk severity.
+    Loads check data from the local controls/registry.json file (synced from
+    CheckID via CI). Returns a hashtable keyed by CheckId with framework
+    mappings and risk severity.
 
     Also builds a reverse lookup from CIS control IDs to CheckIds (stored
     under the special key '__cisReverseLookup') for backward compatibility
     with CSVs that still use the CisControl column.
 .PARAMETER ControlsPath
-    Path to the controls/ directory containing registry.json (fallback) and
+    Path to the controls/ directory containing registry.json and
     risk-severity.json (local overlay).
 .PARAMETER CisFrameworkId
     Framework ID for the active CIS benchmark version, used for the reverse
@@ -29,33 +29,15 @@ function Import-ControlRegistry {
         [string]$CisFrameworkId = 'cis-m365-v6'
     )
 
-    $checks = $null
-
-    # Primary: load from CheckID PSGallery module
-    if (Get-Module -ListAvailable -Name CheckID) {
-        try {
-            Import-Module CheckID -ErrorAction Stop
-            $checks = @(Get-CheckRegistry -ErrorAction Stop)
-            Write-Verbose "Loaded $($checks.Count) checks from CheckID module"
-        }
-        catch {
-            Write-Warning "CheckID module available but failed to load: $_"
-            $checks = $null
-        }
+    $registryPath = Join-Path -Path $ControlsPath -ChildPath 'registry.json'
+    if (-not (Test-Path -Path $registryPath)) {
+        Write-Warning "Control registry not found: $registryPath"
+        return @{}
     }
 
-    # Fallback: load from local controls/registry.json
-    if (-not $checks) {
-        $registryPath = Join-Path -Path $ControlsPath -ChildPath 'registry.json'
-        if (-not (Test-Path -Path $registryPath)) {
-            Write-Warning "Control registry not found: $registryPath"
-            return @{}
-        }
-
-        $raw = Get-Content -Path $registryPath -Raw | ConvertFrom-Json
-        $checks = @($raw.checks)
-        Write-Verbose "Loaded $($checks.Count) checks from local registry.json"
-    }
+    $raw = Get-Content -Path $registryPath -Raw | ConvertFrom-Json
+    $checks = @($raw.checks)
+    Write-Verbose "Loaded $($checks.Count) checks from local registry.json"
 
     # Build hashtable keyed by CheckId
     $lookup = @{}

--- a/Invoke-M365Assessment.ps1
+++ b/Invoke-M365Assessment.ps1
@@ -1484,11 +1484,6 @@ if (-not $SkipConnection) {
         $compatErrors += $missingModules
     }
 
-    # CheckID module is optional (local registry.json fallback exists) but recommended
-    if (-not (Get-Module -ListAvailable -Name CheckID)) {
-        Write-Verbose "CheckID module not installed. Using local controls/registry.json fallback. For versioned registry data: Install-Module CheckID -Scope CurrentUser"
-    }
-
     if ($compatErrors.Count -gt 0) {
         Write-Host ''
         Write-Host '  ╔══════════════════════════════════════════════════════════╗' -ForegroundColor Magenta


### PR DESCRIPTION
## Summary

- `Common/Import-ControlRegistry.ps1`: Remove PSGallery `Import-Module CheckID` primary path — local `controls/registry.json` is now the sole source (synced from CheckID via CI)
- `Invoke-M365Assessment.ps1`: Remove CheckID module availability check and `Install-Module` advisory
- `.github/workflows/ci.yml`: Fetch latest CheckID tag dynamically via `gh api` instead of hardcoded `v1.2.0`

## Test plan

- [x] `Import-ControlRegistry` loads checks from local `controls/registry.json`
- [ ] CI sync-checkid job resolves latest tag and fetches data
- [x] Existing Pester tests pass

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)