### PR TITLE
feat: add Security Defaults gap analysis check

### DIFF
--- a/src/M365-Assess/Entra/EntraPasswordAuthChecks.ps1
+++ b/src/M365-Assess/Entra/EntraPasswordAuthChecks.ps1
@@ -41,6 +41,125 @@ catch {
 }
 
 # ------------------------------------------------------------------
+# 1b. Security Defaults Gap Analysis (CA Coverage)
+# ------------------------------------------------------------------
+if ($isEnabled -eq $false) {
+    try {
+        Write-Verbose "Security Defaults OFF -- evaluating CA policy coverage..."
+        $caResponse = Invoke-MgGraphRequest -Method GET -Uri '/v1.0/identity/conditionalAccess/policies' -ErrorAction Stop
+        $caPolicies = if ($caResponse -and $caResponse['value']) { @($caResponse['value']) } else { @() }
+        $caEnabled = @($caPolicies | Where-Object { $_['state'] -eq 'enabled' })
+
+        $coverageAreas = [ordered]@{
+            'MFA for all users' = $false
+            'Legacy auth blocked' = $false
+            'Admin MFA' = $false
+            'Azure Management MFA' = $false
+        }
+
+        # Well-known admin role template IDs (subset of CIS-recommended roles)
+        $sdAdminRoles = @(
+            '62e90394-69f5-4237-9190-012177145e10'  # Global Administrator
+            'e8611ab8-c189-46e8-94e1-60213ab1f814'  # Privileged Role Administrator
+            'fe930be7-5e62-47db-91af-98c3a49a38b1'  # User Administrator
+            'f28a1f50-f6e7-4571-818b-6a12f2af6b6c'  # SharePoint Administrator
+            '29232cdf-9323-42fd-ade2-1d097af3e4de'  # Exchange Administrator
+        )
+
+        # Azure Management well-known app ID
+        $azureMgmtAppId = '797f4846-ba00-4fd7-ba43-dac1f8f63013'
+
+        foreach ($policy in $caEnabled) {
+            $grants = $policy['grantControls']['builtInControls']
+            $users = $policy['conditions']['users']
+            $clientApps = $policy['conditions']['clientAppTypes']
+            $apps = $policy['conditions']['applications']
+
+            # MFA for all users
+            if (($users['includeUsers'] -contains 'All') -and ($grants -contains 'mfa')) {
+                $coverageAreas['MFA for all users'] = $true
+            }
+
+            # Legacy auth blocked
+            if (($clientApps -contains 'exchangeActiveSync' -or $clientApps -contains 'other') -and ($grants -contains 'block')) {
+                $coverageAreas['Legacy auth blocked'] = $true
+            }
+
+            # Admin MFA
+            $includeRoles = $users['includeRoles']
+            if ($includeRoles) {
+                $hasAdminRole = $false
+                foreach ($role in $includeRoles) {
+                    if ($role -in $sdAdminRoles) { $hasAdminRole = $true; break }
+                }
+                if ($hasAdminRole -and ($grants -contains 'mfa')) {
+                    $coverageAreas['Admin MFA'] = $true
+                }
+            }
+
+            # Azure Management MFA
+            $includeApps = $apps['includeApplications']
+            if (($includeApps -contains $azureMgmtAppId -or $includeApps -contains 'All') -and ($grants -contains 'mfa')) {
+                $coverageAreas['Azure Management MFA'] = $true
+            }
+        }
+
+        $coveredCount = ($coverageAreas.Values | Where-Object { $_ -eq $true }).Count
+        $totalAreas = $coverageAreas.Count
+        $gaps = @($coverageAreas.GetEnumerator() | Where-Object { $_.Value -eq $false } | ForEach-Object { $_.Key })
+
+        if ($coveredCount -eq $totalAreas) {
+            $settingParams = @{
+                Category         = 'Security Defaults'
+                Setting          = 'Security Defaults Gap Analysis'
+                CurrentValue     = "All $totalAreas areas covered by Conditional Access"
+                RecommendedValue = 'Full CA coverage when Security Defaults is OFF'
+                Status           = 'Pass'
+                CheckId          = 'ENTRA-SECDEFAULT-002'
+                Remediation      = 'No action needed. Conditional Access policies provide equivalent coverage to Security Defaults.'
+            }
+        }
+        elseif ($coveredCount -gt 0) {
+            $gapList = $gaps -join ', '
+            $settingParams = @{
+                Category         = 'Security Defaults'
+                Setting          = 'Security Defaults Gap Analysis'
+                CurrentValue     = "$coveredCount/$totalAreas covered. Gaps: $gapList"
+                RecommendedValue = 'Full CA coverage when Security Defaults is OFF'
+                Status           = 'Review'
+                CheckId          = 'ENTRA-SECDEFAULT-002'
+                Remediation      = "Create CA policies to cover: $gapList. Entra admin center > Protection > Conditional Access."
+            }
+        }
+        else {
+            $settingParams = @{
+                Category         = 'Security Defaults'
+                Setting          = 'Security Defaults Gap Analysis'
+                CurrentValue     = "0/$totalAreas areas covered -- no CA policy protection"
+                RecommendedValue = 'Full CA coverage when Security Defaults is OFF'
+                Status           = 'Fail'
+                CheckId          = 'ENTRA-SECDEFAULT-002'
+                Remediation      = 'Either enable Security Defaults or create CA policies for: MFA for all users, legacy auth block, admin MFA, Azure Management MFA. Entra admin center > Protection > Conditional Access.'
+            }
+        }
+        Add-Setting @settingParams
+    }
+    catch {
+        Write-Warning "Could not evaluate CA coverage for Security Defaults gap analysis: $_"
+        $settingParams = @{
+            Category         = 'Security Defaults'
+            Setting          = 'Security Defaults Gap Analysis'
+            CurrentValue     = 'Unable to evaluate'
+            RecommendedValue = 'Full CA coverage when Security Defaults is OFF'
+            Status           = 'Review'
+            CheckId          = 'ENTRA-SECDEFAULT-002'
+            Remediation      = 'Verify CA policies are configured. Entra admin center > Protection > Conditional Access.'
+        }
+        Add-Setting @settingParams
+    }
+}
+
+# ------------------------------------------------------------------
 # 7. Self-Service Password Reset
 # ------------------------------------------------------------------
 try {

--- a/src/M365-Assess/controls/registry.json
+++ b/src/M365-Assess/controls/registry.json
@@ -14250,6 +14250,45 @@
       }
     },
     {
+      "checkId": "ENTRA-SECDEFAULT-002",
+      "name": "Security Defaults Gap Analysis (CA Coverage)",
+      "category": "SECDEFAULT",
+      "collector": "Entra",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "cis-m365-v6": {
+          "controlId": "5.1.2.1",
+          "title": "Ensure Security Defaults is disabled on Azure Active Directory",
+          "profiles": [
+            "E3-L1",
+            "E5-L1"
+          ]
+        },
+        "nist-csf": {
+          "controlId": "PR.AC-1"
+        },
+        "nist-800-53": {
+          "controlId": "AC-2;IA-2(1)",
+          "title": "Account Management; Identification and Authentication (Multifactor Authentication)",
+          "profiles": [
+            "Moderate",
+            "High"
+          ]
+        },
+        "cisa-scuba": {
+          "controlId": "MS.AAD.1.1v1"
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.2",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access"
+        }
+      }
+    },
+    {
       "checkId": "ENTRA-CA-003",
       "name": "Enabled Conditional Access Policies",
       "category": "CA",

--- a/src/M365-Assess/controls/risk-severity.json
+++ b/src/M365-Assess/controls/risk-severity.json
@@ -116,6 +116,7 @@
     "ENTRA-PIM-004": "Medium",
     "ENTRA-PIM-005": "Medium",
     "ENTRA-SECDEFAULT-001": "Medium",
+    "ENTRA-SECDEFAULT-002": "Medium",
     "ENTRA-SSPR-001": "High",
     "ENTRA-TENANT-001": "High",
     "EXO-ADDINS-001": "Medium",


### PR DESCRIPTION
## Summary
- New check **ENTRA-SECDEFAULT-002**: evaluates CA policy coverage when Security Defaults is OFF
- Self-contained -- makes its own CA policy Graph call, no cross-collector coupling
- Evaluates 4 coverage areas:
  1. MFA for all users (CA-MFA-ALL equivalent)
  2. Legacy auth blocked (CA-LEGACYAUTH equivalent)
  3. Admin MFA (CA-MFA-ADMIN equivalent)
  4. Azure Management MFA (app ID `797f4846-ba00-4fd7-ba43-dac1f8f63013`)
- Results: **Pass** (4/4), **Review** (partial + gap list), **Fail** (0/4)
- Registry entry with CIS 5.1.2.1, NIST 800-53, CISA-ScuBA, SOC 2 mappings
- Risk severity: Medium
- Only runs when ENTRA-SECDEFAULT-001 determines Security Defaults is OFF

Closes #270

## Test plan
- [x] All 7 registry integrity tests pass
- [x] Entra security config tests pass (pre-existing failures unrelated)
- [ ] Test against tenant with Security Defaults OFF + full CA coverage -> Pass
- [ ] Test against tenant with Security Defaults OFF + partial CA -> Review with gaps
- [ ] Test against tenant with Security Defaults ON -> check skipped (not executed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)