### PR TITLE
fix: use global scope for adoption signals

### DIFF
--- a/src/M365-Assess/Common/SecurityConfigHelper.ps1
+++ b/src/M365-Assess/Common/SecurityConfigHelper.ps1
@@ -29,7 +29,7 @@ function Initialize-SecurityConfig {
     [OutputType([hashtable])]
     param()
 
-    $script:AdoptionSignals = @{}
+    $global:AdoptionSignals = @{}
     @{
         Settings       = [System.Collections.Generic.List[PSCustomObject]]::new()
         CheckIdCounter = @{}
@@ -118,7 +118,7 @@ function Add-SecuritySetting {
 
     # Accumulate adoption signal for Value Opportunity analysis
     if ($CheckId) {
-        $script:AdoptionSignals[$subCheckId] = @{
+        $global:AdoptionSignals[$subCheckId] = @{
             Status       = $Status
             Setting      = $Setting
             CurrentValue = $CurrentValue
@@ -186,8 +186,8 @@ function Get-AdoptionSignals {
     [OutputType([hashtable])]
     param()
 
-    if ($script:AdoptionSignals) {
-        return $script:AdoptionSignals.Clone()
+    if ($global:AdoptionSignals) {
+        return $global:AdoptionSignals.Clone()
     }
     return @{}
 }

--- a/src/M365-Assess/ValueOpportunity/Get-FeatureAdoption.ps1
+++ b/src/M365-Assess/ValueOpportunity/Get-FeatureAdoption.ps1
@@ -172,6 +172,9 @@ if ($ProjectRoot -and $AssessmentFolder) {
     if (Get-Command -Name Get-AdoptionSignals -ErrorAction SilentlyContinue) {
         $signals = Get-AdoptionSignals
     }
+    elseif ($global:AdoptionSignals) {
+        $signals = $global:AdoptionSignals.Clone()
+    }
 
     # Read sibling License Utilization CSV
     $licCsvPath = Join-Path -Path $AssessmentFolder -ChildPath '40-License-Utilization.csv'


### PR DESCRIPTION
## Summary
Adoption signals were inaccessible to Value Opportunity collectors. `$script:AdoptionSignals` in SecurityConfigHelper was only visible within that file's scope, not to child scripts called via `&` by the orchestrator.

Fix: `$script:AdoptionSignals` -> `$global:AdoptionSignals`, matching the existing `$global:CheckProgressState` pattern. Added fallback in Get-FeatureAdoption.ps1.

## Test plan
- [x] 110/110 tests pass
- [ ] Re-test live: Feature Adoption should now show real adoption states instead of all "Unknown"

🤖 Generated with [Claude Code](https://claude.com/claude-code)