### PR TITLE
feat: make service-area chart bars clickable navigation links (#304)

### DIFF
--- a/src/M365-Assess/Common/Get-ReportTemplate.ps1
+++ b/src/M365-Assess/Common/Get-ReportTemplate.ps1
@@ -568,6 +568,8 @@ $html = @"
             border: none;
             padding: 0;
         }
+        .chart-nav-link { cursor: pointer; }
+        .chart-nav-link:hover text:first-child { text-decoration: underline; fill: var(--m365a-accent); }
 
         /* ----------------------------------------------------------
            Tenant Organization Card
@@ -2618,6 +2620,21 @@ $html += @"
                 e.preventDefault();
                 if (idx > 0) navigateTo(pageIds[idx - 1]);
             }
+        });
+
+        // Chart bar navigation -- click a service-area row to navigate to its section
+        document.querySelectorAll('[data-nav]').forEach(function(el) {
+            el.addEventListener('click', function() {
+                var target = el.getAttribute('data-nav');
+                if (target) navigateTo(target);
+            });
+            el.addEventListener('keydown', function(e) {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    var target = el.getAttribute('data-nav');
+                    if (target) navigateTo(target);
+                }
+            });
         });
 
         // Initialize: show the correct page on load

--- a/src/M365-Assess/Common/ReportHelpers.ps1
+++ b/src/M365-Assess/Common/ReportHelpers.ps1
@@ -209,6 +209,12 @@ function Get-SvgStackedBar {
         $y = $barStartY + ($rowIndex * ($BarHeight + $Gap))
         $textY = $y + [math]::Round($BarHeight / 2, 0) + 4
 
+        # Derive navigation target from label: lowercase, replace non-alphanumeric with dash
+        $navTarget = 'section-' + ($row.Label -replace '[^a-zA-Z0-9]', '-').ToLower()
+
+        # Wrap entire row in a clickable group with data-nav
+        $svg += "<g class='chart-nav-link' data-nav='$navTarget' role='link' tabindex='0' aria-label='Navigate to $($row.Label) section'>"
+
         # Row label
         $svg += "<text x='$($LabelWidth - 8)' y='$textY' font-family='Inter, sans-serif' font-size='10' fill='var(--m365a-text)' text-anchor='end'>$($row.Label)</text>"
 
@@ -216,6 +222,7 @@ function Get-SvgStackedBar {
         if ($total -eq 0) {
             # Empty bar track
             $svg += "<rect x='$LabelWidth' y='$y' width='$barWidth' height='$BarHeight' rx='4' fill='var(--m365a-border)' opacity='0.3'/>"
+            $svg += "</g>"
             continue
         }
 
@@ -264,6 +271,9 @@ function Get-SvgStackedBar {
         # Total count label on right
         $countX = $LabelWidth + $barWidth + 6
         $svg += "<text x='$countX' y='$textY' font-family='Inter, sans-serif' font-size='10' fill='var(--m365a-medium-gray)'>$total</text>"
+
+        # Close clickable row group
+        $svg += "</g>"
     }
 
     $svg += "</svg>"


### PR DESCRIPTION
## Summary
- Service-area chart bars in the executive summary are now clickable -- clicking a bar navigates to that section's page
- Each SVG row wrapped in `<g class="chart-nav-link" data-nav="section-{name}">` with cursor pointer and hover accent
- JS click + keyboard (Enter/Space) handlers call `navigateTo()` from the existing pagination system

Closes #304

## Test plan
- [x] PSScriptAnalyzer clean
- [x] All 79 report tests pass
- [x] Chart bars show pointer cursor on hover
- [x] Clicking a bar navigates to the correct section page

🤖 Generated with [Claude Code](https://claude.com/claude-code)