### PR TITLE
release: v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to M365 Assess are documented here. This project uses [Conve
 
 ## [Unreleased]
 
-## [1.2.0] - 2026-04-01
+## [1.2.0] - 2026-04-02
 
 ### Added
+- **Admin MFA strength classification** -- MFA Report now includes `MfaStrength` column (Phishing-Resistant/Standard/Weak/None) and new ENTRA-ADMIN-004 security check flags Global Administrators lacking phishing-resistant MFA methods. (#318)
 - **Paginated report navigation** -- sidebar nav with section list, status badges, hash routing, browser back/forward, keyboard arrows, "Show All" toggle, and mobile hamburger menu. Report sections are now focused pages instead of one long scroll. (#288, #303)
 - **Compact hero banner** -- dark branded banner with cropped logo replaces full-screen cover page on screen. Full cover preserved for print/PDF only. (#306)
 - **Service-area breakdown chart** -- SVG stacked bar chart in executive summary showing pass/fail/warning/review per service area. Uses CSS variables for dark mode. (#276, #293)

--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -56,7 +56,7 @@ The assessment suite includes **191 automated security checks** across 15 securi
 
 ## Control Registry
 
-Framework mappings are defined in `controls/registry.json`, which contains **276 control entries** (192 automated, 276 active, 84 manual-only). Each entry specifies the check ID, description, and mappings to all applicable frameworks.
+Framework mappings are defined in `controls/registry.json`, which contains **277 control entries** (193 automated, 277 active, 84 manual-only). Each entry specifies the check ID, description, and mappings to all applicable frameworks.
 
 To view or edit mappings:
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [![Coverage](https://img.shields.io/badge/coverage-check%20CI-informational)](https://github.com/Galvnyz/M365-Assess/actions/workflows/ci.yml)
 [![PowerShell 7.x](https://img.shields.io/badge/PowerShell-7.x-blue?logo=powershell&logoColor=white)](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows)
 [![Read-Only](https://img.shields.io/badge/Operations-Read--Only-brightgreen)](.)
-[![Version](https://img.shields.io/badge/version-1.0.1-blue)](.)
+[![Version](https://img.shields.io/badge/version-1.2.0-blue)](.)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 </div>

--- a/src/M365-Assess/Entra/EntraAdminRoleChecks.ps1
+++ b/src/M365-Assess/Entra/EntraAdminRoleChecks.ps1
@@ -522,3 +522,87 @@ try {
 catch {
     Write-Warning "Could not check emergency access accounts: $_"
 }
+
+# ------------------------------------------------------------------
+# 33. Admin MFA Method Strength (phishing-resistant required)
+# ------------------------------------------------------------------
+try {
+    Write-Verbose "Checking admin MFA method strength..."
+    $gaRoleTemplateId = '62e90394-69f5-4237-9190-012177145e10'
+    $graphParams = @{
+        Method      = 'GET'
+        Uri         = "/v1.0/directoryRoles/roleTemplateId=$gaRoleTemplateId/members?`$select=id,displayName,userPrincipalName"
+        ErrorAction = 'Stop'
+    }
+    $adminMembers = Invoke-MgGraphRequest @graphParams
+    $adminList = if ($adminMembers -and $adminMembers['value']) { @($adminMembers['value']) } else { @() }
+
+    if ($adminList.Count -gt 0) {
+        $graphParams = @{
+            Method      = 'GET'
+            Uri         = '/beta/reports/authenticationMethods/userRegistrationDetails'
+            ErrorAction = 'Stop'
+        }
+        $mfaDetails = Invoke-MgGraphRequest @graphParams
+        $mfaList = if ($mfaDetails -and $mfaDetails['value']) { @($mfaDetails['value']) } else { @() }
+
+        $phishingResistantMethods = @(
+            'fido2'
+            'windowsHelloForBusiness'
+            'x509CertificateMultiFactor'
+            'passKeyDeviceBound'
+            'passKeyDeviceBoundAuthenticator'
+        )
+
+        $adminIds = @($adminList | ForEach-Object { $_['id'] })
+        $adminMfa = @($mfaList | Where-Object { $_['id'] -in $adminIds })
+
+        $adminsWithoutPhishRes = @($adminMfa | Where-Object {
+            $methods = @($_['methodsRegistered'])
+            -not ($methods | Where-Object { $_ -in $phishingResistantMethods })
+        })
+        $adminsNoMfa = @($adminMfa | Where-Object { -not $_['isMfaRegistered'] })
+
+        if ($adminsNoMfa.Count -gt 0) {
+            $names = ($adminsNoMfa | ForEach-Object { $_['userDisplayName'] }) -join ', '
+            $settingParams = @{
+                Category         = 'Admin Accounts'
+                Setting          = 'Admin MFA Method Strength'
+                CurrentValue     = "$($adminsNoMfa.Count) admin(s) without MFA: $names"
+                RecommendedValue = 'All admins use phishing-resistant MFA'
+                Status           = 'Fail'
+                CheckId          = 'ENTRA-ADMIN-004'
+                Remediation      = 'Enroll all Global Administrators in phishing-resistant MFA (FIDO2, Windows Hello for Business, or certificate-based). Entra admin center > Protection > Authentication methods > Policies.'
+            }
+            Add-Setting @settingParams
+        }
+        elseif ($adminsWithoutPhishRes.Count -gt 0) {
+            $names = ($adminsWithoutPhishRes | ForEach-Object { $_['userDisplayName'] }) -join ', '
+            $settingParams = @{
+                Category         = 'Admin Accounts'
+                Setting          = 'Admin MFA Method Strength'
+                CurrentValue     = "$($adminsWithoutPhishRes.Count) admin(s) without phishing-resistant MFA: $names"
+                RecommendedValue = 'All admins use phishing-resistant MFA'
+                Status           = 'Warning'
+                CheckId          = 'ENTRA-ADMIN-004'
+                Remediation      = 'Upgrade admin MFA to phishing-resistant methods (FIDO2, Windows Hello for Business, or certificate-based). Standard MFA (push/TOTP) is vulnerable to adversary-in-the-middle attacks. Entra admin center > Protection > Authentication methods > Policies.'
+            }
+            Add-Setting @settingParams
+        }
+        else {
+            $settingParams = @{
+                Category         = 'Admin Accounts'
+                Setting          = 'Admin MFA Method Strength'
+                CurrentValue     = "All $($adminMfa.Count) admin(s) have phishing-resistant MFA"
+                RecommendedValue = 'All admins use phishing-resistant MFA'
+                Status           = 'Pass'
+                CheckId          = 'ENTRA-ADMIN-004'
+                Remediation      = 'No action needed.'
+            }
+            Add-Setting @settingParams
+        }
+    }
+}
+catch {
+    Write-Warning "Could not check admin MFA method strength: $_"
+}

--- a/src/M365-Assess/Entra/Get-MfaReport.ps1
+++ b/src/M365-Assess/Entra/Get-MfaReport.ps1
@@ -33,6 +33,44 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+function Get-MfaMethodStrength {
+    <#
+    .SYNOPSIS
+        Classifies the strongest MFA method from a list of registered methods.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter()]
+        [string[]]$Methods
+    )
+
+    $phishingResistant = @(
+        'fido2'
+        'windowsHelloForBusiness'
+        'x509CertificateMultiFactor'
+        'passKeyDeviceBound'
+        'passKeyDeviceBoundAuthenticator'
+    )
+    $standard = @(
+        'microsoftAuthenticatorPush'
+        'microsoftAuthenticatorPasswordless'
+        'softwareOneTimePasscode'
+    )
+    $weak = @(
+        'mobilePhone'
+        'alternateMobilePhone'
+        'voiceAlternateMobile'
+        'email'
+    )
+
+    if (-not $Methods -or $Methods.Count -eq 0) { return 'None' }
+    if ($Methods | Where-Object { $_ -in $phishingResistant }) { return 'Phishing-Resistant' }
+    if ($Methods | Where-Object { $_ -in $standard }) { return 'Standard' }
+    if ($Methods | Where-Object { $_ -in $weak }) { return 'Weak' }
+    return 'Unknown'
+}
+
 # Verify Graph connection
 if (-not (Assert-GraphConnection)) { return }
 
@@ -75,6 +113,7 @@ $report = foreach ($detail in $allDetails) {
         IsSsprCapable         = $detail.IsSsprCapable
         MethodsRegistered     = $methodsRegistered
         DefaultMfaMethod      = $detail.DefaultMfaMethod
+        MfaStrength           = (Get-MfaMethodStrength -Methods @($detail.MethodsRegistered))
         IsAdmin               = $detail.IsAdmin
     }
 }

--- a/src/M365-Assess/M365-Assess.psd1
+++ b/src/M365-Assess/M365-Assess.psd1
@@ -3,7 +3,7 @@
     # Generated: 2026-03-08
 
     RootModule        = 'M365-Assess.psm1'
-    ModuleVersion     = '1.0.1'
+    ModuleVersion     = '1.2.0'
     GUID              = 'f7e3b2a1-4c5d-6e8f-9a0b-1c2d3e4f5a6b'
     Author            = 'Galvnyz'
     CompanyName       = 'Community'
@@ -181,7 +181,7 @@
                              'PowerBI', 'CIS', 'NIST', 'SOC2', 'HIPAA', 'ZeroTrust', 'SecurityBaseline')
             LicenseUri   = 'https://github.com/Galvnyz/M365-Assess/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/Galvnyz/M365-Assess'
-            ReleaseNotes = 'v1.0.1 - Fix false failures for tenants with Standard/Strict preset security policies enabled in Defender for Office 365'
+            ReleaseNotes = 'v1.2.0 - Paginated report navigation, decomposed collectors, inline callouts, admin MFA strength classification, service-area charts'
         }
     }
 }

--- a/src/M365-Assess/controls/registry.json
+++ b/src/M365-Assess/controls/registry.json
@@ -206,6 +206,47 @@
       }
     },
     {
+      "checkId": "ENTRA-ADMIN-004",
+      "name": "Ensure all Global Administrators use phishing-resistant MFA",
+      "category": "ADMIN",
+      "collector": "Entra",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "nist-csf": {
+          "controlId": "PR.AA-01;PR.AA-03",
+          "title": "Identities and credentials for authorized users are managed; Users, devices, and other assets are authenticated commensurate with the risk of the transaction"
+        },
+        "nist-800-53": {
+          "controlId": "IA-2(6);IA-2(8)",
+          "title": "Access to Accounts -- Resistance to Replay; Access to Accounts -- Resistance to Replay",
+          "profiles": [
+            "High"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.8.5",
+          "title": "Secure authentication"
+        },
+        "pci-dss": {
+          "controlId": "8.4.2;8.4.3"
+        },
+        "cmmc": {
+          "controlId": "3.5.3"
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.6",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures; Security Measures Against Threats Outside System Boundaries"
+        },
+        "mitre-attack": {
+          "controlId": "T1556;T1111;T1621"
+        }
+      }
+    },
+    {
       "checkId": "MANUAL-CIS-1-1-2",
       "name": "Ensure two emergency access accounts have been defined",
       "category": "",

--- a/src/M365-Assess/controls/risk-severity.json
+++ b/src/M365-Assess/controls/risk-severity.json
@@ -44,6 +44,7 @@
     "ENTRA-ADMIN-001": "High",
     "ENTRA-ADMIN-002": "High",
     "ENTRA-ADMIN-003": "High",
+    "ENTRA-ADMIN-004": "Critical",
     "ENTRA-APPREG-001": "Medium",
     "ENTRA-APPS-001": "Medium",
     "ENTRA-AUTHMETHOD-001": "Critical",

--- a/tests/Entra/Get-MfaReport.Tests.ps1
+++ b/tests/Entra/Get-MfaReport.Tests.ps1
@@ -6,6 +6,8 @@ Describe 'Get-MfaReport' {
     BeforeAll {
         # Stub Get-MgContext so the connection check passes
         function Get-MgContext { return @{ TenantId = 'test-tenant-id' } }
+        # Stub Graph cmdlet so Pester can mock it without the module installed
+        function Get-MgReportAuthenticationMethodUserRegistrationDetail { }
 
         # Stub Import-Module to prevent actual module loading
         Mock Import-Module { }
@@ -80,11 +82,80 @@ Describe 'Get-MfaReport' {
         $user1.MethodsRegistered | Should -Match 'microsoftAuthenticatorPush'
         $user1.MethodsRegistered | Should -Match ';'
     }
+
+    It 'Output has MfaStrength property' {
+        $first = $result | Select-Object -First 1
+        $first.PSObject.Properties.Name | Should -Contain 'MfaStrength'
+    }
+
+    It 'Classifies phishing-resistant MFA correctly' {
+        $admin = $result | Where-Object { $_.UserPrincipalName -eq 'admin@contoso.com' }
+        $admin.MfaStrength | Should -Be 'Phishing-Resistant'
+    }
+
+    It 'Classifies standard MFA correctly' {
+        $user1 = $result | Where-Object { $_.UserPrincipalName -eq 'user1@contoso.com' }
+        $user1.MfaStrength | Should -Be 'Standard'
+    }
+
+    It 'Classifies no-MFA users as None' {
+        $noMfa = $result | Where-Object { $_.UserPrincipalName -eq 'nomfa@contoso.com' }
+        $noMfa.MfaStrength | Should -Be 'None'
+    }
+}
+
+Describe 'Get-MfaMethodStrength' {
+    BeforeAll {
+        # Stub dependencies so we can dot-source for the function definition
+        function Get-MgContext { return @{ TenantId = 'test-tenant-id' } }
+        function Get-MgReportAuthenticationMethodUserRegistrationDetail { }
+        Mock Import-Module { }
+        Mock Get-MgReportAuthenticationMethodUserRegistrationDetail { return @() }
+        . "$PSScriptRoot/../../src/M365-Assess/Orchestrator/AssessmentHelpers.ps1"
+        . "$PSScriptRoot/../../src/M365-Assess/Entra/Get-MfaReport.ps1"
+    }
+
+    It 'Returns Phishing-Resistant for FIDO2' {
+        Get-MfaMethodStrength -Methods @('fido2') | Should -Be 'Phishing-Resistant'
+    }
+
+    It 'Returns Phishing-Resistant for Windows Hello' {
+        Get-MfaMethodStrength -Methods @('windowsHelloForBusiness') | Should -Be 'Phishing-Resistant'
+    }
+
+    It 'Returns Phishing-Resistant when mixed with weaker methods' {
+        Get-MfaMethodStrength -Methods @('mobilePhone', 'fido2', 'softwareOneTimePasscode') | Should -Be 'Phishing-Resistant'
+    }
+
+    It 'Returns Standard for Authenticator push' {
+        Get-MfaMethodStrength -Methods @('microsoftAuthenticatorPush') | Should -Be 'Standard'
+    }
+
+    It 'Returns Standard for TOTP' {
+        Get-MfaMethodStrength -Methods @('softwareOneTimePasscode') | Should -Be 'Standard'
+    }
+
+    It 'Returns Weak for SMS only' {
+        Get-MfaMethodStrength -Methods @('mobilePhone') | Should -Be 'Weak'
+    }
+
+    It 'Returns None for empty array' {
+        Get-MfaMethodStrength -Methods @() | Should -Be 'None'
+    }
+
+    It 'Returns None for null' {
+        Get-MfaMethodStrength -Methods $null | Should -Be 'None'
+    }
+
+    It 'Returns Unknown for unrecognized method' {
+        Get-MfaMethodStrength -Methods @('someNewMethod') | Should -Be 'Unknown'
+    }
 }
 
 Describe 'Get-MfaReport - Edge Cases' {
     BeforeAll {
         function Get-MgContext { return @{ TenantId = 'test-tenant-id' } }
+        function Get-MgReportAuthenticationMethodUserRegistrationDetail { }
         Mock Import-Module { }
     }
 


### PR DESCRIPTION
## Summary
- Bump module version from 1.0.1 to 1.2.0 across all version locations
- Add admin MFA strength classification (#318): `MfaStrength` column in MFA Report + `ENTRA-ADMIN-004` security check for admin phishing-resistant MFA
- Update registry (277 entries), risk-severity, COMPLIANCE.md counts
- 13 new Pester tests (883 total passing, 0 failures)
- All prior v1.2.0 sprint work already merged to main

## Test plan
- [x] Full Pester suite: 883 passed, 0 failed
- [x] MFA strength classification: FIDO2/WHfB = Phishing-Resistant, Authenticator = Standard, SMS = Weak, none = None
- [x] Registry integrity tests pass (SOC 2 + NIST cross-mapping enforced)
- [ ] Verify version displays correctly in report output after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)