### PR TITLE
fix: preserve adoption signals across collectors

### DIFF
--- a/src/M365-Assess/Common/SecurityConfigHelper.ps1
+++ b/src/M365-Assess/Common/SecurityConfigHelper.ps1
@@ -29,7 +29,7 @@ function Initialize-SecurityConfig {
     [OutputType([hashtable])]
     param()
 
-    $global:AdoptionSignals = @{}
+    if (-not $global:AdoptionSignals) { $global:AdoptionSignals = @{} }
     @{
         Settings       = [System.Collections.Generic.List[PSCustomObject]]::new()
         CheckIdCounter = @{}

--- a/tests/Common/SecurityConfigContract.Tests.ps1
+++ b/tests/Common/SecurityConfigContract.Tests.ps1
@@ -188,6 +188,10 @@ Describe 'Adoption Signal Accumulator' {
         . "$PSScriptRoot/../../src/M365-Assess/Common/SecurityConfigHelper.ps1"
     }
 
+    BeforeEach {
+        $global:AdoptionSignals = $null
+    }
+
     It 'Should initialize with empty adoption signals' {
         $ctx = Initialize-SecurityConfig
         $signals = Get-AdoptionSignals


### PR DESCRIPTION
Each collector's Initialize-SecurityConfig was wiping signals. Now only initializes if empty.