### PR TITLE
fix: show QuickScan banner on every page in paginated mode

### DIFF
--- a/src/M365-Assess/Common/Get-ReportTemplate.ps1
+++ b/src/M365-Assess/Common/Get-ReportTemplate.ps1
@@ -2571,18 +2571,18 @@ if (-not $SkipCoverPage) {
 "@
 }
 
-# Overview page: cover + exec summary + org profile combined
-$html += @"
-
-        <div class="report-page page-active" data-page="overview" id="overview">
-"@
-
 if ($QuickScan) {
     $html += @"
 
         <div class="quickscan-banner">Quick Scan Mode &mdash; showing Critical and High severity findings only</div>
 "@
 }
+
+# Overview page: cover + exec summary + org profile combined
+$html += @"
+
+        <div class="report-page page-active" data-page="overview" id="overview">
+"@
 
 if (-not $SkipCoverPage) {
     # Full cover page (print only, hidden on screen)


### PR DESCRIPTION
## Summary
Move the QuickScan amber banner from inside the overview `report-page` to above all `report-page` divs, same pattern as the hero banner fix in PR #356.

Closes #359

## Test plan
- [x] 1,147 Pester tests pass
- [ ] Run with `-QuickScan` and verify banner persists across page navigation


🤖 Generated with [Claude Code](https://claude.com/claude-code)