### PR TITLE
feat: replace email protocol accordion with tabbed interface

### DIFF
--- a/src/M365-Assess/Common/Build-SectionHtml.ps1
+++ b/src/M365-Assess/Common/Build-SectionHtml.ps1
@@ -53,7 +53,7 @@ $sectionCallouts = @{
     )
     'Email'         = @(
         @{
-            Type  = 'accordion'
+            Type  = 'tabs'
             Title = 'Email Authentication Protocols'
             Items = @(
                 @{
@@ -268,7 +268,34 @@ foreach ($sectionName in $sections) {
     $callouts = $sectionCallouts[$sectionName]
     if ($callouts) {
         foreach ($callout in $callouts) {
-            if ($callout.Type -eq 'accordion') {
+            if ($callout.Type -eq 'tabs') {
+                $tabGroupId = "tabs-$(($callout.Title -replace '[^a-zA-Z0-9]', '-').ToLower())"
+                $null = $sectionHtml.AppendLine("<div class='callout-tabs' id='$tabGroupId'>")
+                $null = $sectionHtml.AppendLine("<div class='callout-tabs-title'>$($callout.Title)</div>")
+                $null = $sectionHtml.AppendLine("<div class='tab-header' role='tablist'>")
+                for ($i = 0; $i -lt $callout.Items.Count; $i++) {
+                    $tabItem = $callout.Items[$i]
+                    $tabId = "$tabGroupId-tab-$i"
+                    $panelId = "$tabGroupId-panel-$i"
+                    $activeClass = if ($i -eq 0) { ' active' } else { '' }
+                    $ariaSelected = if ($i -eq 0) { 'true' } else { 'false' }
+                    $null = $sectionHtml.AppendLine("<button class='tab-btn$activeClass' role='tab' id='$tabId' aria-selected='$ariaSelected' aria-controls='$panelId'>$($tabItem.Title)</button>")
+                }
+                $null = $sectionHtml.AppendLine("</div>")
+                for ($i = 0; $i -lt $callout.Items.Count; $i++) {
+                    $tabItem = $callout.Items[$i]
+                    $tabId = "$tabGroupId-tab-$i"
+                    $panelId = "$tabGroupId-panel-$i"
+                    $activeClass = if ($i -eq 0) { ' active' } else { '' }
+                    $null = $sectionHtml.AppendLine("<div class='tab-panel$activeClass' id='$panelId' role='tabpanel' aria-labelledby='$tabId'>$($tabItem.Body)</div>")
+                }
+                if ($callout.Resources) {
+                    $links = ($callout.Resources | ForEach-Object { "<a href='$($_.Url)' target='_blank'>$($_.Label)</a>" }) -join ' &middot; '
+                    $null = $sectionHtml.AppendLine("<div class='tab-resources'><strong>Resources:</strong> $links</div>")
+                }
+                $null = $sectionHtml.AppendLine("</div>")
+            }
+            elseif ($callout.Type -eq 'accordion') {
                 $null = $sectionHtml.AppendLine("<details class='callout-accordion'>")
                 $null = $sectionHtml.AppendLine("<summary class='callout-accordion-title'>$($callout.Title)</summary>")
                 foreach ($item in $callout.Items) {

--- a/src/M365-Assess/Common/Get-ReportTemplate.ps1
+++ b/src/M365-Assess/Common/Get-ReportTemplate.ps1
@@ -486,6 +486,76 @@ $html = @"
         .accordion-resources a { color: var(--m365a-accent); text-decoration: none; }
         .accordion-resources a:hover { text-decoration: underline; }
 
+        /* Tabbed callout (protocol explainers) */
+        .callout-tabs {
+            flex: 1 1 100%;
+            border-radius: 6px;
+            border: 1px solid var(--m365a-border);
+            background: var(--m365a-card-bg);
+            overflow: hidden;
+        }
+        .callout-tabs-title {
+            padding: 10px 14px 0;
+            font-weight: 600;
+            font-size: 9.5pt;
+            color: var(--m365a-accent);
+        }
+        .tab-header {
+            display: flex;
+            gap: 0;
+            border-bottom: 1px solid var(--m365a-border);
+            padding: 0 14px;
+        }
+        .tab-btn {
+            background: none;
+            border: none;
+            border-bottom: 2px solid transparent;
+            padding: 8px 14px;
+            font-size: 9pt;
+            font-weight: 600;
+            color: var(--m365a-medium-gray);
+            cursor: pointer;
+            transition: color 0.15s, border-color 0.15s;
+        }
+        .tab-btn:hover {
+            color: var(--m365a-accent);
+        }
+        .tab-btn.active {
+            color: var(--m365a-accent);
+            border-bottom-color: var(--m365a-accent);
+        }
+        .tab-panel {
+            display: none;
+            padding: 10px 14px 10px 28px;
+            font-size: 9pt;
+            color: var(--m365a-medium-gray);
+            line-height: 1.6;
+        }
+        .tab-panel.active {
+            display: block;
+        }
+        .tab-panel code {
+            background: var(--m365a-border);
+            padding: 1px 5px;
+            border-radius: 3px;
+            font-size: 8.5pt;
+        }
+        .tab-panel a { color: var(--m365a-accent); text-decoration: none; }
+        .tab-panel a:hover { text-decoration: underline; }
+        .tab-resources {
+            padding: 8px 14px;
+            font-size: 8.5pt;
+            color: var(--m365a-medium-gray);
+            border-top: 1px solid var(--m365a-border);
+        }
+        .tab-resources a { color: var(--m365a-accent); text-decoration: none; }
+        .tab-resources a:hover { text-decoration: underline; }
+        @media (max-width: 600px) {
+            .tab-header { flex-direction: column; }
+            .tab-btn { text-align: left; border-bottom: none; border-left: 2px solid transparent; }
+            .tab-btn.active { border-left-color: var(--m365a-accent); border-bottom-color: transparent; }
+        }
+
         /* ----------------------------------------------------------
            Executive Summary Hero
            ---------------------------------------------------------- */
@@ -2242,6 +2312,10 @@ $html = @"
             .callout-accordion { border: none; }
             .callout-accordion-title { pointer-events: none; }
             .callout-accordion-title::before { content: ''; }
+            .callout-tabs { border: none; }
+            .tab-header { display: none; }
+            .tab-panel { display: block !important; padding: 4px 14px; }
+            .tab-panel::before { content: attr(aria-labelledby); font-weight: 600; display: block; margin-bottom: 4px; }
             .callout { border-left-width: 3px; page-break-inside: avoid; }
 
             /* --- Fix 8: Hide hover effects in print --- */
@@ -3136,6 +3210,24 @@ $html += @"
             }, 1500);
         });
     }
+
+    // --- Tab switching for callout-tabs ---
+    document.querySelectorAll('.tab-header .tab-btn').forEach(function(btn) {
+        btn.addEventListener('click', function() {
+            var tabGroup = this.closest('.callout-tabs');
+            tabGroup.querySelectorAll('.tab-btn').forEach(function(b) {
+                b.classList.remove('active');
+                b.setAttribute('aria-selected', 'false');
+            });
+            tabGroup.querySelectorAll('.tab-panel').forEach(function(p) {
+                p.classList.remove('active');
+            });
+            this.classList.add('active');
+            this.setAttribute('aria-selected', 'true');
+            var panel = tabGroup.querySelector('#' + this.getAttribute('aria-controls'));
+            if (panel) panel.classList.add('active');
+        });
+    });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace the single collapsible accordion for Email Authentication Protocols with a **tabbed card interface**
- Four tabs: SPF, DKIM, DMARC, MTA-STS & TLS-RPT
- New `tabs` callout type alongside existing `accordion` type (backward compatible)
- ARIA `role="tablist"` / `role="tabpanel"` for accessibility
- Responsive: tabs stack vertically on screens < 600px
- Print mode: expands all panels, hides tab buttons
- Resource links rendered below tab panels with visual separator

## Files Changed
- `Build-SectionHtml.ps1` -- new tab rendering logic + callout type change
- `Get-ReportTemplate.ps1` -- tab CSS, responsive breakpoint, print styles, tab switching JS

Closes #307

## Test plan
- [x] All 79 `Export-AssessmentReport.Tests.ps1` tests pass
- [ ] Visual inspection: tab switching works correctly
- [ ] ARIA attributes verified for screen reader compatibility
- [ ] Mobile responsive: tabs stack vertically at 600px breakpoint
- [ ] Print: all panels visible, tab header hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)