### PR TITLE
feat: export security-config collectors as public module cmdlets (#241)

### DIFF
--- a/src/M365-Assess/M365-Assess.psd1
+++ b/src/M365-Assess/M365-Assess.psd1
@@ -30,7 +30,22 @@
     )
 
     # Functions to export from this module
-    FunctionsToExport = @('Invoke-M365Assessment')
+    FunctionsToExport = @(
+        'Invoke-M365Assessment'
+        'Get-M365ExoSecurityConfig'
+        'Get-M365DnsSecurityConfig'
+        'Get-M365EntraSecurityConfig'
+        'Get-M365CASecurityConfig'
+        'Get-M365EntAppSecurityConfig'
+        'Get-M365IntuneSecurityConfig'
+        'Get-M365DefenderSecurityConfig'
+        'Get-M365ComplianceSecurityConfig'
+        'Get-M365SharePointSecurityConfig'
+        'Get-M365TeamsSecurityConfig'
+        'Get-M365FormsSecurityConfig'
+        'Get-M365PowerBISecurityConfig'
+        'Get-M365PurviewRetentionConfig'
+    )
     CmdletsToExport   = @()
     VariablesToExport = @()
     AliasesToExport   = @()

--- a/src/M365-Assess/M365-Assess.psm1
+++ b/src/M365-Assess/M365-Assess.psm1
@@ -3,7 +3,205 @@
 # Dot-source orchestrator internal modules
 Get-ChildItem -Path "$PSScriptRoot\Orchestrator\*.ps1" | ForEach-Object { . $_.FullName }
 
+# Dot-source shared helpers needed by public cmdlets
+. "$PSScriptRoot\Common\SecurityConfigHelper.ps1"
+. "$PSScriptRoot\Common\Resolve-DnsRecord.ps1"
+
 # Dot-source the main orchestrator to import Invoke-M365Assessment function
 . $PSScriptRoot\Invoke-M365Assessment.ps1
 
-Export-ModuleMember -Function 'Invoke-M365Assessment'
+# ------------------------------------------------------------------
+# Public cmdlet wrappers for security-config collectors
+#
+# These thin wrappers delegate to the existing collector scripts,
+# allowing them to be called as module-level commands:
+#   Import-Module M365-Assess
+#   Get-M365ExoSecurityConfig -OutputPath .\results.csv
+#
+# Each collector is a standalone script that handles its own
+# connection checks, data collection, and output formatting.
+# ------------------------------------------------------------------
+
+function Get-M365ExoSecurityConfig {
+    <#
+    .SYNOPSIS
+        Collects Exchange Online security configuration settings.
+    .PARAMETER OutputPath
+        Optional path to export results as CSV.
+    #>
+    [CmdletBinding()]
+    param([string]$OutputPath)
+    & "$PSScriptRoot\Exchange-Online\Get-ExoSecurityConfig.ps1" @PSBoundParameters
+}
+
+function Get-M365DnsSecurityConfig {
+    <#
+    .SYNOPSIS
+        Evaluates DNS authentication records (SPF, DKIM, DMARC).
+    .PARAMETER OutputPath
+        Optional path to export results as CSV.
+    .PARAMETER AcceptedDomains
+        Pre-cached accepted domain objects.
+    .PARAMETER DkimConfigs
+        Pre-cached DKIM signing configuration objects.
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$OutputPath,
+        [object[]]$AcceptedDomains,
+        [object[]]$DkimConfigs
+    )
+    & "$PSScriptRoot\Exchange-Online\Get-DnsSecurityConfig.ps1" @PSBoundParameters
+}
+
+function Get-M365EntraSecurityConfig {
+    <#
+    .SYNOPSIS
+        Collects Entra ID security configuration settings.
+    .PARAMETER OutputPath
+        Optional path to export results as CSV.
+    #>
+    [CmdletBinding()]
+    param([string]$OutputPath)
+    & "$PSScriptRoot\Entra\Get-EntraSecurityConfig.ps1" @PSBoundParameters
+}
+
+function Get-M365CASecurityConfig {
+    <#
+    .SYNOPSIS
+        Evaluates Conditional Access policies against CIS requirements.
+    .PARAMETER OutputPath
+        Optional path to export results as CSV.
+    #>
+    [CmdletBinding()]
+    param([string]$OutputPath)
+    & "$PSScriptRoot\Entra\Get-CASecurityConfig.ps1" @PSBoundParameters
+}
+
+function Get-M365EntAppSecurityConfig {
+    <#
+    .SYNOPSIS
+        Evaluates enterprise application and service principal security posture.
+    .PARAMETER OutputPath
+        Optional path to export results as CSV.
+    #>
+    [CmdletBinding()]
+    param([string]$OutputPath)
+    & "$PSScriptRoot\Entra\Get-EntAppSecurityConfig.ps1" @PSBoundParameters
+}
+
+function Get-M365IntuneSecurityConfig {
+    <#
+    .SYNOPSIS
+        Evaluates Intune/Endpoint Manager security settings.
+    .PARAMETER OutputPath
+        Optional path to export results as CSV.
+    #>
+    [CmdletBinding()]
+    param([string]$OutputPath)
+    & "$PSScriptRoot\Intune\Get-IntuneSecurityConfig.ps1" @PSBoundParameters
+}
+
+function Get-M365DefenderSecurityConfig {
+    <#
+    .SYNOPSIS
+        Collects Microsoft Defender for Office 365 security configuration.
+    .PARAMETER OutputPath
+        Optional path to export results as CSV.
+    #>
+    [CmdletBinding()]
+    param([string]$OutputPath)
+    & "$PSScriptRoot\Security\Get-DefenderSecurityConfig.ps1" @PSBoundParameters
+}
+
+function Get-M365ComplianceSecurityConfig {
+    <#
+    .SYNOPSIS
+        Collects Purview/Compliance security configuration settings.
+    .PARAMETER OutputPath
+        Optional path to export results as CSV.
+    #>
+    [CmdletBinding()]
+    param([string]$OutputPath)
+    & "$PSScriptRoot\Security\Get-ComplianceSecurityConfig.ps1" @PSBoundParameters
+}
+
+function Get-M365SharePointSecurityConfig {
+    <#
+    .SYNOPSIS
+        Collects SharePoint Online security configuration settings.
+    .PARAMETER OutputPath
+        Optional path to export results as CSV.
+    #>
+    [CmdletBinding()]
+    param([string]$OutputPath)
+    & "$PSScriptRoot\Collaboration\Get-SharePointSecurityConfig.ps1" @PSBoundParameters
+}
+
+function Get-M365TeamsSecurityConfig {
+    <#
+    .SYNOPSIS
+        Collects Microsoft Teams security configuration settings.
+    .PARAMETER OutputPath
+        Optional path to export results as CSV.
+    #>
+    [CmdletBinding()]
+    param([string]$OutputPath)
+    & "$PSScriptRoot\Collaboration\Get-TeamsSecurityConfig.ps1" @PSBoundParameters
+}
+
+function Get-M365FormsSecurityConfig {
+    <#
+    .SYNOPSIS
+        Collects Microsoft Forms security configuration settings.
+    .PARAMETER OutputPath
+        Optional path to export results as CSV.
+    #>
+    [CmdletBinding()]
+    param([string]$OutputPath)
+    & "$PSScriptRoot\Collaboration\Get-FormsSecurityConfig.ps1" @PSBoundParameters
+}
+
+function Get-M365PowerBISecurityConfig {
+    <#
+    .SYNOPSIS
+        Collects Power BI security and tenant configuration settings.
+    .PARAMETER OutputPath
+        Optional path to export results as CSV.
+    #>
+    [CmdletBinding()]
+    param([string]$OutputPath)
+    & "$PSScriptRoot\PowerBI\Get-PowerBISecurityConfig.ps1" @PSBoundParameters
+}
+
+function Get-M365PurviewRetentionConfig {
+    <#
+    .SYNOPSIS
+        Collects Purview data lifecycle retention compliance policy configuration.
+    .PARAMETER OutputPath
+        Optional path to export results as CSV.
+    #>
+    [CmdletBinding()]
+    param([string]$OutputPath)
+    & "$PSScriptRoot\Purview\Get-PurviewRetentionConfig.ps1" @PSBoundParameters
+}
+
+# ------------------------------------------------------------------
+# Export public functions
+# ------------------------------------------------------------------
+Export-ModuleMember -Function @(
+    'Invoke-M365Assessment'
+    'Get-M365ExoSecurityConfig'
+    'Get-M365DnsSecurityConfig'
+    'Get-M365EntraSecurityConfig'
+    'Get-M365CASecurityConfig'
+    'Get-M365EntAppSecurityConfig'
+    'Get-M365IntuneSecurityConfig'
+    'Get-M365DefenderSecurityConfig'
+    'Get-M365ComplianceSecurityConfig'
+    'Get-M365SharePointSecurityConfig'
+    'Get-M365TeamsSecurityConfig'
+    'Get-M365FormsSecurityConfig'
+    'Get-M365PowerBISecurityConfig'
+    'Get-M365PurviewRetentionConfig'
+)


### PR DESCRIPTION
## Summary

- Export 13 security-config collectors as public module cmdlets via thin wrapper functions
- Users can now run individual collectors standalone after `Import-Module M365-Assess`
- Wrapper pattern: each function delegates to the existing collector script via call operator, preserving all existing behavior
- Module loader dot-sources `SecurityConfigHelper.ps1` and `Resolve-DnsRecord.ps1` at load time for public cmdlet dependencies

## New Public Commands

| Command | Collector |
|---------|-----------|
| `Get-M365ExoSecurityConfig` | Exchange Online |
| `Get-M365DnsSecurityConfig` | DNS Authentication (SPF/DKIM/DMARC) |
| `Get-M365EntraSecurityConfig` | Entra ID |
| `Get-M365CASecurityConfig` | Conditional Access |
| `Get-M365EntAppSecurityConfig` | Enterprise Apps |
| `Get-M365IntuneSecurityConfig` | Intune |
| `Get-M365DefenderSecurityConfig` | Defender for Office 365 |
| `Get-M365ComplianceSecurityConfig` | Purview Compliance |
| `Get-M365SharePointSecurityConfig` | SharePoint Online |
| `Get-M365TeamsSecurityConfig` | Teams |
| `Get-M365FormsSecurityConfig` | Microsoft Forms |
| `Get-M365PowerBISecurityConfig` | Power BI |
| `Get-M365PurviewRetentionConfig` | Purview Retention |

Closes #241

## Test plan

- [x] `Import-Module ./src/M365-Assess -Force` loads cleanly with 14 exported commands
- [x] Full Pester suite: 817/817 (zero regressions)
- [x] PSScriptAnalyzer: zero warnings
- [x] PSGallery readiness smoke test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)