### PR TITLE
fix: rename Analyze-ValueOpportunity + extract M365 Average from AdditionalProperties

### DIFF
--- a/src/M365-Assess/Common/Build-ValueOpportunityHtml.ps1
+++ b/src/M365-Assess/Common/Build-ValueOpportunityHtml.ps1
@@ -9,7 +9,7 @@ function Build-ValueOpportunityHtml {
         StringBuilder for efficient string building and follows existing report
         HTML conventions.
     .PARAMETER Analysis
-        Hashtable from Analyze-ValueOpportunity containing OverallAdoptionPct,
+        Hashtable from Measure-ValueOpportunity containing OverallAdoptionPct,
         LicensedFeatureCount, AdoptedFeatureCount, PartialFeatureCount, GapCount,
         CategoryBreakdown, Roadmap, GapMatrix, and NotLicensedFeatures.
     .EXAMPLE

--- a/src/M365-Assess/Common/Export-AssessmentReport.ps1
+++ b/src/M365-Assess/Common/Export-AssessmentReport.ps1
@@ -326,7 +326,7 @@ $featureMapPath = Join-Path -Path $projectRoot -ChildPath 'controls' -Additional
 if ((Test-Path -Path $voLicensePath) -and (Test-Path -Path $voAdoptionPath) -and (Test-Path -Path $voReadinessPath) -and (Test-Path -Path $featureMapPath)) {
     try {
         . (Join-Path -Path $PSScriptRoot -ChildPath 'Build-ValueOpportunityHtml.ps1')
-        . (Join-Path -Path $projectRoot -ChildPath 'ValueOpportunity' -AdditionalChildPath 'Analyze-ValueOpportunity.ps1')
+        . (Join-Path -Path $projectRoot -ChildPath 'ValueOpportunity' -AdditionalChildPath 'Measure-ValueOpportunity.ps1')
 
         $featureMap = Get-Content -Path $featureMapPath -Raw | ConvertFrom-Json
         $voLicense = Import-Csv -Path $voLicensePath
@@ -338,7 +338,7 @@ if ((Test-Path -Path $voLicensePath) -and (Test-Path -Path $voAdoptionPath) -and
             $row.IsLicensed = $row.IsLicensed -eq 'True'
         }
 
-        $voAnalysis = Analyze-ValueOpportunity -LicenseUtilization $voLicense -FeatureAdoption $voAdoption -FeatureReadiness $voReadiness -FeatureMap $featureMap
+        $voAnalysis = Measure-ValueOpportunity -LicenseUtilization $voLicense -FeatureAdoption $voAdoption -FeatureReadiness $voReadiness -FeatureMap $featureMap
         $valueOpportunityHtml = Build-ValueOpportunityHtml -Analysis $voAnalysis
     }
     catch {

--- a/src/M365-Assess/M365-Assess.psd1
+++ b/src/M365-Assess/M365-Assess.psd1
@@ -150,7 +150,7 @@
         'ValueOpportunity\Get-LicenseUtilization.ps1'
         'ValueOpportunity\Get-FeatureAdoption.ps1'
         'ValueOpportunity\Get-FeatureReadiness.ps1'
-        'ValueOpportunity\Analyze-ValueOpportunity.ps1'
+        'ValueOpportunity\Measure-ValueOpportunity.ps1'
         'Networking\Test-PortConnectivity.ps1'
         'Windows\Get-InstalledSoftware.ps1'
         'controls\role-tiers.json'

--- a/src/M365-Assess/ValueOpportunity/Measure-ValueOpportunity.ps1
+++ b/src/M365-Assess/ValueOpportunity/Measure-ValueOpportunity.ps1
@@ -1,4 +1,4 @@
-function Analyze-ValueOpportunity {
+function Measure-ValueOpportunity {
     <#
     .SYNOPSIS
         Merges license utilization, feature adoption, and readiness into a unified analysis.

--- a/tests/ValueOpportunity/Measure-ValueOpportunity.Tests.ps1
+++ b/tests/ValueOpportunity/Measure-ValueOpportunity.Tests.ps1
@@ -1,8 +1,8 @@
 BeforeAll {
-    . "$PSScriptRoot/../../src/M365-Assess/ValueOpportunity/Analyze-ValueOpportunity.ps1"
+    . "$PSScriptRoot/../../src/M365-Assess/ValueOpportunity/Measure-ValueOpportunity.ps1"
 }
 
-Describe 'Analyze-ValueOpportunity' {
+Describe 'Measure-ValueOpportunity' {
     BeforeAll {
         $script:mockFeatureMap = @{
             categories = @(
@@ -37,14 +37,14 @@ Describe 'Analyze-ValueOpportunity' {
     }
 
     It 'Should calculate overall adoption percentage from licensed features' {
-        $result = Analyze-ValueOpportunity -LicenseUtilization $script:mockLicense -FeatureAdoption $script:mockAdoption -FeatureReadiness $script:mockReadiness -FeatureMap $script:mockFeatureMap
+        $result = Measure-ValueOpportunity -LicenseUtilization $script:mockLicense -FeatureAdoption $script:mockAdoption -FeatureReadiness $script:mockReadiness -FeatureMap $script:mockFeatureMap
         # 3 licensed features: f1 (Adopted), f2 (NotAdopted), f4 (Partial)
         # 2 of 3 are adopted/partial = 67%
         $result.OverallAdoptionPct | Should -Be 67
     }
 
     It 'Should count licensed and adopted features' {
-        $result = Analyze-ValueOpportunity -LicenseUtilization $script:mockLicense -FeatureAdoption $script:mockAdoption -FeatureReadiness $script:mockReadiness -FeatureMap $script:mockFeatureMap
+        $result = Measure-ValueOpportunity -LicenseUtilization $script:mockLicense -FeatureAdoption $script:mockAdoption -FeatureReadiness $script:mockReadiness -FeatureMap $script:mockFeatureMap
         $result.LicensedFeatureCount | Should -Be 3
         $result.AdoptedFeatureCount | Should -Be 1
         $result.PartialFeatureCount | Should -Be 1
@@ -52,7 +52,7 @@ Describe 'Analyze-ValueOpportunity' {
     }
 
     It 'Should produce category breakdown' {
-        $result = Analyze-ValueOpportunity -LicenseUtilization $script:mockLicense -FeatureAdoption $script:mockAdoption -FeatureReadiness $script:mockReadiness -FeatureMap $script:mockFeatureMap
+        $result = Measure-ValueOpportunity -LicenseUtilization $script:mockLicense -FeatureAdoption $script:mockAdoption -FeatureReadiness $script:mockReadiness -FeatureMap $script:mockFeatureMap
         $result.CategoryBreakdown.Count | Should -Be 2
         $idCat = $result.CategoryBreakdown | Where-Object { $_.Category -eq 'Identity & Access' }
         $idCat.Licensed | Should -Be 2
@@ -60,14 +60,14 @@ Describe 'Analyze-ValueOpportunity' {
     }
 
     It 'Should produce roadmap with only licensed not-adopted features' {
-        $result = Analyze-ValueOpportunity -LicenseUtilization $script:mockLicense -FeatureAdoption $script:mockAdoption -FeatureReadiness $script:mockReadiness -FeatureMap $script:mockFeatureMap
+        $result = Measure-ValueOpportunity -LicenseUtilization $script:mockLicense -FeatureAdoption $script:mockAdoption -FeatureReadiness $script:mockReadiness -FeatureMap $script:mockFeatureMap
         # f2 is licensed + NotAdopted + Medium effort
         $result.Roadmap['Medium'].Count | Should -Be 1
         $result.Roadmap['Medium'][0].FeatureId | Should -Be 'f2'
     }
 
     It 'Should list not-licensed features separately' {
-        $result = Analyze-ValueOpportunity -LicenseUtilization $script:mockLicense -FeatureAdoption $script:mockAdoption -FeatureReadiness $script:mockReadiness -FeatureMap $script:mockFeatureMap
+        $result = Measure-ValueOpportunity -LicenseUtilization $script:mockLicense -FeatureAdoption $script:mockAdoption -FeatureReadiness $script:mockReadiness -FeatureMap $script:mockFeatureMap
         $result.NotLicensedFeatures.Count | Should -Be 1
         $result.NotLicensedFeatures[0].FeatureId | Should -Be 'f3'
     }
@@ -85,7 +85,7 @@ Describe 'Analyze-ValueOpportunity' {
             [PSCustomObject]@{ FeatureId = 'f3'; FeatureName = 'F3'; Category = 'Email Security'; AdoptionState = 'NotLicensed'; AdoptionScore = 0 }
             [PSCustomObject]@{ FeatureId = 'f4'; FeatureName = 'F4'; Category = 'Email Security'; AdoptionState = 'NotLicensed'; AdoptionScore = 0 }
         )
-        $result = Analyze-ValueOpportunity -LicenseUtilization $emptyLicense -FeatureAdoption $allNotLicensed -FeatureReadiness $script:mockReadiness -FeatureMap $script:mockFeatureMap
+        $result = Measure-ValueOpportunity -LicenseUtilization $emptyLicense -FeatureAdoption $allNotLicensed -FeatureReadiness $script:mockReadiness -FeatureMap $script:mockFeatureMap
         $result.OverallAdoptionPct | Should -Be 0
         $result.LicensedFeatureCount | Should -Be 0
     }


### PR DESCRIPTION
## Summary
- Renames `Analyze-ValueOpportunity` to `Measure-ValueOpportunity` -- `Analyze` is not an approved PowerShell verb, causing PSScriptAnalyzer to fail CI Quality Gates since PR #340
- Fixes M365 Average showing N/A in Secure Score dashboard by adding `AdditionalProperties` fallback for `AverageComparativeScores` (Graph SDK deserialization quirk)
- Adds stub functions for Graph cmdlets so Pester mocks work without Microsoft.Graph.Security installed locally

## Test plan
- [x] PSScriptAnalyzer: zero warnings/errors
- [x] Pester: 23/23 ValueOpportunity tests + 7/7 SecureScore tests passing
- [ ] CI Quality Gates + Pester matrix pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)