### PR TITLE
fix: detect preset-managed Defender policies via EOPProtectionPolicyRule (#245)

### DIFF
--- a/src/M365-Assess/Security/Get-DefenderSecurityConfig.ps1
+++ b/src/M365-Assess/Security/Get-DefenderSecurityConfig.ps1
@@ -88,13 +88,29 @@ try {
         foreach ($rule in $script:eopRules) {
             $tier = if ($rule.Identity -match 'Strict') { 'Strict' } elseif ($rule.Identity -match 'Standard') { 'Standard' } else { $null }
             if ($tier -and $rule.State -eq 'Enabled') {
-                # Map the preset tier to the policy names it manages
-                # EOP presets auto-create policies with these naming patterns
-                $script:presetPolicyNames["$tier Preset Security Policy"] = $tier
+                # Map exact policy names from the rule to their preset tier
+                # Each rule references the specific policies it manages:
+                #   HostedContentFilterPolicy, AntiPhishPolicy, MalwareFilterPolicy
+                # These names include a numeric suffix (e.g., "Standard Preset Security Policy1774914322474")
+                if ($rule.HostedContentFilterPolicy) { $script:presetPolicyNames[$rule.HostedContentFilterPolicy] = $tier }
+                if ($rule.AntiPhishPolicy)            { $script:presetPolicyNames[$rule.AntiPhishPolicy] = $tier }
+                if ($rule.MalwareFilterPolicy)        { $script:presetPolicyNames[$rule.MalwareFilterPolicy] = $tier }
+            }
+        }
+        # Also check ATP rules for Safe Links / Safe Attachments
+        $atpRuleAvailable = Get-Command -Name Get-ATPProtectionPolicyRule -ErrorAction SilentlyContinue
+        if ($atpRuleAvailable) {
+            $atpRules = @(Get-ATPProtectionPolicyRule -ErrorAction Stop)
+            foreach ($rule in $atpRules) {
+                $tier = if ($rule.Identity -match 'Strict') { 'Strict' } elseif ($rule.Identity -match 'Standard') { 'Standard' } else { $null }
+                if ($tier -and $rule.State -eq 'Enabled') {
+                    if ($rule.SafeLinksPolicy)       { $script:presetPolicyNames[$rule.SafeLinksPolicy] = $tier }
+                    if ($rule.SafeAttachmentPolicy)   { $script:presetPolicyNames[$rule.SafeAttachmentPolicy] = $tier }
+                }
             }
         }
         if ($script:presetPolicyNames.Count -gt 0) {
-            Write-Verbose "Active preset policies detected: $($script:presetPolicyNames.Values -join ', ')"
+            Write-Verbose "Active preset-managed policies: $($script:presetPolicyNames.Keys -join ', ')"
         }
     }
 }
@@ -104,10 +120,8 @@ catch {
 
 function Test-PresetPolicy {
     param([string]$PolicyName)
-    foreach ($pattern in $script:presetPolicyNames.Keys) {
-        if ($PolicyName -match [regex]::Escape($pattern)) {
-            return $script:presetPolicyNames[$pattern]
-        }
+    if ($script:presetPolicyNames.ContainsKey($PolicyName)) {
+        return $script:presetPolicyNames[$PolicyName]
     }
     return $null
 }


### PR DESCRIPTION
## Summary

Fixes false "disabled" reports for anti-spam, anti-phishing, anti-malware, Safe Links, and Safe Attachments policies on tenants using Standard or Strict preset security policies.

**Root cause:** When presets are enabled, M365 creates backend policy objects whose individual properties may not match the conventions of custom policies. The collector was checking these properties and reporting failures.

**Fix:** Query `Get-EOPProtectionPolicyRule` early and identify which presets are active. In all 5 policy-iterating sections, detect preset-managed policies and report them as Pass ("Managed by Standard/Strict preset security policy") instead of checking individual properties that don't accurately reflect the enforced state.

## Test plan
- [x] PSScriptAnalyzer: 0 issues
- [x] 191 smoke + consistency tests pass
- [x] 13 Defender Security Config tests pass
- [x] CI passes
- [x] Live test on tenant with Standard/Strict presets enabled

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)