### PR TITLE
feat: auto-sync CheckID registry on upstream release

### DIFF
--- a/.github/workflows/sync-on-release.yml
+++ b/.github/workflows/sync-on-release.yml
@@ -1,0 +1,66 @@
+name: Sync CheckID on Release
+
+on:
+  repository_dispatch:
+    types: [checkid-released]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    name: Sync CheckID registry
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch CheckID data
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}
+        run: |
+          TAG="${{ github.event.client_payload.tag }}"
+          echo "Syncing from CheckID $TAG"
+          BASE="https://raw.githubusercontent.com/Galvnyz/CheckID/$TAG/data"
+          curl -sL "$BASE/registry.json" -o controls/registry.json
+          for f in cis-controls-v8 cis-m365-v6 cisa-scuba cmmc essential-eight fedramp hipaa iso-27001 mitre-attack nist-800-53-r5 nist-csf pci-dss-v4 soc2-tsc stig; do
+            curl -sL "$BASE/frameworks/$f.json" -o "controls/frameworks/$f.json"
+          done
+
+      - name: Check for changes
+        id: diff
+        run: |
+          git diff --quiet controls/ && echo "changed=false" >> "$GITHUB_OUTPUT" \
+            || echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Create PR if changed
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}
+        run: |
+          TAG="${{ github.event.client_payload.tag }}"
+          BRANCH="chore/sync-checkid-$TAG"
+          git checkout -b "$BRANCH"
+          git add controls/
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore: sync CheckID registry to $TAG"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore: sync CheckID registry to $TAG" \
+            --body "Automated PR triggered by CheckID $TAG release.
+
+Updates \`controls/registry.json\` and framework definitions from upstream CheckID.
+
+Review the diff and merge when ready." \
+            --base main \
+            --head "$BRANCH"
+
+      - name: Summary
+        run: |
+          TAG="${{ github.event.client_payload.tag }}"
+          if [ "${{ steps.diff.outputs.changed }}" = "true" ]; then
+            echo "### CheckID $TAG sync PR created" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "### CheckID $TAG — no changes detected" >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
## Summary

Adds `sync-on-release.yml` workflow that receives `checkid-released` dispatch from CheckID, fetches the latest registry and framework JSONs, and opens a PR if changes detected.

### Prerequisites

Requires `CROSS_REPO_TOKEN` secret (PAT with repo scope).

## Test plan

- [ ] CheckID tag push triggers this workflow via dispatch
- [ ] PR created with updated controls/registry.json and framework files

🤖 Generated with [Claude Code](https://claude.com/claude-code)