### PR TITLE
feat: add 5 new Conditional Access security checks

### DIFF
--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -73,7 +73,7 @@ The assessment suite includes **191 automated security checks** across 15 securi
 
 ## Control Registry
 
-Framework mappings are defined in `controls/registry.json`, which contains **295 control entries** (211 automated, 295 active, 84 manual-only). Each entry specifies the check ID, description, and mappings to all applicable frameworks.
+Framework mappings are defined in `controls/registry.json`, which contains **298 control entries** (214 automated, 298 active, 84 manual-only). Each entry specifies the check ID, description, and mappings to all applicable frameworks.
 
 To view or edit mappings:
 

--- a/src/M365-Assess/Entra/Get-CASecurityConfig.ps1
+++ b/src/M365-Assess/Entra/Get-CASecurityConfig.ps1
@@ -686,6 +686,242 @@ catch {
 }
 
 # ------------------------------------------------------------------
+# 13. Report-Only Policies (stale auditing)
+# ------------------------------------------------------------------
+try {
+    Write-Verbose "Checking CA: Report-only policies..."
+    $reportOnlyPolicies = @($allPolicies | Where-Object { $_['state'] -eq 'enabledForReportingButNotEnforced' })
+
+    if ($reportOnlyPolicies.Count -eq 0) {
+        $settingParams = @{
+            Category         = 'Conditional Access'
+            Setting          = 'Report-Only Policies'
+            CurrentValue     = 'None'
+            RecommendedValue = 'Review and promote or remove'
+            Status           = 'Pass'
+            CheckId          = 'CA-REPORTONLY-001'
+            Remediation      = 'No action needed.'
+        }
+        Add-Setting @settingParams
+    }
+    else {
+        $names = ($reportOnlyPolicies | ForEach-Object { $_['displayName'] }) -join '; '
+        $settingParams = @{
+            Category         = 'Conditional Access'
+            Setting          = 'Report-Only Policies'
+            CurrentValue     = "$($reportOnlyPolicies.Count) policies in report-only: $names"
+            RecommendedValue = 'Review and promote or remove'
+            Status           = 'Warning'
+            CheckId          = 'CA-REPORTONLY-001'
+            Remediation      = 'Review report-only policies and either enable enforcement or remove if no longer needed. Entra admin center > Protection > Conditional Access.'
+        }
+        Add-Setting @settingParams
+    }
+}
+catch {
+    Write-Warning "Could not check CA report-only policies: $_"
+}
+
+# ------------------------------------------------------------------
+# 14. Named Locations Risk (IP-based trusted locations)
+# ------------------------------------------------------------------
+try {
+    Write-Verbose "Checking CA: Named location risk..."
+    $namedLocResponse = Invoke-MgGraphRequest -Method GET -Uri '/v1.0/identity/conditionalAccess/namedLocations' -ErrorAction Stop
+    $namedLocations = if ($namedLocResponse -and $namedLocResponse['value']) { @($namedLocResponse['value']) } else { @() }
+    $ipLocations = @($namedLocations | Where-Object {
+        $_['@odata.type'] -eq '#microsoft.graph.ipNamedLocation' -and $_['isTrusted'] -eq $true
+    })
+
+    if ($ipLocations.Count -eq 0) {
+        $settingParams = @{
+            Category         = 'Conditional Access'
+            Setting          = 'Trusted IP Named Locations'
+            CurrentValue     = 'None configured'
+            RecommendedValue = 'Use country-based or compliant network locations'
+            Status           = 'Pass'
+            CheckId          = 'CA-NAMEDLOC-001'
+            Remediation      = 'No action needed.'
+        }
+        Add-Setting @settingParams
+    }
+    else {
+        $names = ($ipLocations | ForEach-Object { $_['displayName'] }) -join '; '
+        $settingParams = @{
+            Category         = 'Conditional Access'
+            Setting          = 'Trusted IP Named Locations'
+            CurrentValue     = "$($ipLocations.Count) trusted IP locations: $names"
+            RecommendedValue = 'Prefer compliant network or country-based locations'
+            Status           = 'Review'
+            CheckId          = 'CA-NAMEDLOC-001'
+            Remediation      = 'IP-based trusted locations can be spoofed via VPN or proxy. Consider Global Secure Access compliant network checks or country-based locations for stronger assurance. Entra admin center > Protection > Conditional Access > Named locations.'
+        }
+        Add-Setting @settingParams
+    }
+}
+catch {
+    Write-Warning "Could not check CA named locations: $_"
+}
+
+# ------------------------------------------------------------------
+# 15. Persistent Browser Session Without Device Compliance
+# ------------------------------------------------------------------
+try {
+    Write-Verbose "Checking CA: Persistent browser sessions..."
+    $persistentBrowserPolicies = @($enabledPolicies | Where-Object {
+        $sessionControls = $_['sessionControls']
+        $persistentBrowser = if ($sessionControls) { $sessionControls['persistentBrowser'] } else { $null }
+        $persistentBrowser -and $persistentBrowser['mode'] -eq 'always' -and $persistentBrowser['isEnabled'] -eq $true
+    })
+
+    # Check if any of those also require device compliance
+    $persistentWithoutDevice = @($persistentBrowserPolicies | Where-Object {
+        $grantControls = $_['grantControls']['builtInControls']
+        -not ($grantControls -contains 'compliantDevice' -or $grantControls -contains 'domainJoinedDevice')
+    })
+
+    if ($persistentWithoutDevice.Count -eq 0) {
+        $settingParams = @{
+            Category         = 'Conditional Access'
+            Setting          = 'Persistent Browser Without Device Compliance'
+            CurrentValue     = 'None'
+            RecommendedValue = 'No persistent sessions without device compliance'
+            Status           = 'Pass'
+            CheckId          = 'CA-SESSION-001'
+            Remediation      = 'No action needed.'
+        }
+        Add-Setting @settingParams
+    }
+    else {
+        $names = ($persistentWithoutDevice | ForEach-Object { $_['displayName'] }) -join '; '
+        $settingParams = @{
+            Category         = 'Conditional Access'
+            Setting          = 'Persistent Browser Without Device Compliance'
+            CurrentValue     = "$($persistentWithoutDevice.Count) policies allow persistent sessions without device compliance: $names"
+            RecommendedValue = 'No persistent sessions without device compliance'
+            Status           = 'Warning'
+            CheckId          = 'CA-SESSION-001'
+            Remediation      = 'Persistent browser sessions on unmanaged devices increase the risk of session hijacking. Require device compliance or remove persistent browser grants. Entra admin center > Protection > Conditional Access.'
+        }
+        Add-Setting @settingParams
+    }
+}
+catch {
+    Write-Warning "Could not check CA persistent browser sessions: $_"
+}
+
+# ------------------------------------------------------------------
+# 16. Combined Sign-in Risk + User Risk Anti-Pattern
+# ------------------------------------------------------------------
+try {
+    Write-Verbose "Checking CA: Risk policy anti-pattern..."
+    $combinedRiskPolicies = @($enabledPolicies | Where-Object {
+        $conditions = $_['conditions']
+        $signInRisk = $conditions['signInRiskLevels']
+        $userRisk = $conditions['userRiskLevels']
+        ($signInRisk -and $signInRisk.Count -gt 0) -and ($userRisk -and $userRisk.Count -gt 0)
+    })
+
+    if ($combinedRiskPolicies.Count -eq 0) {
+        $settingParams = @{
+            Category         = 'Conditional Access'
+            Setting          = 'Combined Risk Policy Anti-Pattern'
+            CurrentValue     = 'None'
+            RecommendedValue = 'Separate sign-in risk and user risk into distinct policies'
+            Status           = 'Pass'
+            CheckId          = 'CA-RISKPOLICY-001'
+            Remediation      = 'No action needed.'
+        }
+        Add-Setting @settingParams
+    }
+    else {
+        $names = ($combinedRiskPolicies | ForEach-Object { $_['displayName'] }) -join '; '
+        $settingParams = @{
+            Category         = 'Conditional Access'
+            Setting          = 'Combined Risk Policy Anti-Pattern'
+            CurrentValue     = "$($combinedRiskPolicies.Count) policies combine both risk types: $names"
+            RecommendedValue = 'Separate sign-in risk and user risk into distinct policies'
+            Status           = 'Warning'
+            CheckId          = 'CA-RISKPOLICY-001'
+            Remediation      = 'Combining sign-in risk and user risk in one CA policy creates an AND condition -- both must be true to trigger. Microsoft recommends separate policies for each risk type. Entra admin center > Protection > Conditional Access.'
+        }
+        Add-Setting @settingParams
+    }
+}
+catch {
+    Write-Warning "Could not check CA risk policy anti-pattern: $_"
+}
+
+# ------------------------------------------------------------------
+# 17. Directory Role Coverage Gaps
+# ------------------------------------------------------------------
+try {
+    Write-Verbose "Checking CA: Role coverage gaps..."
+    # Get active role assignments to find which Tier-0 roles are actually in use
+    $roleAssignments = Invoke-MgGraphRequest -Method GET -Uri '/v1.0/roleManagement/directory/roleAssignments?$top=999' -ErrorAction Stop
+    $activeRoleIds = @($roleAssignments['value'] | ForEach-Object { $_['roleDefinitionId'] } | Sort-Object -Unique)
+
+    # Find CA policies that target specific directory roles (not "All users")
+    $roleTargetingPolicies = @($enabledPolicies | Where-Object {
+        $includeRoles = $_['conditions']['users']['includeRoles']
+        $includeRoles -and $includeRoles.Count -gt 0
+    })
+
+    if ($roleTargetingPolicies.Count -eq 0) {
+        $settingParams = @{
+            Category         = 'Conditional Access'
+            Setting          = 'Tier-0 Role Coverage in CA Policies'
+            CurrentValue     = 'No role-targeted CA policies found'
+            RecommendedValue = 'Target active privileged roles'
+            Status           = 'Review'
+            CheckId          = 'CA-ROLECOVERAGE-001'
+            Remediation      = 'Consider creating CA policies that specifically target privileged directory roles with stricter controls (phishing-resistant MFA, compliant devices).'
+        }
+        Add-Setting @settingParams
+    }
+    else {
+        # Collect all roles covered by CA policies
+        $coveredRoles = [System.Collections.Generic.HashSet[string]]::new()
+        foreach ($p in $roleTargetingPolicies) {
+            foreach ($r in $p['conditions']['users']['includeRoles']) {
+                [void]$coveredRoles.Add($r)
+            }
+        }
+        # Find active Tier-0 roles not covered by any CA policy
+        $tier0Roles = @($adminRoleIds | Where-Object { $_ -in $activeRoleIds })
+        $uncoveredRoles = @($tier0Roles | Where-Object { -not $coveredRoles.Contains($_) })
+
+        if ($uncoveredRoles.Count -eq 0) {
+            $settingParams = @{
+                Category         = 'Conditional Access'
+                Setting          = 'Tier-0 Role Coverage in CA Policies'
+                CurrentValue     = "All $($tier0Roles.Count) active Tier-0 roles covered"
+                RecommendedValue = 'All active privileged roles covered'
+                Status           = 'Pass'
+                CheckId          = 'CA-ROLECOVERAGE-001'
+                Remediation      = 'No action needed.'
+            }
+            Add-Setting @settingParams
+        }
+        else {
+            $settingParams = @{
+                Category         = 'Conditional Access'
+                Setting          = 'Tier-0 Role Coverage in CA Policies'
+                CurrentValue     = "$($uncoveredRoles.Count) of $($tier0Roles.Count) active Tier-0 roles not targeted by any CA policy"
+                RecommendedValue = 'All active privileged roles covered'
+                Status           = 'Warning'
+                CheckId          = 'CA-ROLECOVERAGE-001'
+                Remediation      = 'Add the uncovered role IDs to existing admin-targeted CA policies. Entra admin center > Protection > Conditional Access > Select policy > Users > Include roles.'
+            }
+            Add-Setting @settingParams
+        }
+    }
+}
+catch {
+    Write-Warning "Could not check CA role coverage: $_"
+}
+
+# ------------------------------------------------------------------
 # Output
 # ------------------------------------------------------------------
 Export-SecurityConfigReport -Settings $settings -OutputPath $OutputPath -ServiceLabel 'Conditional Access'

--- a/src/M365-Assess/controls/registry.json
+++ b/src/M365-Assess/controls/registry.json
@@ -7830,6 +7830,122 @@
       "supersededBy": "CA-DEVICECODE-001"
     },
     {
+      "checkId": "CA-REPORTONLY-001",
+      "name": "Conditional Access policies in report-only mode",
+      "category": "REPORTONLY",
+      "collector": "CAEvaluator",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "requiredServicePlans": []
+      },
+      "frameworks": {
+        "nist-800-53": {
+          "controlId": "CM-3",
+          "title": "Configuration Change Control",
+          "profiles": ["Moderate", "High"]
+        },
+        "nist-csf": {
+          "controlId": "PR.IP-01",
+          "title": "Configuration management processes are established"
+        },
+        "iso-27001": {
+          "controlId": "A.8.9",
+          "title": "Configuration management"
+        },
+        "cis-controls-v8": {
+          "controlId": "4.1",
+          "title": "Establish and Maintain a Secure Configuration Process",
+          "profiles": ["IG1", "IG2", "IG3"]
+        },
+        "soc2": {
+          "controlId": "CC8.1"
+        },
+        "mitre-attack": {
+          "controlId": "T1562.001"
+        }
+      }
+    },
+    {
+      "checkId": "CA-NAMEDLOC-001",
+      "name": "Trusted IP-based named locations susceptible to spoofing",
+      "category": "NAMEDLOC",
+      "collector": "CAEvaluator",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "requiredServicePlans": []
+      },
+      "frameworks": {
+        "nist-800-53": {
+          "controlId": "SC-7",
+          "title": "Boundary Protection",
+          "profiles": ["Low", "Moderate", "High"]
+        },
+        "nist-csf": {
+          "controlId": "PR.AC-05",
+          "title": "Network integrity is protected"
+        },
+        "iso-27001": {
+          "controlId": "A.8.20",
+          "title": "Networks security"
+        },
+        "pci-dss": {
+          "controlId": "1.3",
+          "title": "Network access to and from the cardholder data environment is restricted"
+        },
+        "cis-controls-v8": {
+          "controlId": "12.1",
+          "title": "Ensure Network Infrastructure is Up-to-Date",
+          "profiles": ["IG1", "IG2", "IG3"]
+        },
+        "soc2": {
+          "controlId": "CC6.1"
+        },
+        "mitre-attack": {
+          "controlId": "T1090;T1090.002"
+        }
+      }
+    },
+    {
+      "checkId": "CA-SESSION-001",
+      "name": "Persistent browser sessions allowed without device compliance",
+      "category": "SESSION",
+      "collector": "CAEvaluator",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "requiredServicePlans": []
+      },
+      "frameworks": {
+        "nist-800-53": {
+          "controlId": "AC-12",
+          "title": "Session Termination",
+          "profiles": ["Moderate", "High"]
+        },
+        "nist-csf": {
+          "controlId": "PR.AC-04",
+          "title": "Access permissions and authorizations are managed"
+        },
+        "iso-27001": {
+          "controlId": "A.8.11",
+          "title": "Data masking"
+        },
+        "pci-dss": {
+          "controlId": "8.2",
+          "title": "Multi-factor authentication (MFA) is implemented"
+        },
+        "cis-controls-v8": {
+          "controlId": "6.3",
+          "title": "Require MFA for Externally-Exposed Applications",
+          "profiles": ["IG1", "IG2", "IG3"]
+        },
+        "soc2": {
+          "controlId": "CC6.1"
+        },
+        "mitre-attack": {
+          "controlId": "T1550.001"
+        }
+      }
+    },
+    {
       "checkId": "ENTRA-AUTHMETHOD-003",
       "name": "Ensure Microsoft Authenticator is configured to protect against MFA fatigue",
       "category": "AUTHMETHOD",

--- a/tests/Entra/Get-CASecurityConfig.Tests.ps1
+++ b/tests/Entra/Get-CASecurityConfig.Tests.ps1
@@ -277,10 +277,18 @@ Describe 'Get-CASecurityConfig - No Policies' {
         $settings.Count | Should -BeGreaterThan 0
     }
 
-    It 'All checks should Fail when no policies exist and SD is off' {
+    It 'All checks should Fail or Pass-by-absence when no policies exist and SD is off' {
+        # Checks that correctly Pass when no policies exist (absence is the desired state)
+        $passOnAbsence = @('Report-Only Policies', 'Persistent Browser Without Device Compliance',
+            'Combined Risk Policy Anti-Pattern', 'Trusted IP Named Locations',
+            'Tier-0 Role Coverage in CA Policies')
         foreach ($s in $settings) {
-            $s.Status | Should -Be 'Fail' `
-                -Because "Setting '$($s.Setting)' should fail with no CA policies and SD off"
+            if ($s.Setting -in $passOnAbsence) {
+                $s.Status | Should -BeIn @('Pass', 'Review') -Because "Setting '$($s.Setting)' should pass or review when no problematic policies exist"
+            }
+            else {
+                $s.Status | Should -Be 'Fail' -Because "Setting '$($s.Setting)' should fail with no CA policies and SD off"
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
5 new CA security checks -- 3 brand new, 2 previously registered but unimplemented:

| CheckId | Check | Status Logic |
|---------|-------|-------------|
| CA-REPORTONLY-001 | Policies stuck in report-only mode | Warning if any found, Pass if none |
| CA-NAMEDLOC-001 | IP-based trusted locations (spoofable) | Review if trusted IPs found, Pass if none |
| CA-SESSION-001 | Persistent browser without device compliance | Warning if found, Pass if none |
| CA-RISKPOLICY-001 | Combined sign-in + user risk anti-pattern | Warning if found, Pass if none |
| CA-ROLECOVERAGE-001 | Active Tier-0 roles missing from CA policies | Warning if gaps, Pass if covered |

Registry updated: 298 entries (214 automated, up from 295/211). Two new Graph calls for named locations and role assignments (no new scopes needed -- Policy.Read.All and RoleManagement.Read.Directory already requested).

Addresses #368

## Test plan
- [x] 1,147 Pester tests pass
- [x] Run against tenant and verify new checks appear in CA Policy Evaluation section
- [x] Verify named locations show "Review" if IP-based trusted locations exist
- [x] Verify report-only detection catches policies in audit mode


🤖 Generated with [Claude Code](https://claude.com/claude-code)