### PR TITLE
feat: validate Graph API scopes after connection

### DIFF
--- a/src/M365-Assess/M365-Assess.psd1
+++ b/src/M365-Assess/M365-Assess.psd1
@@ -49,6 +49,7 @@
         'Orchestrator\Test-ModuleCompatibility.ps1'
         'Orchestrator\Connect-RequiredService.ps1'
         'Orchestrator\Test-BlockedScripts.ps1'
+        'Orchestrator\Test-GraphPermissions.ps1'
         'Orchestrator\Invoke-DnsAuthentication.ps1'
         'Common\Connect-Service.ps1'
         'Common\Resolve-DnsRecord.ps1'

--- a/src/M365-Assess/Orchestrator/Connect-RequiredService.ps1
+++ b/src/M365-Assess/Orchestrator/Connect-RequiredService.ps1
@@ -87,6 +87,14 @@ function Connect-RequiredService {
             $connectedServices.Add($svc) | Out-Null
             Write-AssessmentLog -Level INFO -Message "Connected to $svc successfully." -Section $SectionName
 
+            # Validate Graph scopes once after first connection
+            if ($svc -eq 'Graph' -and -not $script:graphPermissionsChecked) {
+                $script:graphPermissionsChecked = $true
+                if (Get-Command -Name Test-GraphPermissions -ErrorAction SilentlyContinue) {
+                    Test-GraphPermissions -RequiredScopes $graphScopes -SectionScopeMap $sectionScopeMap -ActiveSections $Section
+                }
+            }
+
             # After first Graph connection, capture connected tenant domain for
             # later use (e.g. report headers, logging).
             if ($svc -eq 'Graph' -and -not $script:resolvedTenantDomain) {

--- a/src/M365-Assess/Orchestrator/Test-GraphPermissions.ps1
+++ b/src/M365-Assess/Orchestrator/Test-GraphPermissions.ps1
@@ -1,0 +1,93 @@
+<#
+.SYNOPSIS
+    Validates Graph API scopes after connection against required scopes.
+.DESCRIPTION
+    Compares granted scopes from Get-MgContext against the scopes
+    required by selected assessment sections. Warns about missing
+    scopes before collectors run.
+#>
+function Test-GraphPermissions {
+    <#
+    .SYNOPSIS
+        Validates Graph API scopes after connection.
+    .DESCRIPTION
+        Compares the scopes granted by Get-MgContext against the scopes
+        required by the selected assessment sections (from sectionScopeMap).
+        Warns about missing scopes before collectors run, so users know
+        which sections may produce incomplete results.
+
+        With app-only auth (certificate/managed identity), scopes are
+        determined by app registration and Get-MgContext.Scopes may show
+        '.default' only. In this case the check is skipped with an
+        informational message.
+    .PARAMETER RequiredScopes
+        Array of Graph scope strings required for the selected sections.
+    .PARAMETER SectionScopeMap
+        Hashtable mapping section names to their required scope arrays.
+    .PARAMETER ActiveSections
+        Array of section names the user selected.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$RequiredScopes,
+
+        [Parameter(Mandatory)]
+        [hashtable]$SectionScopeMap,
+
+        [Parameter(Mandatory)]
+        [string[]]$ActiveSections
+    )
+
+    $context = Get-MgContext -ErrorAction SilentlyContinue
+    if (-not $context) {
+        Write-AssessmentLog -Level WARN -Message 'Graph context not available -- skipping scope validation' -Section 'Setup'
+        return
+    }
+
+    $grantedScopes = @($context.Scopes)
+
+    # App-only auth: scopes may be empty or contain only '.default'
+    if ($grantedScopes.Count -eq 0 -or ($grantedScopes.Count -eq 1 -and $grantedScopes[0] -eq '.default')) {
+        Write-Host '    i App-only auth detected -- scope validation not available (permissions set in app registration)' -ForegroundColor DarkGray
+        Write-AssessmentLog -Level INFO -Message 'App-only auth: scope validation skipped (permissions defined in Entra app registration)' -Section 'Setup'
+        return
+    }
+
+    # Compare required vs granted (case-insensitive)
+    $grantedLower = $grantedScopes | ForEach-Object { $_.ToLower() }
+    $missingScopes = @($RequiredScopes | Where-Object { $_.ToLower() -notin $grantedLower })
+
+    if ($missingScopes.Count -eq 0) {
+        Write-Host "    $([char]0x2714) All $($RequiredScopes.Count) required Graph scopes granted" -ForegroundColor Green
+        Write-AssessmentLog -Level INFO -Message "Graph scope validation passed ($($RequiredScopes.Count) scopes)" -Section 'Setup'
+        return
+    }
+
+    # Map missing scopes back to affected sections
+    $affectedSections = @{}
+    foreach ($scope in $missingScopes) {
+        foreach ($section in $ActiveSections) {
+            if (-not $SectionScopeMap.ContainsKey($section)) { continue }
+            $sectionScopes = $SectionScopeMap[$section] | ForEach-Object { $_.ToLower() }
+            if ($scope.ToLower() -in $sectionScopes) {
+                if (-not $affectedSections.ContainsKey($section)) {
+                    $affectedSections[$section] = [System.Collections.Generic.List[string]]::new()
+                }
+                $affectedSections[$section].Add($scope)
+            }
+        }
+    }
+
+    # Display warnings
+    Write-Host ''
+    Write-Host "    $([char]0x26A0) $($missingScopes.Count) Graph scope(s) not consented -- some checks may fail:" -ForegroundColor Yellow
+    foreach ($section in $affectedSections.Keys | Sort-Object) {
+        $scopeList = ($affectedSections[$section] | Sort-Object) -join ', '
+        Write-Host "      ${section}: $scopeList" -ForegroundColor Yellow
+    }
+    Write-Host '    Tip: re-run consent or update app registration to include these scopes' -ForegroundColor DarkGray
+    Write-Host ''
+
+    Write-AssessmentLog -Level WARN -Message "Missing Graph scopes: $($missingScopes -join ', ')" -Section 'Setup'
+}


### PR DESCRIPTION
## Summary

Adds pre-flight Graph permission validation that runs once after the first Graph connection. Compares scopes granted by `Get-MgContext` against the `sectionScopeMap` for selected sections, warning about missing scopes before collectors run.

Closes #272

## Changes

| File | Change |
|------|--------|
| `Orchestrator/Test-GraphPermissions.ps1` | New function: scope comparison, affected-section mapping, app-only detection |
| `Orchestrator/Connect-RequiredService.ps1` | Call Test-GraphPermissions once after first Graph connect |
| `M365-Assess.psd1` | Register new file in FileList |

## Behavior

- **Delegated auth**: compares consented scopes vs required, lists missing scopes grouped by affected section
- **App-only auth**: detects `.default` scope and skips with informational message (permissions come from app registration)
- **All scopes granted**: shows green checkmark with scope count
- Assessment continues regardless (warnings, not errors)

## Test plan

- [x] Smoke tests: 180/180 passing (includes parse + help checks for new file)
- [ ] Manual: connect with limited scopes, verify warning lists missing scopes by section
- [ ] Manual: connect with app-only cert auth, verify "scope validation not available" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)