### PR TITLE
fix: manifest FileList and COMPLIANCE.md registry count

### DIFF
--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -56,7 +56,7 @@ The assessment suite includes **191 automated security checks** across 15 securi
 
 ## Control Registry
 
-Framework mappings are defined in `controls/registry.json`, which contains **294 control entries** (210 automated, 294 active, 84 manual-only). Each entry specifies the check ID, description, and mappings to all applicable frameworks.
+Framework mappings are defined in `controls/registry.json`, which contains **295 control entries** (211 automated, 295 active, 84 manual-only). Each entry specifies the check ID, description, and mappings to all applicable frameworks.
 
 To view or edit mappings:
 

--- a/src/M365-Assess/M365-Assess.psd1
+++ b/src/M365-Assess/M365-Assess.psd1
@@ -70,6 +70,7 @@
         'Common\SecurityConfigHelper.ps1'
         'Common\Connect-Service.ps1'
         'Common\Resolve-DnsRecord.ps1'
+        'Common\Resolve-TenantLicenses.ps1'
         'Common\Export-AssessmentReport.ps1'
         'Common\ReportHelpers.ps1'
         'Common\Build-SectionHtml.ps1'


### PR DESCRIPTION
## Summary
- Add `Common\Resolve-TenantLicenses.ps1` to `M365-Assess.psd1` FileList (missed in #333)
- Update `COMPLIANCE.md` registry count from 294 to 295 (new ENTRA-SECDEFAULT-002 from #332)

Fixes 2 metadata consistency test failures after v1.5.0 PRs merged.

## Test plan
- [ ] `Metadata-Consistency.Tests.ps1` passes (FileList + registry count)

🤖 Generated with [Claude Code](https://claude.com/claude-code)