### PR TITLE
feat: add -QuickScan switch for Critical/High-only assessments

### DIFF
--- a/src/M365-Assess/Common/Export-AssessmentReport.ps1
+++ b/src/M365-Assess/Common/Export-AssessmentReport.ps1
@@ -111,7 +111,10 @@ param(
     [string]$CisFrameworkId = 'cis-m365-v6',
 
     [Parameter()]
-    [switch]$OpenReport
+    [switch]$OpenReport,
+
+    [Parameter()]
+    [switch]$QuickScan
 )
 
 $ErrorActionPreference = 'Stop'

--- a/src/M365-Assess/Common/Get-ReportTemplate.ps1
+++ b/src/M365-Assess/Common/Get-ReportTemplate.ps1
@@ -288,6 +288,22 @@ $html = @"
         /* Full cover page hidden on screen, shown in print */
         .cover-print-only { display: none; }
 
+        /* Quick Scan mode banner */
+        .quickscan-banner {
+            background: #f59e0b;
+            color: #1a1a1a;
+            text-align: center;
+            padding: 8px 16px;
+            font-weight: 600;
+            font-size: 9.5pt;
+            border-radius: 6px;
+            margin-bottom: 12px;
+        }
+        body.dark-theme .quickscan-banner {
+            background: #b45309;
+            color: #fff;
+        }
+
         /* Compact hero banner (screen only) */
         .hero-banner {
             display: flex;
@@ -2443,6 +2459,13 @@ $html += @"
 
         <div class="report-page page-active" data-page="overview" id="overview">
 "@
+
+if ($QuickScan) {
+    $html += @"
+
+        <div class="quickscan-banner">Quick Scan Mode &mdash; showing Critical and High severity findings only</div>
+"@
+}
 
 if (-not $SkipCoverPage) {
     # Compact hero banner for screen; full cover page rendered in print CSS only

--- a/src/M365-Assess/Invoke-M365Assessment.ps1
+++ b/src/M365-Assess/Invoke-M365Assessment.ps1
@@ -73,6 +73,10 @@
 .PARAMETER CisBenchmarkVersion
     CIS benchmark version to use for framework rendering. Defaults to 'v6'
     (CIS Microsoft 365 v6.0.1). Set to 'v7' when CIS v7.0 data is available.
+.PARAMETER QuickScan
+    Run only Critical and High severity checks. Useful for CI/CD pipelines
+    and daily monitoring. Collectors with no qualifying checks are skipped
+    entirely. The report shows a "Quick Scan Mode" banner.
 .PARAMETER NonInteractive
     Suppresses all interactive prompts for module installation, EXO downgrade,
     and script unblocking. When a required module is missing or incompatible,
@@ -188,7 +192,10 @@ param(
     [string]$CisBenchmarkVersion = 'v6',
 
     [Parameter()]
-    [switch]$NonInteractive
+    [switch]$NonInteractive,
+
+    [Parameter()]
+    [switch]$QuickScan
 )
 
 $ErrorActionPreference = 'Stop'
@@ -509,6 +516,7 @@ if (Test-Path -Path $progressHelper) {
                 ActiveSections  = $Section
             }
             if ($tenantLicenses) { $progressParams['TenantLicenses'] = $tenantLicenses }
+            if ($QuickScan) { $progressParams['SeverityFilter'] = @('Critical', 'High') }
             Initialize-CheckProgress @progressParams
         }
     } else {
@@ -958,6 +966,7 @@ if (Test-Path -Path $reportScriptPath) {
         if ($FrameworkFilter) { $reportParams['FrameworkFilter'] = $FrameworkFilter }
         if ($CustomBranding) { $reportParams['CustomBranding'] = $CustomBranding }
         if ($FrameworkExport) { $reportParams['FrameworkExport'] = $FrameworkExport }
+        if ($QuickScan) { $reportParams['QuickScan'] = $true }
         $reportParams['CisFrameworkId'] = "cis-m365-$CisBenchmarkVersion"
 
         $reportOutput = & $reportScriptPath @reportParams

--- a/src/M365-Assess/Orchestrator/Show-InteractiveWizard.ps1
+++ b/src/M365-Assess/Orchestrator/Show-InteractiveWizard.ps1
@@ -270,6 +270,7 @@ function Show-InteractiveWizard {
         '3' = @{ Name = 'ExecutiveSummary';    Label = 'Executive Summary';    Selected = $true }
         '4' = @{ Name = 'NoBranding';          Label = 'Remove Branding';      Selected = $false }
         '5' = @{ Name = 'LimitFrameworks';     Label = 'Limit Frameworks';     Selected = $false }
+        '6' = @{ Name = 'QuickScan';           Label = 'Quick Scan (Critical + High only)'; Selected = $false }
     }
     $wizFrameworkFilter = @()
 
@@ -466,6 +467,7 @@ function Show-InteractiveWizard {
     if (-not $reportOptions['3'].Selected) { $wizardResult['SkipExecutiveSummary'] = $true }
     if ($reportOptions['4'].Selected) { $wizardResult['NoBranding'] = $true }
     if ($wizFrameworkFilter.Count -gt 0) { $wizardResult['FrameworkFilter'] = $wizFrameworkFilter }
+    if ($reportOptions['6'].Selected) { $wizardResult['QuickScan'] = $true }
 
     if ($tenantInput.Trim()) {
         $wizardResult['TenantId'] = $tenantInput.Trim()


### PR DESCRIPTION
## Summary
- New `-QuickScan` switch on `Invoke-M365Assessment` -- runs only Critical and High severity checks
- Composes with license gating (#268/#333): `SeverityFilter` param on `Initialize-CheckProgress` works alongside `TenantLicenses`
- Collectors with zero qualifying checks are skipped entirely
- Amber "Quick Scan Mode" banner in report (styled for both light and dark themes)
- Wizard option 6: "Quick Scan (Critical + High only)" in Report Options step

Closes #273

## Test plan
- [x] All 183 affected tests pass
- [ ] `Invoke-M365Assessment -QuickScan` shows reduced check count
- [ ] Report contains amber "Quick Scan Mode" banner
- [ ] Wizard toggle works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)