### PR TITLE
fix: null-array guards in Entra password and CA sign-in frequency checks (#426)

### DIFF
--- a/src/M365-Assess/Entra/EntraPasswordAuthChecks.ps1
+++ b/src/M365-Assess/Entra/EntraPasswordAuthChecks.ps1
@@ -329,7 +329,23 @@ try {
     }
 }
 catch {
-    Write-Warning "Could not check password protection: $_"
+    if ($_.ToString() -match '400 Bad Request|BadRequest|Resource not found for the segment') {
+        # Tenant has no configured directory settings — normal for tenants that have never
+        # customized Entra password protection. Add a single Info item so the check appears
+        # in the report rather than silently disappearing.
+        Add-Setting @{
+            Category         = 'Password Management'
+            Setting          = 'Custom Banned Password Protection'
+            CurrentValue     = 'Directory settings not configured (using Entra defaults)'
+            RecommendedValue = 'Configured'
+            Status           = 'Info'
+            CheckId          = 'ENTRA-PASSWORD-002'
+            Remediation      = 'Entra admin center > Protection > Authentication methods > Password protection. Configure a custom banned password list and smart lockout threshold.'
+        }
+    }
+    else {
+        Write-Warning "Could not check password protection: $_"
+    }
 }
 
 # ------------------------------------------------------------------
@@ -370,20 +386,34 @@ try {
 
         if ($authenticator) {
             $featureSettings = $authenticator['featureSettings']
-            $numberMatch = $featureSettings['numberMatchingRequiredState']['state']
-            $appInfo = $featureSettings['displayAppInformationRequiredState']['state']
+            if ($null -ne $featureSettings) {
+                $numberMatch = $featureSettings['numberMatchingRequiredState']['state']
+                $appInfo = $featureSettings['displayAppInformationRequiredState']['state']
 
-            $fatiguePassed = ($numberMatch -eq 'enabled') -and ($appInfo -eq 'enabled')
-            $settingParams = @{
-                Category         = 'Authentication Methods'
-                Setting          = 'Authenticator Fatigue Protection'
-                CurrentValue     = "Number matching: $numberMatch; App context: $appInfo"
-                RecommendedValue = 'Both enabled'
-                Status           = $(if ($fatiguePassed) { 'Pass' } else { 'Fail' })
-                CheckId          = 'ENTRA-AUTHMETHOD-003'
-                Remediation      = 'Entra admin center > Protection > Authentication methods > Microsoft Authenticator > Configure > Require number matching = Enabled, Show application name = Enabled.'
+                $fatiguePassed = ($numberMatch -eq 'enabled') -and ($appInfo -eq 'enabled')
+                $settingParams = @{
+                    Category         = 'Authentication Methods'
+                    Setting          = 'Authenticator Fatigue Protection'
+                    CurrentValue     = "Number matching: $numberMatch; App context: $appInfo"
+                    RecommendedValue = 'Both enabled'
+                    Status           = $(if ($fatiguePassed) { 'Pass' } else { 'Fail' })
+                    CheckId          = 'ENTRA-AUTHMETHOD-003'
+                    Remediation      = 'Entra admin center > Protection > Authentication methods > Microsoft Authenticator > Configure > Require number matching = Enabled, Show application name = Enabled.'
+                }
+                Add-Setting @settingParams
             }
-            Add-Setting @settingParams
+            else {
+                $settingParams = @{
+                    Category         = 'Authentication Methods'
+                    Setting          = 'Authenticator Fatigue Protection'
+                    CurrentValue     = 'Feature settings not available for Microsoft Authenticator'
+                    RecommendedValue = 'Both enabled'
+                    Status           = 'Review'
+                    CheckId          = 'ENTRA-AUTHMETHOD-003'
+                    Remediation      = 'Verify Microsoft Authenticator feature settings in Entra admin center > Protection > Authentication methods > Microsoft Authenticator > Configure.'
+                }
+                Add-Setting @settingParams
+            }
         }
         else {
             $settingParams = @{
@@ -502,6 +532,9 @@ try {
     $orgValue = if ($orgInfo -and $orgInfo['value']) { @($orgInfo['value']) } else { @() }
     if ($orgValue -and $orgValue.Count -gt 0) {
         $org = $orgValue[0]
+        if ($null -eq $org) {
+            throw "Organization data returned null element — cannot evaluate hybrid sync state"
+        }
         $onPremSync = $org['onPremisesSyncEnabled']
 
         if ($null -eq $onPremSync -or $onPremSync -eq $false) {

--- a/src/M365-Assess/Entra/Get-CASecurityConfig.ps1
+++ b/src/M365-Assess/Entra/Get-CASecurityConfig.ps1
@@ -303,7 +303,10 @@ try {
     Write-Verbose "Checking CA: Sign-in frequency for admins..."
     $signinFreqPolicies = @($enabledPolicies | Where-Object {
         (Test-TargetAdminRole -Policy $_) -and
+        $null -ne $_['sessionControls'] -and
+        $null -ne $_['sessionControls']['signInFrequency'] -and
         $_['sessionControls']['signInFrequency']['isEnabled'] -eq $true -and
+        $null -ne $_['sessionControls']['persistentBrowser'] -and
         $_['sessionControls']['persistentBrowser']['mode'] -eq 'never'
     })
 
@@ -606,6 +609,8 @@ try {
     $intuneFreqPolicies = @($enabledPolicies | Where-Object {
         $includeApps = $_['conditions']['applications']['includeApplications']
         ($includeApps -contains $intuneAppId -or $includeApps -contains 'All') -and
+        $null -ne $_['sessionControls'] -and
+        $null -ne $_['sessionControls']['signInFrequency'] -and
         $_['sessionControls']['signInFrequency']['isEnabled'] -eq $true -and
         $_['sessionControls']['signInFrequency']['type'] -eq 'everyTime'
     })


### PR DESCRIPTION
## Summary

Fixes null-array exceptions that silently dropped check results on tenants without certain features configured (e.g., dev/trial tenants, cloud-only tenants, or tenants with minimal CA policies).

### `EntraPasswordAuthChecks.ps1`

**Section 8 — `/v1.0/settings` 400 BadRequest (Password Protection)**
- Tenants that have never configured Entra directory settings return `400 "Resource not found for the segment 'settings'"` instead of `200 + empty array`
- Was: emitted a WARN and silently skipped the check
- Now: adds a single `Info` result ("Directory settings not configured") so the check appears in the report with a remediation link

**Section 20 — Authenticator Fatigue (ENTRA-AUTHMETHOD-003)**
- `$authenticator['featureSettings']` returns null on some tenants where the Authenticator policy exists but has no feature settings object
- Was: `$featureSettings['numberMatchingRequiredState']['state']` threw "Cannot index into a null array"
- Now: guards `$null -ne $featureSettings`, returns `Review` when absent

**Section 33 — Password Hash Sync (ENTRA-HYBRID-001)**
- `$orgValue[0]` can return null in edge cases (null element in Graph response array)
- Now: throws a descriptive message instead of the opaque null-array error, caught by outer catch

### `Get-CASecurityConfig.ps1`

**Sections 4 and 11 — Sign-in Frequency filters**
- CA policies without `sessionControls` defined caused `$_['sessionControls']['signInFrequency']['isEnabled']` to throw
- Now: `$null -ne $_['sessionControls']` and `$null -ne $_['sessionControls']['signInFrequency']` guards short-circuit before the deep access

## Test plan
- [ ] All CA tests pass: `Invoke-Pester -Path './tests/Entra/Get-CASecurityConfig.Tests.ps1'`
- [ ] All Entra tests pass: `Invoke-Pester -Path './tests/Entra/Get-EntraSecurityConfig.Tests.ps1'`
- [ ] Run against a dev/trial tenant — no "Cannot index into a null array" warnings in assessment log
- [ ] Password protection check appears as `Info` on tenants without directory settings

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)