### PR TITLE
chore: force sync workflow reindex

### DIFF
--- a/.github/workflows/sync-on-release.yml
+++ b/.github/workflows/sync-on-release.yml
@@ -1,4 +1,5 @@
 name: Sync CheckID on Release
+# Triggered by CheckID tag push via repository_dispatch, or manually via workflow_dispatch
 
 on:
   repository_dispatch:


### PR DESCRIPTION
Trivial comment addition to force GitHub to re-index sync-on-release.yml for repository_dispatch events.