### PR TITLE
Phase 2: dark mode CSS variables and accessibility (#209, #212)

### DIFF
--- a/src/M365-Assess/Common/Export-AssessmentReport.ps1
+++ b/src/M365-Assess/Common/Export-AssessmentReport.ps1
@@ -373,7 +373,7 @@ function Get-SvgDonut {
     $center = $Size / 2
     $displayVal = if ($Label) { $Label } else { "$Percentage%" }
     return @"
-<svg class='donut-chart' width='$Size' height='$Size' viewBox='0 0 $Size $Size'>
+<svg class='donut-chart' width='$Size' height='$Size' viewBox='0 0 $Size $Size' role='img' aria-label='Chart showing $displayVal'>
 <circle class='donut-track' cx='$center' cy='$center' r='$radius' fill='none' stroke-width='$StrokeWidth'/>
 <circle class='donut-fill donut-$CssClass' cx='$center' cy='$center' r='$radius' fill='none' stroke-width='$StrokeWidth'
   stroke-dasharray='$circumference' stroke-dashoffset='$dashOffset' stroke-linecap='round' transform='rotate(-90 $center $center)'/>
@@ -392,7 +392,7 @@ function Get-SvgMultiDonut {
     $radius = ($Size / 2) - $StrokeWidth
     $circumference = 2 * [math]::PI * $radius
     $center = $Size / 2
-    $svg = "<svg class='donut-chart' width='$Size' height='$Size' viewBox='0 0 $Size $Size'>"
+    $svg = "<svg class='donut-chart' width='$Size' height='$Size' viewBox='0 0 $Size $Size' role='img' aria-label='Chart showing $CenterLabel'>"
     $svg += "<circle class='donut-track' cx='$center' cy='$center' r='$radius' fill='none' stroke-width='$StrokeWidth'/>"
     # Filter to visible segments and track cumulative arc to eliminate rounding gaps
     $visibleSegs = @($Segments | Where-Object { $_.Pct -gt 0 })
@@ -1583,6 +1583,7 @@ foreach ($sectionName in $sections) {
 
         $null = $sectionHtml.AppendLine("<div class='table-wrapper'>")
         $null = $sectionHtml.AppendLine("<table class='data-table'>")
+        $null = $sectionHtml.AppendLine("<caption class='sr-only'>$($collector.Label) assessment results</caption>")
         $null = $sectionHtml.AppendLine("<thead><tr>")
         foreach ($col in $columns) {
             $displayCol = Format-ColumnHeader -Name $col
@@ -1658,7 +1659,7 @@ foreach ($sectionName in $sections) {
                 if ($col -eq 'Remediation' -and $row.Remediation -match '^(Set|Get|New|Remove|Update|Enable|Disable|Add|Connect|Grant|Revoke|Install|Uninstall|Import|Export)-') {
                     $rawRemediation = ConvertTo-HtmlSafe -Text "$($row.Remediation)"
                     if ($rawRemediation.Length -gt 200) { $rawRemediation = $rawRemediation.Substring(0, 197) + '...' }
-                    $null = $sectionHtml.AppendLine("<td class='remediation-cell'><span class='remediation-text'>$rawRemediation</span><button type='button' class='copy-btn' title='Copy command' onclick='copyRemediation(this)'>&#128203;</button></td>")
+                    $null = $sectionHtml.AppendLine("<td class='remediation-cell'><span class='remediation-text'>$rawRemediation</span><button type='button' class='copy-btn' title='Copy command' aria-label='Copy remediation command' onclick='copyRemediation(this)'>&#128203;</button></td>")
                     continue
                 }
                 $null = $sectionHtml.AppendLine("<td>$val</td>")
@@ -1818,6 +1819,7 @@ if ($issues.Count -gt 0) {
     $null = $issuesHtml.AppendLine("<details class='section' open>")
     $null = $issuesHtml.AppendLine("<summary><h2>Technical Issues</h2></summary>")
     $null = $issuesHtml.AppendLine("<table class='data-table'>")
+    $null = $issuesHtml.AppendLine("<caption class='sr-only'>Technical issues found during assessment</caption>")
     $null = $issuesHtml.AppendLine("<thead><tr><th scope='col'>Severity</th><th scope='col'>Section</th><th scope='col'>Collector</th><th scope='col'>Description</th><th scope='col'>Recommended Action</th></tr></thead>")
     $null = $issuesHtml.AppendLine("<tbody>")
 
@@ -1875,6 +1877,10 @@ $html = @"
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <style>
+        .skip-nav { position: absolute; left: -9999px; top: auto; }
+        .skip-nav:focus { left: 10px; top: 10px; z-index: 9999; background: var(--m365a-card-bg); padding: 8px 16px; border: 2px solid var(--m365a-primary); border-radius: 4px; color: var(--m365a-text); text-decoration: none; }
+    </style>
     <style>
         /* ----------------------------------------------------------
            M365 Assess Theme
@@ -1994,6 +2000,19 @@ $html = @"
         }
 
         * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        /* Screen-reader-only utility (visually hidden but accessible) */
+        .sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
+        }
 
         body {
             font-family: 'Inter', 'Segoe UI', Arial, sans-serif;
@@ -3538,6 +3557,8 @@ $html = @"
            Print Styles
            ---------------------------------------------------------- */
         @media print {
+            .data-table { page-break-inside: avoid; }
+            .section { page-break-inside: avoid; }
             body { font-size: 9pt; }
             .theme-toggle { display: none; }
 
@@ -3684,6 +3705,7 @@ $accentCss
 </head>
 <body>
     <!-- Theme Toggle -->
+    <a href="#main-content" class="skip-nav">Skip to main content</a>
     <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode" title="Toggle light/dark mode">
         <span class="theme-icon-light">&#9788;</span>
         <span class="theme-icon-dark">&#9790;</span>
@@ -3715,7 +3737,7 @@ $(if (-not $NoBranding) {
 })
 
     <!-- Content -->
-    <main class="content">
+    <main class="content" id="main-content" role="main">
 "@
 
 if (-not $SkipExecutiveSummary) {
@@ -3826,8 +3848,8 @@ else {
 $html += @"
 
         <div class="report-controls" id="reportControls">
-            <button type="button" id="expandAllGlobal" class="report-ctrl-btn" title="Expand all sections and tables">&#9660; Expand All</button>
-            <button type="button" id="collapseAllGlobal" class="report-ctrl-btn" title="Collapse all sections and tables">&#9650; Collapse All</button>
+            <button type="button" id="expandAllGlobal" class="report-ctrl-btn" title="Expand all sections and tables" aria-label="Expand all sections">&#9660; Expand All</button>
+            <button type="button" id="collapseAllGlobal" class="report-ctrl-btn" title="Collapse all sections and tables" aria-label="Collapse all sections">&#9650; Collapse All</button>
         </div>
 
         $($sectionHtml.ToString())


### PR DESCRIPTION
## Summary
- **#209** Convert hardcoded hex colors to CSS variables for proper dark mode support. Adds 26 new CSS variables covering badge text colors, cloud environment badges, and DKIM badges. DKIM badges previously had NO dark mode support at all. Removes 11 redundant `body.dark-theme` override rules now handled by the variable system.
- **#212** Add accessibility attributes to HTML report: `.sr-only` class, skip-nav link, `role="img"` on SVG charts, `<caption>` on all data tables, `aria-label` on interactive buttons, `role="main"` landmark, and print page-break rules.

## Test plan
- [x] PSScriptAnalyzer: 0 issues
- [x] 242 tests pass (smoke + consistency + report tests)
- [x] CI workflow passes
- [ ] Visual check: open a generated report, toggle dark mode, verify cloud/DKIM badges render correctly in both themes
- [ ] Screen reader check: verify skip-nav link appears on focus, table captions are announced

Closes #209, closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)