### PR TITLE
feat: add license-aware check gating via service plan detection

### DIFF
--- a/src/M365-Assess/Common/Export-ComplianceOverview.ps1
+++ b/src/M365-Assess/Common/Export-ComplianceOverview.ps1
@@ -65,6 +65,12 @@ function Export-ComplianceOverview {
     $null = $html.AppendLine("<p>This compliance assessment is provided for <strong>informational purposes only</strong> and does not constitute a comprehensive security assessment, audit, or certification. Results reflect automated checks at a point in time and should not be considered conclusive. For a thorough security evaluation, consider engaging a qualified security professional.</p>")
     $null = $html.AppendLine("</div>")
 
+    # License-skipped notice
+    if ($global:CheckProgressState -and $global:CheckProgressState.LicenseSkipped.Count -gt 0) {
+        $skipCount = $global:CheckProgressState.LicenseSkipped.Count
+        $null = $html.AppendLine("<div class='callout callout-info'><div class='callout-title'><span class='callout-icon'>&#9432;</span> License-Aware Check Gating</div><div class='callout-body'>$skipCount checks were skipped because the tenant does not have the required license service plans. Upgrade your license to enable these checks.</div></div>")
+    }
+
     # Framework multi-selector (one checkbox per framework)
     $null = $html.AppendLine("<div class='fw-selector' id='fwSelector'>")
     $null = $html.AppendLine("<span class='fw-selector-label'>Frameworks:</span>")

--- a/src/M365-Assess/Common/Resolve-TenantLicenses.ps1
+++ b/src/M365-Assess/Common/Resolve-TenantLicenses.ps1
@@ -1,0 +1,48 @@
+function Resolve-TenantLicenses {
+    <#
+    .SYNOPSIS
+        Resolves the active service plans for the connected tenant.
+    .DESCRIPTION
+        Queries Get-MgSubscribedSku and extracts unique ServicePlanName values
+        where ProvisioningStatus is 'Success'. Returns a hashtable with a HashSet
+        for O(1) lookup, used by Initialize-CheckProgress to gate checks by license.
+    .EXAMPLE
+        $licenses = Resolve-TenantLicenses
+        $licenses.ActiveServicePlans.Contains('AAD_PREMIUM_P2')
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param()
+
+    $activePlans = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::OrdinalIgnoreCase
+    )
+    $skuPartNumbers = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::OrdinalIgnoreCase
+    )
+
+    try {
+        Write-Verbose "Resolving tenant license service plans..."
+        $skus = Get-MgSubscribedSku -All -ErrorAction Stop
+
+        foreach ($sku in $skus) {
+            $null = $skuPartNumbers.Add($sku.SkuPartNumber)
+
+            foreach ($plan in $sku.ServicePlans) {
+                if ($plan.ProvisioningStatus -eq 'Success') {
+                    $null = $activePlans.Add($plan.ServicePlanName)
+                }
+            }
+        }
+
+        Write-Verbose "Resolved $($activePlans.Count) active service plans from $($skus.Count) SKUs."
+    }
+    catch {
+        Write-Warning "Could not resolve tenant licenses: $_. License-aware gating disabled."
+    }
+
+    return @{
+        ActiveServicePlans = $activePlans
+        SkuPartNumbers     = $skuPartNumbers
+    }
+}

--- a/src/M365-Assess/Common/Show-CheckProgress.ps1
+++ b/src/M365-Assess/Common/Show-CheckProgress.ps1
@@ -56,6 +56,12 @@ function Initialize-CheckProgress {
         Hashtable returned by Import-ControlRegistry.
     .PARAMETER ActiveSections
         Array of section names the user selected (e.g., 'Identity', 'Email').
+    .PARAMETER TenantLicenses
+        Hashtable from Resolve-TenantLicenses with ActiveServicePlans HashSet.
+        Checks requiring service plans not in this set are skipped.
+    .PARAMETER SeverityFilter
+        Array of severity levels to include (e.g., @('Critical','High') for QuickScan).
+        If empty or null, all severities are included.
     #>
     [CmdletBinding()]
     param(
@@ -63,11 +69,18 @@ function Initialize-CheckProgress {
         [hashtable]$ControlRegistry,
 
         [Parameter(Mandatory)]
-        [string[]]$ActiveSections
+        [string[]]$ActiveSections,
+
+        [Parameter()]
+        [hashtable]$TenantLicenses,
+
+        [Parameter()]
+        [string[]]$SeverityFilter
     )
 
     # Build ordered list of automated checks for active sections
     $checksByCollector = [ordered]@{}
+    $licenseSkipped = @{}
 
     foreach ($collectorName in $script:CollectorOrder) {
         $section = $script:CollectorSectionMap[$collectorName]
@@ -81,6 +94,34 @@ function Initialize-CheckProgress {
             } |
             ForEach-Object { $_.Value } |
             Sort-Object -Property checkId
+
+        # Apply license gating filter
+        if ($TenantLicenses -and $TenantLicenses.ActiveServicePlans.Count -gt 0) {
+            $checks = @($checks | Where-Object {
+                $requiredPlans = $_.licensing.requiredServicePlans
+                if ($requiredPlans -and @($requiredPlans).Count -gt 0) {
+                    $hasAny = $false
+                    foreach ($plan in $requiredPlans) {
+                        if ($TenantLicenses.ActiveServicePlans.Contains($plan)) {
+                            $hasAny = $true
+                            break
+                        }
+                    }
+                    if (-not $hasAny) {
+                        $licenseSkipped[$_.checkId] = @($requiredPlans)
+                        return $false
+                    }
+                }
+                return $true
+            })
+        }
+
+        # Apply severity filter (for QuickScan)
+        if ($SeverityFilter -and $SeverityFilter.Count -gt 0) {
+            $checks = @($checks | Where-Object {
+                $_.riskSeverity -in $SeverityFilter
+            })
+        }
 
         if (@($checks).Count -gt 0) {
             $checksByCollector[$collectorName] = @($checks)
@@ -101,6 +142,7 @@ function Initialize-CheckProgress {
         CollectorDone     = @{}      # collector -> completed count
         PrintedHeaders    = @{}      # collector -> $true (header printed)
         LabelMap          = $script:CollectorLabelMap  # accessible from any scope via global state
+        LicenseSkipped    = $licenseSkipped  # checkId -> required plans (for compliance overview)
     }
 
     # Populate check IDs and collector counts
@@ -138,6 +180,9 @@ function Initialize-CheckProgress {
         $label = $script:CollectorLabelMap[$collectorName]
         $count = $checksByCollector[$collectorName].Count
         Write-Host "    $([char]0x25B8) $label — $count checks" -ForegroundColor DarkGray
+    }
+    if ($licenseSkipped.Count -gt 0) {
+        Write-Host "  $($licenseSkipped.Count) checks skipped (tenant licensing)" -ForegroundColor DarkYellow
     }
     Write-Host ''
 

--- a/src/M365-Assess/Invoke-M365Assessment.ps1
+++ b/src/M365-Assess/Invoke-M365Assessment.ps1
@@ -497,7 +497,19 @@ if (Test-Path -Path $progressHelper) {
         $controlsDir = Join-Path -Path $projectRoot -ChildPath 'controls'
         $progressRegistry = Import-ControlRegistry -ControlsPath $controlsDir
         if ($progressRegistry.Count -gt 1) {
-            Initialize-CheckProgress -ControlRegistry $progressRegistry -ActiveSections $Section
+            # Resolve tenant licenses for check gating
+            $licenseHelper = Join-Path -Path $projectRoot -ChildPath 'Common\Resolve-TenantLicenses.ps1'
+            $tenantLicenses = $null
+            if (Test-Path -Path $licenseHelper) {
+                . $licenseHelper
+                $tenantLicenses = Resolve-TenantLicenses
+            }
+            $progressParams = @{
+                ControlRegistry = $progressRegistry
+                ActiveSections  = $Section
+            }
+            if ($tenantLicenses) { $progressParams['TenantLicenses'] = $tenantLicenses }
+            Initialize-CheckProgress @progressParams
         }
     } else {
         Write-Warning "Import-ControlRegistry.ps1 not found - progress tracking disabled."

--- a/src/M365-Assess/controls/registry.json
+++ b/src/M365-Assess/controls/registry.json
@@ -10,7 +10,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -80,7 +80,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -151,7 +151,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -212,7 +212,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-csf": {
@@ -253,7 +253,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -315,7 +315,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -384,7 +384,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -447,7 +447,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -511,7 +511,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -575,7 +575,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -640,7 +640,7 @@
       "collector": "ExchangeOnline",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -698,7 +698,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -757,7 +757,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -821,7 +821,7 @@
       "collector": "SharePoint",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -881,7 +881,7 @@
       "collector": "ExchangeOnline",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -942,7 +942,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -1003,7 +1003,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -1065,7 +1065,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -1125,7 +1125,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -1186,7 +1186,9 @@
       "collector": "ExchangeOnline",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": [
+          "LOCKBOX_ENTERPRISE"
+        ]
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -1249,7 +1251,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -1310,7 +1312,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -1372,7 +1374,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -1433,7 +1435,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -1497,7 +1499,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -1562,7 +1564,9 @@
       "collector": "Defender",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": [
+          "ATP_ENTERPRISE"
+        ]
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -1625,7 +1629,7 @@
       "collector": "Defender",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -1689,7 +1693,7 @@
       "collector": "Defender",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -1750,7 +1754,9 @@
       "collector": "Defender",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": [
+          "ATP_ENTERPRISE"
+        ]
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -1813,7 +1819,9 @@
       "collector": "Defender",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": [
+          "ATP_ENTERPRISE"
+        ]
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -1864,7 +1872,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -1916,7 +1924,7 @@
       "collector": "Defender",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -1977,7 +1985,9 @@
       "collector": "Defender",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": [
+          "ATP_ENTERPRISE"
+        ]
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -2039,7 +2049,7 @@
       "collector": "DNS",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -2103,7 +2113,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -2168,7 +2178,7 @@
       "collector": "DNS",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -2231,7 +2241,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -2295,7 +2305,7 @@
       "collector": "DNS",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -2358,7 +2368,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -2422,7 +2432,7 @@
       "collector": "Defender",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -2486,7 +2496,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -2551,7 +2561,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -2612,7 +2622,7 @@
       "collector": "ExchangeOnline",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -2672,7 +2682,7 @@
       "collector": "ExchangeOnline",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -2732,7 +2742,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -2793,7 +2803,7 @@
       "collector": "Defender",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -2853,7 +2863,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -2914,7 +2924,7 @@
       "collector": "Defender",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -2975,7 +2985,9 @@
       "collector": "Defender",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": [
+          "ATP_ENTERPRISE"
+        ]
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -3035,7 +3047,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -3096,7 +3108,9 @@
       "collector": "Defender",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": [
+          "ATP_ENTERPRISE"
+        ]
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -3156,7 +3170,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -3217,7 +3231,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -3276,7 +3290,9 @@
       "collector": "Defender",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": [
+          "ATP_ENTERPRISE"
+        ]
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -3336,7 +3352,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -3397,7 +3413,7 @@
       "collector": "Compliance",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -3455,7 +3471,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -3514,7 +3530,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -3574,7 +3590,7 @@
       "collector": "Compliance",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -3633,7 +3649,9 @@
       "collector": "Compliance",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": [
+          "INFORMATION_PROTECTION_COMPLIANCE"
+        ]
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -3688,7 +3706,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -3744,7 +3762,7 @@
       "collector": "Compliance",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -3805,7 +3823,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -3867,7 +3885,7 @@
       "collector": "Intune",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -3931,7 +3949,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -3996,7 +4014,7 @@
       "collector": "Intune",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -4057,7 +4075,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -4119,7 +4137,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -4183,7 +4201,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -4248,7 +4266,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -4315,7 +4333,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -4383,7 +4401,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -4447,7 +4465,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -4512,7 +4530,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -4576,7 +4594,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -4636,7 +4654,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -4697,7 +4715,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -4759,7 +4777,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -4823,7 +4841,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -4888,7 +4906,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -4952,7 +4970,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -5013,7 +5031,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -5075,7 +5093,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -5139,7 +5157,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -5204,7 +5222,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -5268,7 +5286,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -5333,7 +5351,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -5398,7 +5416,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -5462,7 +5480,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -5526,7 +5544,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -5591,7 +5609,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -5655,7 +5673,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -5720,7 +5738,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -5787,7 +5805,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -5855,7 +5873,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -5916,7 +5934,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -5978,7 +5996,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -6047,7 +6065,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -6113,7 +6131,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -6174,7 +6192,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -6236,7 +6254,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -6307,7 +6325,7 @@
       "collector": "CAEvaluator",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -6377,7 +6395,7 @@
       "collector": "CAEvaluator",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -6447,7 +6465,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -6518,7 +6536,7 @@
       "collector": "CAEvaluator",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -6585,7 +6603,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -6653,7 +6671,7 @@
       "collector": "CAEvaluator",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -6716,7 +6734,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -6780,7 +6798,7 @@
       "collector": "CAEvaluator",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -6850,7 +6868,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -6921,7 +6939,9 @@
       "collector": "CAEvaluator",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": [
+          "AAD_PREMIUM_P2"
+        ]
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -6983,7 +7003,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -7046,7 +7066,9 @@
       "collector": "CAEvaluator",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": [
+          "AAD_PREMIUM_P2"
+        ]
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -7108,7 +7130,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -7171,7 +7193,9 @@
       "collector": "CAEvaluator",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": [
+          "AAD_PREMIUM_P2"
+        ]
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -7233,7 +7257,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -7296,7 +7320,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -7361,7 +7385,7 @@
       "collector": "CAEvaluator",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -7425,7 +7449,7 @@
       "collector": "CAEvaluator",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -7489,7 +7513,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -7554,7 +7578,7 @@
       "collector": "CAEvaluator",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -7621,7 +7645,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -7689,7 +7713,7 @@
       "collector": "CAEvaluator",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -7750,7 +7774,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -7812,7 +7836,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -7879,7 +7903,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -7947,7 +7971,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -8008,7 +8032,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -8069,7 +8093,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -8131,7 +8155,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -8195,7 +8219,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -8251,7 +8275,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -8306,7 +8330,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -8370,7 +8394,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -8435,7 +8459,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -8496,7 +8520,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -8558,7 +8582,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -8619,7 +8643,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -8681,7 +8705,9 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": [
+          "AAD_PREMIUM_P2"
+        ]
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -8754,7 +8780,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -8824,7 +8850,9 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": [
+          "AAD_PREMIUM_P2"
+        ]
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -8889,7 +8917,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -8955,7 +8983,9 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": [
+          "AAD_PREMIUM_P2"
+        ]
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -9020,7 +9050,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -9086,7 +9116,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -9152,7 +9182,9 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": [
+          "AAD_PREMIUM_P2"
+        ]
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -9217,7 +9249,9 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": [
+          "AAD_PREMIUM_P2"
+        ]
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -9282,7 +9316,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -9348,7 +9382,7 @@
       "collector": "ExchangeOnline",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -9406,7 +9440,7 @@
       "collector": "ExchangeOnline",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -9464,7 +9498,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -9523,7 +9557,7 @@
       "collector": "ExchangeOnline",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -9581,7 +9615,7 @@
       "collector": "ExchangeOnline",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -9644,7 +9678,7 @@
       "collector": "ExchangeOnline",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -9704,7 +9738,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -9765,7 +9799,7 @@
       "collector": "ExchangeOnline",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -9828,7 +9862,7 @@
       "collector": "ExchangeOnline",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -9889,7 +9923,7 @@
       "collector": "ExchangeOnline",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -9950,7 +9984,7 @@
       "collector": "ExchangeOnline",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -9992,7 +10026,7 @@
       "collector": "ExchangeOnline",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -10053,7 +10087,7 @@
       "collector": "ExchangeOnline",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -10117,7 +10151,7 @@
       "collector": "ExchangeOnline",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -10165,7 +10199,7 @@
       "collector": "ExchangeOnline",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-csf": {
@@ -10201,7 +10235,7 @@
       "collector": "SharePoint",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -10262,7 +10296,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -10324,7 +10358,7 @@
       "collector": "SharePoint",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -10385,7 +10419,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -10447,7 +10481,7 @@
       "collector": "SharePoint",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -10508,7 +10542,7 @@
       "collector": "SharePoint",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -10569,7 +10603,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -10631,7 +10665,7 @@
       "collector": "SharePoint",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -10695,7 +10729,7 @@
       "collector": "SharePoint",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -10759,7 +10793,7 @@
       "collector": "SharePoint",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -10822,7 +10856,7 @@
       "collector": "SharePoint",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -10886,7 +10920,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -10951,7 +10985,7 @@
       "collector": "SharePoint",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -11009,7 +11043,7 @@
       "collector": "SharePoint",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -11067,7 +11101,7 @@
       "collector": "SharePoint",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -11130,7 +11164,9 @@
       "collector": "SharePoint",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": [
+          "ATP_ENTERPRISE"
+        ]
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -11181,7 +11217,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -11233,7 +11269,7 @@
       "collector": "SharePoint",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -11294,7 +11330,7 @@
       "collector": "SharePoint",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -11352,7 +11388,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -11411,7 +11447,7 @@
       "collector": "SharePoint",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -11469,7 +11505,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -11528,7 +11564,7 @@
       "collector": "Teams",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -11589,7 +11625,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -11651,7 +11687,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -11712,7 +11748,7 @@
       "collector": "Teams",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -11772,7 +11808,7 @@
       "collector": "Teams",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -11830,7 +11866,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -11889,7 +11925,7 @@
       "collector": "Teams",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -11950,7 +11986,7 @@
       "collector": "Teams",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -12011,7 +12047,7 @@
       "collector": "Teams",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -12072,7 +12108,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -12134,7 +12170,7 @@
       "collector": "Teams",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -12192,7 +12228,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -12251,7 +12287,7 @@
       "collector": "Teams",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -12309,7 +12345,7 @@
       "collector": "Teams",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -12361,7 +12397,7 @@
       "collector": "Teams",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -12419,7 +12455,7 @@
       "collector": "Teams",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -12471,7 +12507,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -12530,7 +12566,7 @@
       "collector": "Teams",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -12588,7 +12624,7 @@
       "collector": "Teams",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -12646,7 +12682,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -12705,7 +12741,7 @@
       "collector": "Teams",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -12757,7 +12793,7 @@
       "collector": "Teams",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -12818,7 +12854,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -12880,7 +12916,7 @@
       "collector": "Teams",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -12941,7 +12977,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -13003,7 +13039,7 @@
       "collector": "Teams",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -13057,7 +13093,7 @@
       "collector": "",
       "hasAutomatedCheck": false,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -13112,7 +13148,7 @@
       "collector": "PowerBI",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -13176,7 +13212,7 @@
       "collector": "PowerBI",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -13240,7 +13276,7 @@
       "collector": "PowerBI",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -13304,7 +13340,7 @@
       "collector": "PowerBI",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -13365,7 +13401,7 @@
       "collector": "PowerBI",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -13429,7 +13465,7 @@
       "collector": "PowerBI",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -13490,7 +13526,7 @@
       "collector": "PowerBI",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -13550,7 +13586,7 @@
       "collector": "PowerBI",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -13611,7 +13647,7 @@
       "collector": "PowerBI",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -13672,7 +13708,7 @@
       "collector": "PowerBI",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -13735,7 +13771,7 @@
       "collector": "PowerBI",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -13798,7 +13834,7 @@
       "collector": "SharePoint",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-800-53": {
@@ -13840,7 +13876,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-csf": {
@@ -13890,7 +13926,7 @@
       "collector": "SharePoint",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-800-53": {
@@ -13932,7 +13968,7 @@
       "collector": "SharePoint",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-800-53": {
@@ -13974,7 +14010,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-csf": {
@@ -14024,7 +14060,7 @@
       "collector": "Teams",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-csf": {
@@ -14074,7 +14110,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-csf": {
@@ -14112,7 +14148,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-csf": {
@@ -14150,7 +14186,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-csf": {
@@ -14203,7 +14239,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-csf": {
@@ -14256,7 +14292,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-csf": {
@@ -14303,7 +14339,7 @@
       "collector": "Teams",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-800-53": {
@@ -14345,7 +14381,7 @@
       "collector": "Forms",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -14393,7 +14429,7 @@
       "collector": "Forms",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -14441,7 +14477,7 @@
       "collector": "Forms",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-csf": {
@@ -14481,7 +14517,7 @@
       "collector": "Forms",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -14529,7 +14565,7 @@
       "collector": "Forms",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-csf": {
@@ -14569,7 +14605,7 @@
       "collector": "Forms",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-csf": {
@@ -14608,7 +14644,7 @@
       "collector": "PurviewRetention",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-csf": {
@@ -14652,7 +14688,7 @@
       "collector": "PurviewRetention",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-csf": {
@@ -14695,7 +14731,7 @@
       "collector": "PurviewRetention",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-csf": {
@@ -14738,7 +14774,7 @@
       "collector": "PurviewRetention",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-csf": {
@@ -14781,7 +14817,7 @@
       "collector": "PurviewRetention",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-csf": {
@@ -14820,7 +14856,9 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": [
+          "AAD_PREMIUM_P2"
+        ]
       },
       "frameworks": {
         "nist-800-53": {
@@ -14856,7 +14894,9 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": [
+          "AAD_PREMIUM_P2"
+        ]
       },
       "frameworks": {
         "nist-800-53": {
@@ -14889,7 +14929,9 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": [
+          "AAD_PREMIUM_P2"
+        ]
       },
       "frameworks": {
         "nist-800-53": {
@@ -14926,7 +14968,9 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": [
+          "AAD_PREMIUM_P2"
+        ]
       },
       "frameworks": {
         "nist-800-53": {
@@ -14959,7 +15003,9 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": [
+          "AAD_PREMIUM_P2"
+        ]
       },
       "frameworks": {
         "nist-800-53": {
@@ -14993,7 +15039,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-800-53": {
@@ -15033,7 +15079,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-800-53": {
@@ -15065,7 +15111,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-800-53": {
@@ -15094,7 +15140,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-800-53": {
@@ -15124,7 +15170,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-800-53": {
@@ -15153,7 +15199,7 @@
       "collector": "Entra",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-800-53": {
@@ -15190,7 +15236,9 @@
       "collector": "CAEvaluator",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": [
+          "AAD_PREMIUM_P2"
+        ]
       },
       "frameworks": {
         "nist-800-53": {
@@ -15219,7 +15267,7 @@
       "collector": "CAEvaluator",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-800-53": {
@@ -15255,7 +15303,7 @@
       "collector": "EntApp",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-800-53": {
@@ -15285,7 +15333,7 @@
       "collector": "EntApp",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-800-53": {
@@ -15317,7 +15365,7 @@
       "collector": "EntApp",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-800-53": {
@@ -15353,7 +15401,7 @@
       "collector": "EntApp",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-800-53": {
@@ -15382,7 +15430,7 @@
       "collector": "EntApp",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-800-53": {
@@ -15414,7 +15462,7 @@
       "collector": "EntApp",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-800-53": {
@@ -15444,7 +15492,7 @@
       "collector": "EntApp",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-800-53": {
@@ -15473,7 +15521,7 @@
       "collector": "EntApp",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-800-53": {
@@ -15503,7 +15551,7 @@
       "collector": "EntApp",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-800-53": {
@@ -15532,7 +15580,7 @@
       "collector": "EntApp",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-csf": {
@@ -15569,7 +15617,7 @@
       "collector": "EntApp",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-800-53": {
@@ -15598,11 +15646,27 @@
       "category": "ENTAPP",
       "collector": "EntApp",
       "hasAutomatedCheck": true,
-      "licensing": { "minimum": "E3" },
+      "licensing": {
+        "requiredServicePlans": []
+      },
       "frameworks": {
-        "nist-800-53": { "controlId": "IA-5(2)", "title": "Public Key-Based Authentication", "profiles": ["Moderate", "High"] },
-        "soc2": { "controlId": "CC6.1;CC6.6", "evidenceType": "config-export", "title": "Logical Access Security; Security Measures Against Threats" },
-        "mitre-attack": { "controlId": "T1552.004;T1528", "title": "Unsecured Credentials: Private Keys; Steal Application Access Token" }
+        "nist-800-53": {
+          "controlId": "IA-5(2)",
+          "title": "Public Key-Based Authentication",
+          "profiles": [
+            "Moderate",
+            "High"
+          ]
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.6",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security; Security Measures Against Threats"
+        },
+        "mitre-attack": {
+          "controlId": "T1552.004;T1528",
+          "title": "Unsecured Credentials: Private Keys; Steal Application Access Token"
+        }
       }
     },
     {
@@ -15611,10 +15675,24 @@
       "category": "ENTAPP",
       "collector": "EntApp",
       "hasAutomatedCheck": true,
-      "licensing": { "minimum": "E3" },
+      "licensing": {
+        "requiredServicePlans": []
+      },
       "frameworks": {
-        "nist-800-53": { "controlId": "IA-5;IA-5(1)", "title": "Authenticator Management; Password-Based Authentication", "profiles": ["Low", "Moderate", "High"] },
-        "soc2": { "controlId": "CC6.1;CC6.2", "evidenceType": "config-export", "title": "Logical Access Security; Credentials Management" }
+        "nist-800-53": {
+          "controlId": "IA-5;IA-5(1)",
+          "title": "Authenticator Management; Password-Based Authentication",
+          "profiles": [
+            "Low",
+            "Moderate",
+            "High"
+          ]
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.2",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security; Credentials Management"
+        }
       }
     },
     {
@@ -15623,10 +15701,24 @@
       "category": "ENTAPP",
       "collector": "EntApp",
       "hasAutomatedCheck": true,
-      "licensing": { "minimum": "E3" },
+      "licensing": {
+        "requiredServicePlans": []
+      },
       "frameworks": {
-        "nist-800-53": { "controlId": "IA-5", "title": "Authenticator Management", "profiles": ["Low", "Moderate", "High"] },
-        "soc2": { "controlId": "CC6.1", "evidenceType": "config-export", "title": "Logical Access Security" }
+        "nist-800-53": {
+          "controlId": "IA-5",
+          "title": "Authenticator Management",
+          "profiles": [
+            "Low",
+            "Moderate",
+            "High"
+          ]
+        },
+        "soc2": {
+          "controlId": "CC6.1",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security"
+        }
       }
     },
     {
@@ -15635,11 +15727,27 @@
       "category": "ENTAPP",
       "collector": "EntApp",
       "hasAutomatedCheck": true,
-      "licensing": { "minimum": "E3" },
+      "licensing": {
+        "requiredServicePlans": []
+      },
       "frameworks": {
-        "nist-800-53": { "controlId": "AC-6(5);IA-5(2)", "title": "Privileged Accounts; Public Key-Based Authentication", "profiles": ["Moderate", "High"] },
-        "soc2": { "controlId": "CC6.1;CC6.3", "evidenceType": "config-export", "title": "Logical Access Security; Enrollment and Authorization" },
-        "mitre-attack": { "controlId": "T1098.001;T1078.004", "title": "Additional Cloud Credentials; Valid Accounts: Cloud Accounts" }
+        "nist-800-53": {
+          "controlId": "AC-6(5);IA-5(2)",
+          "title": "Privileged Accounts; Public Key-Based Authentication",
+          "profiles": [
+            "Moderate",
+            "High"
+          ]
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.3",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security; Enrollment and Authorization"
+        },
+        "mitre-attack": {
+          "controlId": "T1098.001;T1078.004",
+          "title": "Additional Cloud Credentials; Valid Accounts: Cloud Accounts"
+        }
       }
     },
     {
@@ -15648,11 +15756,27 @@
       "category": "ENTAPP",
       "collector": "EntApp",
       "hasAutomatedCheck": true,
-      "licensing": { "minimum": "E3" },
+      "licensing": {
+        "requiredServicePlans": []
+      },
       "frameworks": {
-        "nist-800-53": { "controlId": "AC-6(5);AC-6(10)", "title": "Privileged Accounts; Prohibit Non-Privileged Users from Executing Privileged Functions", "profiles": ["Moderate", "High"] },
-        "soc2": { "controlId": "CC6.1;CC6.3", "evidenceType": "config-export", "title": "Logical Access Security; Enrollment and Authorization" },
-        "mitre-attack": { "controlId": "T1098.001;T1098.003", "title": "Additional Cloud Credentials; Additional Cloud Roles" }
+        "nist-800-53": {
+          "controlId": "AC-6(5);AC-6(10)",
+          "title": "Privileged Accounts; Prohibit Non-Privileged Users from Executing Privileged Functions",
+          "profiles": [
+            "Moderate",
+            "High"
+          ]
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.3",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security; Enrollment and Authorization"
+        },
+        "mitre-attack": {
+          "controlId": "T1098.001;T1098.003",
+          "title": "Additional Cloud Credentials; Additional Cloud Roles"
+        }
       }
     },
     {
@@ -15661,11 +15785,27 @@
       "category": "ENTAPP",
       "collector": "EntApp",
       "hasAutomatedCheck": true,
-      "licensing": { "minimum": "E3" },
+      "licensing": {
+        "requiredServicePlans": []
+      },
       "frameworks": {
-        "nist-800-53": { "controlId": "AC-6(5)", "title": "Privileged Accounts", "profiles": ["Moderate", "High"] },
-        "soc2": { "controlId": "CC6.1;CC6.3", "evidenceType": "config-export", "title": "Logical Access Security; Enrollment and Authorization" },
-        "mitre-attack": { "controlId": "T1098.001;T1078.004", "title": "Additional Cloud Credentials; Valid Accounts: Cloud Accounts" }
+        "nist-800-53": {
+          "controlId": "AC-6(5)",
+          "title": "Privileged Accounts",
+          "profiles": [
+            "Moderate",
+            "High"
+          ]
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.3",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security; Enrollment and Authorization"
+        },
+        "mitre-attack": {
+          "controlId": "T1098.001;T1078.004",
+          "title": "Additional Cloud Credentials; Valid Accounts: Cloud Accounts"
+        }
       }
     },
     {
@@ -15674,10 +15814,24 @@
       "category": "ENTAPP",
       "collector": "EntApp",
       "hasAutomatedCheck": true,
-      "licensing": { "minimum": "E3" },
+      "licensing": {
+        "requiredServicePlans": []
+      },
       "frameworks": {
-        "nist-800-53": { "controlId": "AC-2", "title": "Account Management", "profiles": ["Low", "Moderate", "High"] },
-        "soc2": { "controlId": "CC6.2;CC6.3", "evidenceType": "config-export", "title": "Credentials Management; Enrollment and Authorization" }
+        "nist-800-53": {
+          "controlId": "AC-2",
+          "title": "Account Management",
+          "profiles": [
+            "Low",
+            "Moderate",
+            "High"
+          ]
+        },
+        "soc2": {
+          "controlId": "CC6.2;CC6.3",
+          "evidenceType": "config-export",
+          "title": "Credentials Management; Enrollment and Authorization"
+        }
       }
     },
     {
@@ -15686,11 +15840,27 @@
       "category": "ENTAPP",
       "collector": "EntApp",
       "hasAutomatedCheck": true,
-      "licensing": { "minimum": "E3" },
+      "licensing": {
+        "requiredServicePlans": []
+      },
       "frameworks": {
-        "nist-800-53": { "controlId": "AC-2(3);AC-6", "title": "Disable Accounts; Least Privilege", "profiles": ["Moderate", "High"] },
-        "soc2": { "controlId": "CC6.1;CC6.3", "evidenceType": "config-export", "title": "Logical Access Security; Enrollment and Authorization" },
-        "mitre-attack": { "controlId": "T1078.004", "title": "Valid Accounts: Cloud Accounts" }
+        "nist-800-53": {
+          "controlId": "AC-2(3);AC-6",
+          "title": "Disable Accounts; Least Privilege",
+          "profiles": [
+            "Moderate",
+            "High"
+          ]
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.3",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security; Enrollment and Authorization"
+        },
+        "mitre-attack": {
+          "controlId": "T1078.004",
+          "title": "Valid Accounts: Cloud Accounts"
+        }
       }
     },
     {
@@ -15699,11 +15869,27 @@
       "category": "ENTAPP",
       "collector": "EntApp",
       "hasAutomatedCheck": true,
-      "licensing": { "minimum": "E3" },
+      "licensing": {
+        "requiredServicePlans": []
+      },
       "frameworks": {
-        "nist-800-53": { "controlId": "SI-3;SI-4", "title": "Malicious Code Protection; System Monitoring", "profiles": ["Moderate", "High"] },
-        "soc2": { "controlId": "CC6.1;CC7.1", "evidenceType": "config-export", "title": "Logical Access Security; Detection of Changes" },
-        "mitre-attack": { "controlId": "T1036;T1566.002", "title": "Masquerading; Spearphishing Link" }
+        "nist-800-53": {
+          "controlId": "SI-3;SI-4",
+          "title": "Malicious Code Protection; System Monitoring",
+          "profiles": [
+            "Moderate",
+            "High"
+          ]
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC7.1",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security; Detection of Changes"
+        },
+        "mitre-attack": {
+          "controlId": "T1036;T1566.002",
+          "title": "Masquerading; Spearphishing Link"
+        }
       }
     },
     {
@@ -15712,10 +15898,24 @@
       "category": "ENTAPP",
       "collector": "EntApp",
       "hasAutomatedCheck": true,
-      "licensing": { "minimum": "E3" },
+      "licensing": {
+        "requiredServicePlans": []
+      },
       "frameworks": {
-        "nist-800-53": { "controlId": "AC-3;AC-22", "title": "Access Enforcement; Publicly Accessible Content", "profiles": ["Low", "Moderate", "High"] },
-        "soc2": { "controlId": "CC6.1", "evidenceType": "config-export", "title": "Logical Access Security" }
+        "nist-800-53": {
+          "controlId": "AC-3;AC-22",
+          "title": "Access Enforcement; Publicly Accessible Content",
+          "profiles": [
+            "Low",
+            "Moderate",
+            "High"
+          ]
+        },
+        "soc2": {
+          "controlId": "CC6.1",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security"
+        }
       }
     },
     {
@@ -15724,11 +15924,27 @@
       "category": "APPREG",
       "collector": "EntApp",
       "hasAutomatedCheck": true,
-      "licensing": { "minimum": "E3" },
+      "licensing": {
+        "requiredServicePlans": []
+      },
       "frameworks": {
-        "nist-800-53": { "controlId": "IA-9", "title": "Service Identification and Authentication", "profiles": ["Moderate", "High"] },
-        "soc2": { "controlId": "CC6.1;CC6.6", "evidenceType": "config-export", "title": "Logical Access Security; Security Measures Against Threats" },
-        "mitre-attack": { "controlId": "T1528", "title": "Steal Application Access Token" }
+        "nist-800-53": {
+          "controlId": "IA-9",
+          "title": "Service Identification and Authentication",
+          "profiles": [
+            "Moderate",
+            "High"
+          ]
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.6",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security; Security Measures Against Threats"
+        },
+        "mitre-attack": {
+          "controlId": "T1528",
+          "title": "Steal Application Access Token"
+        }
       }
     },
     {
@@ -15737,11 +15953,27 @@
       "category": "APPREG",
       "collector": "EntApp",
       "hasAutomatedCheck": true,
-      "licensing": { "minimum": "E3" },
+      "licensing": {
+        "requiredServicePlans": []
+      },
       "frameworks": {
-        "nist-800-53": { "controlId": "SC-8;SC-8(1)", "title": "Transmission Confidentiality and Integrity", "profiles": ["Moderate", "High"] },
-        "soc2": { "controlId": "CC6.1;CC6.7", "evidenceType": "config-export", "title": "Logical Access Security; Restrictions on Data Transmission" },
-        "mitre-attack": { "controlId": "T1557;T1528", "title": "Adversary-in-the-Middle; Steal Application Access Token" }
+        "nist-800-53": {
+          "controlId": "SC-8;SC-8(1)",
+          "title": "Transmission Confidentiality and Integrity",
+          "profiles": [
+            "Moderate",
+            "High"
+          ]
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.7",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security; Restrictions on Data Transmission"
+        },
+        "mitre-attack": {
+          "controlId": "T1557;T1528",
+          "title": "Adversary-in-the-Middle; Steal Application Access Token"
+        }
       }
     },
     {
@@ -15750,11 +15982,27 @@
       "category": "APPREG",
       "collector": "EntApp",
       "hasAutomatedCheck": true,
-      "licensing": { "minimum": "E3" },
+      "licensing": {
+        "requiredServicePlans": []
+      },
       "frameworks": {
-        "nist-800-53": { "controlId": "SC-8;SI-10", "title": "Transmission Confidentiality; Information Input Validation", "profiles": ["Moderate", "High"] },
-        "soc2": { "controlId": "CC6.1;CC6.6", "evidenceType": "config-export", "title": "Logical Access Security; Security Measures Against Threats" },
-        "mitre-attack": { "controlId": "T1528", "title": "Steal Application Access Token" }
+        "nist-800-53": {
+          "controlId": "SC-8;SI-10",
+          "title": "Transmission Confidentiality; Information Input Validation",
+          "profiles": [
+            "Moderate",
+            "High"
+          ]
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.6",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security; Security Measures Against Threats"
+        },
+        "mitre-attack": {
+          "controlId": "T1528",
+          "title": "Steal Application Access Token"
+        }
       }
     },
     {
@@ -15763,11 +16011,28 @@
       "category": "CONSENT",
       "collector": "Entra",
       "hasAutomatedCheck": true,
-      "licensing": { "minimum": "E3" },
+      "licensing": {
+        "requiredServicePlans": []
+      },
       "frameworks": {
-        "cisa-scuba": { "controlId": "MS.AAD.5.2v1", "title": "User consent restricted to verified publishers" },
-        "nist-800-53": { "controlId": "AC-3;AC-6", "title": "Access Enforcement; Least Privilege", "profiles": ["Low", "Moderate", "High"] },
-        "soc2": { "controlId": "CC6.1;CC6.3", "evidenceType": "config-export", "title": "Logical Access Security; Enrollment and Authorization" }
+        "cisa-scuba": {
+          "controlId": "MS.AAD.5.2v1",
+          "title": "User consent restricted to verified publishers"
+        },
+        "nist-800-53": {
+          "controlId": "AC-3;AC-6",
+          "title": "Access Enforcement; Least Privilege",
+          "profiles": [
+            "Low",
+            "Moderate",
+            "High"
+          ]
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.3",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security; Enrollment and Authorization"
+        }
       }
     },
     {
@@ -15776,11 +16041,28 @@
       "category": "CONSENT",
       "collector": "Entra",
       "hasAutomatedCheck": true,
-      "licensing": { "minimum": "E3" },
+      "licensing": {
+        "requiredServicePlans": []
+      },
       "frameworks": {
-        "nist-800-53": { "controlId": "AC-6;AC-2", "title": "Least Privilege; Account Management", "profiles": ["Low", "Moderate", "High"] },
-        "soc2": { "controlId": "CC6.1;CC6.3", "evidenceType": "config-export", "title": "Logical Access Security; Enrollment and Authorization" },
-        "mitre-attack": { "controlId": "T1550.001", "title": "Use Alternate Authentication Material: Application Access Token" }
+        "nist-800-53": {
+          "controlId": "AC-6;AC-2",
+          "title": "Least Privilege; Account Management",
+          "profiles": [
+            "Low",
+            "Moderate",
+            "High"
+          ]
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.3",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security; Enrollment and Authorization"
+        },
+        "mitre-attack": {
+          "controlId": "T1550.001",
+          "title": "Use Alternate Authentication Material: Application Access Token"
+        }
       }
     },
     {
@@ -15790,7 +16072,7 @@
       "collector": "StrykerReadiness",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-800-53": {
@@ -15833,7 +16115,7 @@
       "collector": "StrykerReadiness",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "cis-m365-v6": {
@@ -15881,7 +16163,7 @@
       "collector": "StrykerReadiness",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-800-53": {
@@ -15929,7 +16211,7 @@
       "collector": "StrykerReadiness",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-800-53": {
@@ -15968,7 +16250,7 @@
       "collector": "StrykerReadiness",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-800-53": {
@@ -16007,7 +16289,9 @@
       "collector": "StrykerReadiness",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E5"
+        "requiredServicePlans": [
+          "INTUNE_A"
+        ]
       },
       "frameworks": {
         "nist-800-53": {
@@ -16045,7 +16329,7 @@
       "collector": "StrykerReadiness",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-800-53": {
@@ -16084,7 +16368,7 @@
       "collector": "StrykerReadiness",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-800-53": {
@@ -16131,7 +16415,7 @@
       "collector": "StrykerReadiness",
       "hasAutomatedCheck": true,
       "licensing": {
-        "minimum": "E3"
+        "requiredServicePlans": []
       },
       "frameworks": {
         "nist-800-53": {


### PR DESCRIPTION
## Summary
- Migrate registry.json licensing schema from tier-based (`minimum: "E3"`) to **service plan detection** (`requiredServicePlans: [...]`)
- New `Resolve-TenantLicenses.ps1`: queries `Get-MgSubscribedSku`, returns HashSet of active service plan names
- `Initialize-CheckProgress` gains `TenantLicenses` + `SeverityFilter` params for composable filtering
- OR logic: check runs if tenant has **any** of the listed plans (handles bundles/add-ons)
- 294 entries migrated; 25 checks mapped to specific plans:
  - `AAD_PREMIUM_P2` -> PIM, risk-based CA (14 checks)
  - `ATP_ENTERPRISE` -> Defender for Office 365 (8 checks)
  - `INFORMATION_PROTECTION_COMPLIANCE` -> DLP (1 check)
  - `LOCKBOX_ENTERPRISE` -> Customer Lockbox (1 check)
  - `INTUNE_A` -> Intune compliance (1 check)
- License-skipped checks omitted from report; compliance overview shows info callout with skip count

Closes #268

## Test plan
- [x] All 101 affected tests pass (registry integrity, report, progress, compliance overview)
- [ ] Test against E3-only tenant: verify P2/Defender checks skipped, skip count shown
- [ ] Test against E5 tenant: verify all checks run (no false skips)
- [ ] Verify compliance overview info callout renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)