### PR TITLE
fix: EXO transient errors, OPATH boolean filter, ResultSize noise, Issues log capture (#425)

### DIFF
--- a/src/M365-Assess/Exchange-Online/Get-ExoSecurityConfig.ps1
+++ b/src/M365-Assess/Exchange-Online/Get-ExoSecurityConfig.ps1
@@ -204,7 +204,21 @@ try {
     Add-Setting @settingParams
 }
 catch {
-    Write-Warning "Could not check external sender tagging: $_"
+    if ($_.ToString() -match 'server side error|try again after some time') {
+        # Transient EXO REST API error — emit Review so the check appears in the report
+        Add-Setting @{
+            Category         = 'Email Security'
+            Setting          = 'External Sender Tagging'
+            CurrentValue     = 'Could not verify — transient API error'
+            RecommendedValue = 'True'
+            Status           = 'Review'
+            CheckId          = 'EXO-EXTTAG-001'
+            Remediation      = 'Verify manually: Get-ExternalInOutlook. Enable with: Set-ExternalInOutlook -Enabled $true.'
+        }
+    }
+    else {
+        Write-Warning "Could not check external sender tagging: $_"
+    }
 }
 
 # ------------------------------------------------------------------
@@ -446,7 +460,7 @@ catch {
 # ------------------------------------------------------------------
 try {
     Write-Verbose "Checking mailbox auditing (sampling 50 mailboxes)..."
-    $mailboxes = Get-Mailbox -ResultSize 50 -RecipientTypeDetails UserMailbox -ErrorAction Stop
+    $mailboxes = Get-Mailbox -ResultSize 50 -RecipientTypeDetails UserMailbox -ErrorAction Stop -WarningAction SilentlyContinue
 
     if (@($mailboxes).Count -eq 0) {
         $settingParams = @{
@@ -501,7 +515,7 @@ catch {
 # ------------------------------------------------------------------
 try {
     Write-Verbose "Checking shared mailbox sign-in status..."
-    $sharedMailboxes = Get-Mailbox -RecipientTypeDetails SharedMailbox -ResultSize 100 -ErrorAction Stop
+    $sharedMailboxes = Get-Mailbox -RecipientTypeDetails SharedMailbox -ResultSize 100 -ErrorAction Stop -WarningAction SilentlyContinue
 
     if ($sharedMailboxes.Count -eq 0) {
         $settingParams = @{
@@ -628,7 +642,7 @@ catch {
 # ------------------------------------------------------------------
 try {
     Write-Verbose "Checking for hidden user mailboxes..."
-    $hiddenMailboxes = @(Get-EXOMailbox -RecipientTypeDetails UserMailbox -ResultSize Unlimited -Filter "HiddenFromAddressListsEnabled -eq 'True'" -Properties DisplayName, PrimarySmtpAddress -ErrorAction Stop)
+    $hiddenMailboxes = @(Get-EXOMailbox -RecipientTypeDetails UserMailbox -ResultSize Unlimited -Filter 'HiddenFromAddressListsEnabled -eq $True' -Properties DisplayName, PrimarySmtpAddress -ErrorAction Stop)
 
     if ($hiddenMailboxes.Count -eq 0) {
         $settingParams = @{

--- a/src/M365-Assess/Invoke-M365Assessment.ps1
+++ b/src/M365-Assess/Invoke-M365Assessment.ps1
@@ -971,7 +971,8 @@ foreach ($sectionName in $Section) {
             $capturedWarnings = @($rawOutput | Where-Object { $_ -is [System.Management.Automation.WarningRecord] })
             $results = @($rawOutput | Where-Object { $null -ne $_ -and $_ -isnot [System.Management.Automation.WarningRecord] })
 
-            # Log captured warnings; track permission-related ones as issues
+            # Log captured warnings; track permission failures as WARNING issues,
+            # other technical failures (API errors, null-index) as INFO issues
             $hasPermissionWarning = $false
             foreach ($w in $capturedWarnings) {
                 Write-AssessmentLog -Level WARN -Message $w.Message -Section $sectionName -Collector $collector.Label
@@ -979,6 +980,16 @@ foreach ($sectionName in $Section) {
                     $hasPermissionWarning = $true
                     $issues.Add([PSCustomObject]@{
                         Severity     = 'WARNING'
+                        Section      = $sectionName
+                        Collector    = $collector.Label
+                        Description  = $w.Message
+                        ErrorMessage = $w.Message
+                        Action       = Get-RecommendedAction -ErrorMessage $w.Message
+                    })
+                }
+                elseif ($w.Message -match 'Could not check|Could not retrieve|server side error|querying REST|Cannot index') {
+                    $issues.Add([PSCustomObject]@{
+                        Severity     = 'INFO'
                         Section      = $sectionName
                         Collector    = $collector.Label
                         Description  = $w.Message


### PR DESCRIPTION
## Summary

Fixes four related issues surfaced in the procentrixdev assessment run:

### `Get-ExoSecurityConfig.ps1`

**External Sender Tagging — transient server error**
- `Get-ExternalInOutlook` intermittently returns "A server side error has occurred"
- Was: emitted a WARN and silently dropped the check row
- Now: catches the transient error pattern and emits a `Review` result so the check appears with a remediation link

**Hidden User Mailboxes — invalid OPATH filter**
- Filter `"HiddenFromAddressListsEnabled -eq 'True'"` compared against a *string* `'True'`; EXO REST API OPATH requires a boolean
- Was: `HttpStatusCode=400 Invalid filter clause`
- Now: uses single-quoted `'HiddenFromAddressListsEnabled -eq $True'` — single quotes prevent PowerShell from expanding `$True`, OPATH parser receives the boolean literal

**Mailbox Audit and Shared Mailbox sampling**
- `Get-Mailbox -ResultSize 50/100` always produced "There are more results available..." noise warnings in the assessment log
- Now: adds `-WarningAction SilentlyContinue` to suppress expected truncation warnings

### `Invoke-M365Assessment.ps1`

**Issues log not generated for non-permission failures**
- `$issues` list only captured warnings matching `401|403|Unauthorized|Forbidden|permission|consent`
- All other technical failures (API 400s, null-array errors, server errors) only appeared in `_Assessment-Log.txt`; `_Assessment-Issues*.log` was never created for runs without auth errors
- Now: `Could not check|Could not retrieve|server side error|querying REST|Cannot index` warnings are also added to `$issues` at `INFO` severity so they appear in both the Issues log and the HTML report Issues section

## Test plan
- [ ] All 56 EXO tests pass
- [ ] Run against procentrixdev: no "Invalid filter clause" warning for hidden mailboxes
- [ ] Run against procentrixdev: external sender tagging shows `Review` instead of missing
- [ ] `_Assessment-Issues*.log` created for runs with technical (non-permission) warnings
- [ ] No "more results available" warnings in assessment log for mailbox audit/shared checks

Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)