### PR TITLE
fix: Entra STIG scoring method

### DIFF
--- a/src/M365-Assess/controls/frameworks/entra-id-stig.json
+++ b/src/M365-Assess/controls/frameworks/entra-id-stig.json
@@ -11,7 +11,7 @@
   "csvColumn": "EntraIdStig",
   "displayOrder": 15,
   "scoring": {
-    "method": "pass-rate"
+    "method": "severity-coverage"
   },
   "colors": {
     "light": {


### PR DESCRIPTION
## Summary
- Fix `pass-rate` -> `severity-coverage` scoring method in entra-id-stig.json
- `pass-rate` is not recognized by the framework catalog engine

🤖 Generated with [Claude Code](https://claude.com/claude-code)