### PR TITLE
fix: increase Power BI child process timeout from 30s to 90s

### DIFF
--- a/src/M365-Assess/Invoke-M365Assessment.ps1
+++ b/src/M365-Assess/Invoke-M365Assessment.ps1
@@ -690,7 +690,7 @@ foreach ($sectionName in $Section) {
                 $childOutputFile = [System.IO.Path]::ChangeExtension($childScriptFile, '.log')
                 $childErrFile    = [System.IO.Path]::ChangeExtension($childScriptFile, '.err')
                 Set-Content -Path $childScriptFile -Value ($scriptLines -join "`n") -Encoding UTF8
-                $childTimeoutSec = if ($UseDeviceCode -or (-not $IsWindows -and -not ($ClientId -and ($CertificateThumbprint -or $ClientSecret)))) { 120 } else { 30 }
+                $childTimeoutSec = if ($UseDeviceCode -or (-not $IsWindows -and -not ($ClientId -and ($CertificateThumbprint -or $ClientSecret)))) { 120 } else { 90 }
                 $childNeedsConsole = $UseDeviceCode -or (-not $IsWindows -and -not ($ClientId -and ($CertificateThumbprint -or $ClientSecret)))
                 try {
                     if ($childNeedsConsole) {


### PR DESCRIPTION
## Summary
Interactive Windows auth for Power BI needs time for the browser to open and complete the login flow. The 30-second timeout was too aggressive, causing timeouts before users could authenticate.

Bumped to 90s for interactive auth. Device code / non-Windows path stays at 120s.

## Test plan
- [x] One-line change in `Invoke-M365Assessment.ps1:693`
- [x] Run assessment with Power BI section and verify auth completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)