### PR TITLE
docs: PSGallery is live -- update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,19 +27,16 @@ Run a single command to produce CSV reports, a branded HTML assessment report, a
 
 ## Installation
 
-### From PSGallery (coming soon)
+### From PSGallery (recommended)
 
 ```powershell
 Install-Module M365-Assess -Scope CurrentUser
-Install-Module Microsoft.Graph -Scope CurrentUser
-Install-Module ExchangeOnlineManagement -RequiredVersion 3.7.1 -Scope CurrentUser
-
 Invoke-M365Assessment -TenantId 'contoso.onmicrosoft.com'
 ```
 
-> PSGallery publishing is planned for the v1.0.0 release. Until then, install from source.
+Graph and EXO dependencies are declared in the manifest and installed automatically.
 
-### From Source (recommended)
+### From Source
 
 ```powershell
 git clone https://github.com/Galvnyz/M365-Assess.git

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -37,21 +37,21 @@ Install-Module ImportExcel -Scope CurrentUser
 
 ## 3. Get the Module
 
-### Option A: Clone from source (recommended)
+### Option A: PSGallery (recommended)
+
+```powershell
+Install-Module M365-Assess -Scope CurrentUser
+```
+
+Dependencies (Graph SDK, etc.) are declared in the manifest and installed automatically.
+
+### Option B: Clone from source
 
 ```powershell
 git clone https://github.com/Galvnyz/M365-Assess.git
 cd M365-Assess
 Import-Module ./src/M365-Assess
 ```
-
-### Option B: PSGallery (coming soon)
-
-```powershell
-Install-Module M365-Assess -Scope CurrentUser
-```
-
-> PSGallery publishing is planned for the v1.0.0 release.
 
 > **Downloaded the ZIP?** Windows marks extracted files as blocked. Unblock them:
 > ```powershell


### PR DESCRIPTION
## Summary
M365-Assess v1.0.0 is published to PSGallery. Update README and QUICKSTART:
- PSGallery is now the recommended install method (was "coming soon")
- Simplified install command -- deps are in the manifest
- Source install is now the secondary option

## Test plan
- [x] `Install-Module M365-Assess -Scope CurrentUser` verified working
- [x] CI passes (docs-only)