### PR TITLE
fix: empty CurrentValue regression + move mailbox permissions to Inventory

### DIFF
--- a/src/M365-Assess/Common/SecurityConfigHelper.ps1
+++ b/src/M365-Assess/Common/SecurityConfigHelper.ps1
@@ -79,9 +79,11 @@ function Add-SecuritySetting {
         [string]$Setting,
 
         [Parameter(Mandatory)]
+        [AllowEmptyString()]
         [string]$CurrentValue,
 
         [Parameter(Mandatory)]
+        [AllowEmptyString()]
         [string]$RecommendedValue,
 
         [Parameter(Mandatory)]


### PR DESCRIPTION
## Summary
Two fixes found during multi-tenant testing:

### 1. Allow empty CurrentValue/RecommendedValue in Add-SecuritySetting
The contract migration added `[Parameter(Mandatory)]` which rejects empty strings. Graph API returns null/empty for unconfigured tenant settings, causing the Entra collector to fail. Added `[AllowEmptyString()]` to restore original behavior.

### 2. Move mailbox permissions from Email to Inventory
Mailbox permission enumeration (FullAccess/SendAs/SendOnBehalf) queries every mailbox individually, taking ~60s even in small tenants. This is an audit/inventory task, not a security config check. Moving it keeps Email fast and groups it with related asset enumeration collectors.

## Test plan
- [x] 84/84 contract tests pass
- [x] `Add-SecuritySetting -CurrentValue ''` no longer throws
- [x] Email section render order updated (removed 11c entry)
- [x] Inventory section includes mailbox permissions as first collector

🤖 Generated with [Claude Code](https://claude.com/claude-code)