### PR TITLE
chore: v1.7.0 version bump, changelog, and docs update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to M365 Assess are documented here. This project uses [Conve
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-04-06
+
+### Added
+- **`-DryRun` switch** -- preview sections, services, Graph scopes, and check counts without connecting or collecting data. Useful for first-time setup validation and CI/CD dry runs. (#363)
+- **5 new Conditional Access security checks** -- report-only policy detection (CA-REPORTONLY-001), trusted IP named location risk (CA-NAMEDLOC-001), persistent browser without device compliance (CA-SESSION-001), combined risk policy anti-pattern (CA-RISKPOLICY-001), Tier-0 role coverage gaps (CA-ROLECOVERAGE-001). Registry: 298 entries (214 automated). (#368)
+- **Enriched sidebar nav badges** -- sections without security findings now show contextual badges: gray "skip" for skipped sections, neutral item count for inventory/data sections. (#374)
+- **License-skipped check details in compliance overview** -- callout now lists each skipped check by ID, name, and required service plan instead of just a count. (#360)
+
+### Changed
+- **Framework catalog "Findings" renamed to "Automated Checks"** -- clarifies the distinction between our security checks and the framework's control definitions. Coverage column now shows percentages with hover tooltip for fractions. (#369, #374)
+- **Framework scoring aligned** -- Info-status findings excluded from pass rate denominators in both ComplianceOverview and FrameworkCatalog. Warning and Review shown as separate columns in catalog group tables instead of lumped "Other". (#369, #373)
+- **Section header layout** -- collector chips moved directly under heading for visibility, callouts wrapped in flex container for side-by-side display, duplicate Expand/Collapse buttons removed. (#351, #356)
+- **Persistent banners** -- hero banner and QuickScan banner now visible on every page in paginated mode, not just the overview. (#356, #359)
+- **All 15 framework tags colored** -- fixed CSS class mismatches for Essential Eight, CIS Controls v8, and Entra STIG. Each framework now has a unique color in both light and dark mode. (#374)
+- **Chip error text widened** -- max-width increased from 140px to 280px, expanded state unlimited. Collector chip max-width increased from 340px to 480px. (#356)
+
+### Fixed
+- **License gating ran before Graph connection** -- `Resolve-TenantLicenses` called `Get-MgSubscribedSku` before Graph connected, causing a warning on every run and silently disabling license gating. Moved to post-Graph-connect block with isolated error handling. (#353, #355)
+- **Services not disconnected after assessment** -- Graph, EXO, and Purview sessions now cleanly disconnect after assessment completes. (#354, #355)
+- **Progress summary printed twice** -- silent initialization before connection, authoritative summary with license data printed once after Graph connects. (#355)
+
 ## [1.6.0] - 2026-04-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [![Coverage](https://img.shields.io/badge/coverage-check%20CI-informational)](https://github.com/Galvnyz/M365-Assess/actions/workflows/ci.yml)
 [![PowerShell 7.x](https://img.shields.io/badge/PowerShell-7.x-blue?logo=powershell&logoColor=white)](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows)
 [![Read-Only](https://img.shields.io/badge/Operations-Read--Only-brightgreen)](.)
-[![Version](https://img.shields.io/badge/version-1.6.0-blue)](.)
+[![Version](https://img.shields.io/badge/version-1.7.0-blue)](.)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 </div>

--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -92,6 +92,8 @@ Orchestrates all M365 assessment collector scripts to produce a folder of CSV re
 | `FrameworkExport` | string[] | No | Generate standalone per-framework HTML catalog exports. Specify framework families or `All`. |
 | `CisBenchmarkVersion` | string | No | CIS benchmark version for rendering. Defaults to `v6`. Set to `v7` when v7 data is available. |
 | `NonInteractive` | switch | No | Suppress all interactive prompts. Missing required modules log the fix command and exit. Missing optional modules skip the section with a warning. Use for CI/CD and headless environments. |
+| `QuickScan` | switch | No | Run only Critical and High severity checks. Collectors with no qualifying checks are skipped. Report shows a "Quick Scan Mode" banner. |
+| `DryRun` | switch | No | Show a dry-run preview of sections, services, Graph scopes, and check counts without connecting or collecting data. Useful for validating configuration before a real run. |
 
 **Output:** Assessment folder containing CSV reports, an HTML report, optional XLSX compliance matrix, and optional PDF.
 
@@ -118,6 +120,12 @@ Invoke-M365Assessment -TenantId 'contoso.onmicrosoft.com' `
 
 # Device code auth for multi-profile machines
 Invoke-M365Assessment -TenantId 'contoso.onmicrosoft.us' -UseDeviceCode
+
+# Quick scan -- Critical and High severity only
+Invoke-M365Assessment -TenantId 'contoso.onmicrosoft.com' -QuickScan
+
+# Dry run -- preview what would happen without connecting
+Invoke-M365Assessment -TenantId 'contoso.onmicrosoft.com' -DryRun
 ```
 
 ---

--- a/src/M365-Assess/M365-Assess.psd1
+++ b/src/M365-Assess/M365-Assess.psd1
@@ -3,7 +3,7 @@
     # Generated: 2026-03-08
 
     RootModule        = 'M365-Assess.psm1'
-    ModuleVersion     = '1.6.0'
+    ModuleVersion     = '1.7.0'
     GUID              = 'f7e3b2a1-4c5d-6e8f-9a0b-1c2d3e4f5a6b'
     Author            = 'Galvnyz'
     CompanyName       = 'Community'
@@ -188,7 +188,7 @@
                              'PowerBI', 'CIS', 'NIST', 'SOC2', 'HIPAA', 'ZeroTrust', 'SecurityBaseline')
             LicenseUri   = 'https://github.com/Galvnyz/M365-Assess/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/Galvnyz/M365-Assess'
-            ReleaseNotes = 'v1.6.0 - Stabilization: accurate license detection, Value Opportunity tests, report CSS polish, consent function permissions'
+            ReleaseNotes = 'v1.7.0 - Scoring fixes, CA policy checks, report polish, DryRun mode, enriched sidebar badges, persistent banners'
         }
     }
 }


### PR DESCRIPTION
## Summary
Release preparation for v1.7.0:

- Version bumped in manifest (ModuleVersion + ReleaseNotes), README badge, and CHANGELOG
- Changelog documents all v1.7.0 changes across 6 PRs (#355, #356, #367, #373, #374, #377)
- Cmdlet reference updated with -DryRun and -QuickScan parameters and examples

Closes #375

## After merge
Create GitHub release: `gh release create v1.7.0 --title "v1.7.0" --notes-file CHANGELOG.md`

## Test plan
- [x] 1,147 Pester tests pass
- [x] Version badge shows 1.7.0
- [x] Manifest ModuleVersion = 1.7.0


🤖 Generated with [Claude Code](https://claude.com/claude-code)