### PR TITLE
fix: convert Value Opportunity collectors to orchestrator script pattern

### DIFF
--- a/src/M365-Assess/Invoke-M365Assessment.ps1
+++ b/src/M365-Assess/Invoke-M365Assessment.ps1
@@ -664,6 +664,12 @@ foreach ($sectionName in $Section) {
                 $collectorParams = $collector.Params.Clone()
             }
 
+            # Value Opportunity collectors need project root + assessment folder paths
+            if ($collector.ContainsKey('PassProjectContext') -and $collector.PassProjectContext) {
+                $collectorParams['ProjectRoot'] = $projectRoot
+                $collectorParams['AssessmentFolder'] = $assessmentFolder
+            }
+
             # Special handling for Secure Score (two outputs)
             if ($collector.ContainsKey('HasSecondary') -and $collector.HasSecondary) {
                 $secondaryCsvPath = Join-Path -Path $assessmentFolder -ChildPath "$($collector.SecondaryName).csv"

--- a/src/M365-Assess/Orchestrator/AssessmentMaps.ps1
+++ b/src/M365-Assess/Orchestrator/AssessmentMaps.ps1
@@ -133,9 +133,9 @@ $collectorMap = [ordered]@{
         @{ Name = '36-SOC2-Readiness-Checklist';     Script = 'SOC2\Get-SOC2ReadinessChecklist.ps1';     Label = 'SOC 2 Readiness Checklist' }
     )
     'ValueOpportunity' = @(
-        @{ Name = '40-License-Utilization'; Script = 'ValueOpportunity\Get-LicenseUtilization.ps1'; Label = 'License Utilization'; RequiredServices = @('Graph') }
-        @{ Name = '41-Feature-Adoption';    Script = 'ValueOpportunity\Get-FeatureAdoption.ps1';    Label = 'Feature Adoption' }
-        @{ Name = '42-Feature-Readiness';   Script = 'ValueOpportunity\Get-FeatureReadiness.ps1';   Label = 'Feature Readiness' }
+        @{ Name = '40-License-Utilization'; Script = 'ValueOpportunity\Get-LicenseUtilization.ps1'; Label = 'License Utilization'; RequiredServices = @('Graph'); PassProjectContext = $true }
+        @{ Name = '41-Feature-Adoption';    Script = 'ValueOpportunity\Get-FeatureAdoption.ps1';    Label = 'Feature Adoption'; PassProjectContext = $true }
+        @{ Name = '42-Feature-Readiness';   Script = 'ValueOpportunity\Get-FeatureReadiness.ps1';   Label = 'Feature Readiness'; PassProjectContext = $true }
     )
 }
 

--- a/src/M365-Assess/ValueOpportunity/Get-FeatureAdoption.ps1
+++ b/src/M365-Assess/ValueOpportunity/Get-FeatureAdoption.ps1
@@ -1,32 +1,26 @@
-function Get-FeatureAdoption {
-    <#
-    .SYNOPSIS
-        Scores feature adoption from assessment signals and license data.
-    .DESCRIPTION
-        For each feature in the sku-feature-map, determines adoption state by
-        cross-referencing assessment signals (collected by Add-SecuritySetting)
-        against the feature's checkIds. License utilization data gates whether
-        a feature is even available to the tenant.
+<#
+.SYNOPSIS
+    Scores feature adoption from assessment signals and license data.
+.DESCRIPTION
+    For each feature in sku-feature-map.json, determines adoption state by
+    cross-referencing signals accumulated by Add-SecuritySetting against
+    the feature's checkIds. Reads sibling License Utilization CSV for
+    license gating. Zero new API calls.
+.PARAMETER ProjectRoot
+    Path to the module root (contains controls/).
+.PARAMETER AssessmentFolder
+    Path to the assessment output folder (contains sibling CSVs).
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$ProjectRoot,
 
-        Adoption states: Adopted (100), Partial (1-99), NotAdopted (0),
-        NotLicensed (unlicensed), Unknown (licensed but no signals).
-    .PARAMETER AdoptionSignals
-        Hashtable keyed by sub-check IDs (e.g. ENTRA-PIM-001.1) with Status,
-        Setting, CurrentValue, and Category properties. Populated by the
-        AdoptionAccumulator during assessment collection.
-    .PARAMETER LicenseUtilization
-        Array of PSCustomObject from Get-LicenseUtilization with FeatureId
-        and IsLicensed properties.
-    .PARAMETER FeatureMap
-        Parsed sku-feature-map.json object containing features and categories.
-    .PARAMETER AssessmentFolder
-        Path to the assessment output folder for optional CSV signal parsing.
-    .PARAMETER OutputPath
-        Optional CSV output path for the adoption results.
-    .EXAMPLE
-        Get-FeatureAdoption -AdoptionSignals $signals -LicenseUtilization $license -FeatureMap $map -AssessmentFolder 'C:\output'
-        Returns per-feature adoption scores based on assessment signals.
-    #>
+    [Parameter()]
+    [string]$AssessmentFolder
+)
+
+function Get-FeatureAdoption {
     [CmdletBinding()]
     [OutputType([PSCustomObject[]])]
     param(
@@ -46,13 +40,11 @@ function Get-FeatureAdoption {
         [string]$OutputPath
     )
 
-    # Build category lookup
     $categories = @{}
     foreach ($cat in $FeatureMap.categories) {
         $categories[$cat.id] = $cat.name
     }
 
-    # Build license lookup
     $licenseLookup = @{}
     foreach ($lic in $LicenseUtilization) {
         $licenseLookup[$lic.FeatureId] = $lic.IsLicensed
@@ -65,22 +57,20 @@ function Get-FeatureAdoption {
             $isLicensed = $licenseLookup[$featureId]
         }
 
-        # Not licensed -- skip signal matching
         if (-not $isLicensed) {
             [PSCustomObject]@{
-                FeatureId    = $featureId
-                FeatureName  = $feature.name
-                Category     = $categories[$feature.category]
+                FeatureId     = $featureId
+                FeatureName   = $feature.name
+                Category      = $categories[$feature.category]
                 AdoptionState = 'NotLicensed'
                 AdoptionScore = 0
-                PassedChecks = 0
-                TotalChecks  = 0
-                DepthMetric  = ''
+                PassedChecks  = 0
+                TotalChecks   = 0
+                DepthMetric   = ''
             }
             continue
         }
 
-        # Match signals by base CheckId prefix
         $passedCount = 0
         $totalCount = 0
 
@@ -96,7 +86,6 @@ function Get-FeatureAdoption {
             }
         }
 
-        # Determine adoption state
         if ($totalCount -eq 0) {
             $adoptionState = 'Unknown'
             $adoptionScore = 0
@@ -114,17 +103,14 @@ function Get-FeatureAdoption {
             $adoptionScore = [math]::Round(($passedCount / $totalCount) * 100)
         }
 
-        # Optional CSV depth metrics
         $depthMetric = ''
         $csvSignals = $feature.csvSignals
-        if ($null -ne $csvSignals -and $csvSignals.Count -gt 0) {
+        if ($null -ne $csvSignals -and @($csvSignals).Count -gt 0) {
             $depthParts = @()
             foreach ($csvDef in $csvSignals) {
                 try {
                     $csvFile = Join-Path -Path $AssessmentFolder -ChildPath $csvDef.file
-                    if (-not (Test-Path -Path $csvFile)) {
-                        continue
-                    }
+                    if (-not (Test-Path -Path $csvFile)) { continue }
                     $csvData = Import-Csv -Path $csvFile -Encoding UTF8
 
                     if ($csvDef.metric -eq 'passRate') {
@@ -142,12 +128,11 @@ function Get-FeatureAdoption {
                         $column = $csvDef.column
                         $pattern = $csvDef.pattern
                         $matching = $csvData | Where-Object { $_.$column -match $pattern }
-                        $matchCount = @($matching).Count
-                        $depthParts += "$($csvDef.label): $matchCount"
+                        $depthParts += "$($csvDef.label): $(@($matching).Count)"
                     }
                 }
                 catch {
-                    Write-Verbose "Get-FeatureAdoption: CSV signal parsing failed for $($csvDef.file): $_"
+                    Write-Verbose "CSV signal parsing failed for $($csvDef.file): $_"
                 }
             }
             $depthMetric = $depthParts -join '; '
@@ -172,4 +157,33 @@ function Get-FeatureAdoption {
     else {
         Write-Output $results
     }
+}
+
+# --- Script entry point (called by orchestrator with -ProjectRoot) ---
+if ($ProjectRoot -and $AssessmentFolder) {
+    $featureMapPath = Join-Path -Path $ProjectRoot -ChildPath 'controls\sku-feature-map.json'
+    if (-not (Test-Path -Path $featureMapPath)) {
+        Write-Warning "sku-feature-map.json not found at $featureMapPath"
+        return
+    }
+    $featureMap = Get-Content -Path $featureMapPath -Raw | ConvertFrom-Json
+
+    $signals = @{}
+    if (Get-Command -Name Get-AdoptionSignals -ErrorAction SilentlyContinue) {
+        $signals = Get-AdoptionSignals
+    }
+
+    # Read sibling License Utilization CSV
+    $licCsvPath = Join-Path -Path $AssessmentFolder -ChildPath '40-License-Utilization.csv'
+    $licenseData = @()
+    if (Test-Path -Path $licCsvPath) {
+        $licenseData = @(Import-Csv -Path $licCsvPath -Encoding UTF8 | ForEach-Object {
+            [PSCustomObject]@{
+                FeatureId  = $_.FeatureId
+                IsLicensed = ($_.IsLicensed -eq 'True')
+            }
+        })
+    }
+
+    Get-FeatureAdoption -AdoptionSignals $signals -LicenseUtilization $licenseData -FeatureMap $featureMap -AssessmentFolder $AssessmentFolder
 }

--- a/src/M365-Assess/ValueOpportunity/Get-FeatureReadiness.ps1
+++ b/src/M365-Assess/ValueOpportunity/Get-FeatureReadiness.ps1
@@ -1,16 +1,25 @@
+<#
+.SYNOPSIS
+    Checks prerequisites for non-adopted features.
+.DESCRIPTION
+    For each feature in sku-feature-map.json, determines readiness state
+    (Ready/Blocked/NotLicensed) by checking license status and prerequisite
+    adoption. Reads sibling CSVs from the assessment folder. Zero API calls.
+.PARAMETER ProjectRoot
+    Path to the module root (contains controls/).
+.PARAMETER AssessmentFolder
+    Path to the assessment output folder (contains sibling CSVs).
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$ProjectRoot,
+
+    [Parameter()]
+    [string]$AssessmentFolder
+)
+
 function Get-FeatureReadiness {
-    <#
-    .SYNOPSIS
-        Checks prerequisites for non-adopted features.
-    .PARAMETER LicenseUtilization
-        Array from Get-LicenseUtilization.
-    .PARAMETER FeatureAdoption
-        Array from Get-FeatureAdoption.
-    .PARAMETER FeatureMap
-        Parsed sku-feature-map.json object.
-    .PARAMETER OutputPath
-        Optional CSV output path.
-    #>
     [CmdletBinding()]
     [OutputType([PSCustomObject[]])]
     param(
@@ -57,7 +66,6 @@ function Get-FeatureReadiness {
             continue
         }
 
-        # Check prerequisites
         foreach ($prereqId in $feature.prerequisites) {
             $prereqAdoption = $adoptionLookup[$prereqId]
             if (-not $prereqAdoption -or $prereqAdoption.AdoptionState -notin @('Adopted', 'Partial')) {
@@ -87,4 +95,34 @@ function Get-FeatureReadiness {
     else {
         Write-Output $results
     }
+}
+
+# --- Script entry point (called by orchestrator with -ProjectRoot) ---
+if ($ProjectRoot -and $AssessmentFolder) {
+    $featureMapPath = Join-Path -Path $ProjectRoot -ChildPath 'controls\sku-feature-map.json'
+    if (-not (Test-Path -Path $featureMapPath)) {
+        Write-Warning "sku-feature-map.json not found at $featureMapPath"
+        return
+    }
+    $featureMap = Get-Content -Path $featureMapPath -Raw | ConvertFrom-Json
+
+    # Read sibling CSVs
+    $licCsvPath = Join-Path -Path $AssessmentFolder -ChildPath '40-License-Utilization.csv'
+    $licenseData = @()
+    if (Test-Path -Path $licCsvPath) {
+        $licenseData = @(Import-Csv -Path $licCsvPath -Encoding UTF8 | ForEach-Object {
+            [PSCustomObject]@{
+                FeatureId  = $_.FeatureId
+                IsLicensed = ($_.IsLicensed -eq 'True')
+            }
+        })
+    }
+
+    $adpCsvPath = Join-Path -Path $AssessmentFolder -ChildPath '41-Feature-Adoption.csv'
+    $adoptionData = @()
+    if (Test-Path -Path $adpCsvPath) {
+        $adoptionData = @(Import-Csv -Path $adpCsvPath -Encoding UTF8)
+    }
+
+    Get-FeatureReadiness -LicenseUtilization $licenseData -FeatureAdoption $adoptionData -FeatureMap $featureMap
 }

--- a/src/M365-Assess/ValueOpportunity/Get-LicenseUtilization.ps1
+++ b/src/M365-Assess/ValueOpportunity/Get-LicenseUtilization.ps1
@@ -1,20 +1,27 @@
+<#
+.SYNOPSIS
+    Cross-references tenant licenses against the feature map.
+.DESCRIPTION
+    For each feature in sku-feature-map.json, checks if the tenant has any
+    of the required service plans. Outputs per-feature license status.
+    Called by the orchestrator as a data collector (with -ProjectRoot param)
+    or dot-sourced by tests to access the Get-LicenseUtilization function.
+.PARAMETER ProjectRoot
+    Path to the module root (contains controls/). When provided, runs as
+    a self-contained script.
+.PARAMETER AssessmentFolder
+    Path to the assessment output folder.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$ProjectRoot,
+
+    [Parameter()]
+    [string]$AssessmentFolder
+)
+
 function Get-LicenseUtilization {
-    <#
-    .SYNOPSIS
-        Cross-references tenant licenses against the feature map.
-    .DESCRIPTION
-        For each feature in sku-feature-map.json, checks if the tenant has any
-        of the required service plans. Returns per-feature license status.
-    .PARAMETER TenantLicenses
-        Hashtable from Resolve-TenantLicenses with ActiveServicePlans HashSet.
-    .PARAMETER FeatureMap
-        Parsed sku-feature-map.json object.
-    .PARAMETER OutputPath
-        Optional CSV output path.
-    .EXAMPLE
-        Get-LicenseUtilization -TenantLicenses $licenses -FeatureMap $featureMap
-        Returns one PSCustomObject per feature with IsLicensed status.
-    #>
     [CmdletBinding()]
     [OutputType([PSCustomObject[]])]
     param(
@@ -38,7 +45,6 @@ function Get-LicenseUtilization {
         $sourceSkus = @()
 
         foreach ($plan in $feature.requiredServicePlans) {
-            # "STANDARD" is a sentinel meaning "available in any M365 tenant"
             if ($plan -eq 'STANDARD') {
                 $isLicensed = $true
                 $sourceSkus += 'E3 Baseline'
@@ -68,4 +74,24 @@ function Get-LicenseUtilization {
     else {
         Write-Output $results
     }
+}
+
+# --- Script entry point (called by orchestrator with -ProjectRoot) ---
+if ($ProjectRoot) {
+    $featureMapPath = Join-Path -Path $ProjectRoot -ChildPath 'controls\sku-feature-map.json'
+    if (-not (Test-Path -Path $featureMapPath)) {
+        Write-Warning "sku-feature-map.json not found at $featureMapPath"
+        return
+    }
+    $featureMap = Get-Content -Path $featureMapPath -Raw | ConvertFrom-Json
+
+    $resolverPath = Join-Path -Path $ProjectRoot -ChildPath 'Common\Resolve-TenantLicenses.ps1'
+    if (-not (Test-Path -Path $resolverPath)) {
+        Write-Warning "Resolve-TenantLicenses.ps1 not found"
+        return
+    }
+    . $resolverPath
+    $tenantLicenses = Resolve-TenantLicenses
+
+    Get-LicenseUtilization -TenantLicenses $tenantLicenses -FeatureMap $featureMap
 }


### PR DESCRIPTION
## Summary
Fix collectors returning 0 items when run via orchestrator. The scripts defined functions but never called them.

- Dual-mode scripts: define functions (for tests + report assembly) AND execute as self-contained scripts when `ProjectRoot` is provided (for orchestrator)
- New `PassProjectContext` flag on collector map entries passes `ProjectRoot` + `AssessmentFolder`
- Chaining: Feature Adoption reads License Utilization CSV, Feature Readiness reads both sibling CSVs
- All 50 affected tests pass

## Test plan
- [x] 50/50 ValueOpportunity + orchestrator + metadata tests pass
- [ ] Re-test with live tenant: collectors should now produce 52 items each

🤖 Generated with [Claude Code](https://claude.com/claude-code)