### PR TITLE
feat: add -WhatIf dry run mode for assessment preview

### DIFF
--- a/src/M365-Assess/Invoke-M365Assessment.ps1
+++ b/src/M365-Assess/Invoke-M365Assessment.ps1
@@ -77,6 +77,10 @@
     Run only Critical and High severity checks. Useful for CI/CD pipelines
     and daily monitoring. Collectors with no qualifying checks are skipped
     entirely. The report shows a "Quick Scan Mode" banner.
+.PARAMETER WhatIf
+    Show a dry-run preview of what the assessment would do (sections,
+    services, Graph scopes, check counts) without connecting or collecting
+    data. Useful for validating configuration before a real run.
 .PARAMETER NonInteractive
     Suppresses all interactive prompts for module installation, EXO downgrade,
     and script unblocking. When a required module is missing or incompatible,
@@ -111,6 +115,11 @@
 
     Runs a full assessment using device code auth. You choose which browser profile
     to authenticate in (useful for multi-profile machines).
+.EXAMPLE
+    PS> Invoke-M365Assessment -TenantId 'contoso.onmicrosoft.com' -Section Identity,Email -WhatIf
+
+    Shows a dry-run preview: sections, services, Graph scopes, and check counts
+    without connecting or collecting any data.
 #>
 #Requires -Version 7.0
 
@@ -195,7 +204,10 @@ param(
     [switch]$NonInteractive,
 
     [Parameter()]
-    [switch]$QuickScan
+    [switch]$QuickScan,
+
+    [Parameter()]
+    [switch]$WhatIf
 )
 
 $ErrorActionPreference = 'Stop'
@@ -539,6 +551,62 @@ $sectionOrder = @(
     'ValueOpportunity'  # Must run last — reads adoption signals from all other sections
 )
 $Section = $sectionOrder | Where-Object { $_ -in $Section }
+
+# ------------------------------------------------------------------
+# WhatIf — dry run preview, then exit
+# ------------------------------------------------------------------
+if ($WhatIf) {
+    Write-Host ''
+    Write-Host '  ── Dry Run Preview ──' -ForegroundColor Cyan
+    Write-Host ''
+    Write-Host "  Tenant:       $TenantId" -ForegroundColor White
+    Write-Host "  Environment:  $M365Environment" -ForegroundColor White
+    Write-Host "  Version:      v$script:AssessmentVersion" -ForegroundColor White
+    Write-Host "  Output:       $assessmentFolder" -ForegroundColor White
+    if ($QuickScan) { Write-Host '  Mode:         QuickScan (Critical + High only)' -ForegroundColor Yellow }
+    Write-Host ''
+
+    # Sections and their services
+    Write-Host '  Sections:' -ForegroundColor Cyan
+    foreach ($s in $Section) {
+        $services = if ($sectionServiceMap.ContainsKey($s)) { $sectionServiceMap[$s] -join ', ' } else { '(none)' }
+        $collectorCount = if ($collectorMap.ContainsKey($s)) { $collectorMap[$s].Count } else { 0 }
+        Write-Host "    $([char]0x25B8) $s — $collectorCount collectors — services: $services" -ForegroundColor DarkGray
+    }
+    Write-Host ''
+
+    # Graph scopes
+    if ($graphScopes -and $graphScopes.Count -gt 0) {
+        Write-Host "  Graph scopes ($($graphScopes.Count)):" -ForegroundColor Cyan
+        foreach ($scope in ($graphScopes | Sort-Object)) {
+            Write-Host "    $scope" -ForegroundColor DarkGray
+        }
+        Write-Host ''
+    }
+
+    # Check counts from progress state
+    if ($global:CheckProgressState) {
+        $totalChecks = $global:CheckProgressState.Total
+        $collectorCounts = $global:CheckProgressState.CollectorCounts
+        Write-Host "  Security checks: $totalChecks queued" -ForegroundColor Cyan
+        if ($collectorCounts) {
+            foreach ($cn in $collectorCounts.Keys) {
+                Write-Host "    $([char]0x25B8) $cn — $($collectorCounts[$cn]) checks" -ForegroundColor DarkGray
+            }
+        }
+        Write-Host ''
+    }
+
+    Write-Host '  No connections made. No data collected.' -ForegroundColor DarkGray
+    Write-Host '  Remove -WhatIf to run the assessment.' -ForegroundColor DarkGray
+    Write-Host ''
+
+    # Clean up the empty output folder created earlier
+    if (Test-Path -Path $assessmentFolder) {
+        Remove-Item -Path $assessmentFolder -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    return
+}
 
 foreach ($sectionName in $Section) {
     if (-not $collectorMap.Contains($sectionName)) {


### PR DESCRIPTION
## Summary
Add `-WhatIf` switch to `Invoke-M365Assessment` that shows a dry-run preview without connecting to any services:

```
  ── Dry Run Preview ──

  Tenant:       contoso.onmicrosoft.com
  Environment:  commercial
  Version:      v1.6.0
  Output:       .\M365-Assessment\Assessment_20260406_120000_contoso

  Sections:
    ▸ Tenant -- 1 collectors -- services: Graph
    ▸ Identity -- 3 collectors -- services: Graph
    ...

  Graph scopes (24):
    AuditLog.Read.All
    Directory.Read.All
    ...

  Security checks: 174 queued
    ▸ Entra -- 64 checks
    ...

  No connections made. No data collected.
  Remove -WhatIf to run the assessment.
```

Closes #363

## Test plan
- [x] 1,147 Pester tests pass
- [ ] Run `Invoke-M365Assessment -TenantId contoso.com -WhatIf` and verify preview output
- [ ] Verify no output folder is left behind after WhatIf exits


🤖 Generated with [Claude Code](https://claude.com/claude-code)