### PR TITLE
chore: bump version to 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to M365 Assess are documented here. This project uses [Conve
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-04-15
+
+### Added
+- Remediation Action Plan page in HTML report with severity/section chip filters (#401)
+- Per-table column visibility picker (CheckId, Category, RecommendedValue hidden by default)
+- Universal compact/expand toggle for all section tables
+- Bar chart in Remediation Action Plan header showing checks by section
+- Numbered index column in Appendix: Checks Run table
+- Purview compliance checks: DLP workload coverage, alert policies, auto-labeling, comms compliance (#409)
+- XLSX compliance matrix: 5 new SCF columns (ImpactSeverity, SCFDomain, CSFFunction, etc.) and Verification sheet (#408)
+- CheckID v2.0.0 schema compatibility (scf/impactRating objects, E3/E5 licensing minimum) (#405)
+- 8 missing registry entries restored: CA-NAMEDLOC-001, CA-REPORTONLY-001, CA-SESSION-001, SPO-ACCESS-001/002, SPO-SITE-001/002, SPO-VERSIONING-001 (#411)
+- Project CLAUDE.md with architecture overview and key workflows (#411)
+
+### Changed
+- QuickScan auto-applies compact report format (SkipCoverPage, SkipExecutiveSummary, SkipComplianceOverview)
+- PSGallery package optimized (~8MB to ~4MB via PNG compression and JSON minification)
+
+### Fixed
+- Bar chart section counts were all zero due to ForEach-Object `$_` variable shadowing in nested Where-Object
+- Remediation Action Plan chart card visual cohesion (removed double-card background, added left border divider)
+- Severity row hover now shows white text on all section, data, and remediation tables (removed opacity fade)
+- Null-array exceptions in Entra password checks when directory settings or authenticator feature settings are absent (#426)
+- Null-array exceptions in CA sign-in frequency checks when sessionControls is absent from a policy (#426)
+- EXO hidden mailboxes OPATH filter boolean type mismatch causing 400 Bad Request errors (#425)
+- EXO transient server-side errors now caught and reported as Review status instead of surfacing as warnings (#425)
+- Get-Mailbox ResultSize warnings suppressed with -WarningAction SilentlyContinue (#425)
+- Issues log now captures technical collector failures, not only permission errors (#425)
+- DNS false positives for .onmicrosoft.com domains filtered at source (carried from #397)
+
 ## [1.9.0] - 2026-04-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [![Coverage](https://img.shields.io/badge/coverage-check%20CI-informational)](https://github.com/Galvnyz/M365-Assess/actions/workflows/ci.yml)
 [![PowerShell 7.x](https://img.shields.io/badge/PowerShell-7.x-blue?logo=powershell&logoColor=white)](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows)
 [![Read-Only](https://img.shields.io/badge/Operations-Read--Only-brightgreen)](.)
-[![Version](https://img.shields.io/badge/version-1.9.0-blue)](.)
+[![Version](https://img.shields.io/badge/version-1.10.0-blue)](.)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 </div>

--- a/src/M365-Assess/M365-Assess.psd1
+++ b/src/M365-Assess/M365-Assess.psd1
@@ -3,7 +3,7 @@
     # Generated: 2026-03-08
 
     RootModule        = 'M365-Assess.psm1'
-    ModuleVersion     = '1.9.0'
+    ModuleVersion     = '1.10.0'
     GUID              = 'f7e3b2a1-4c5d-6e8f-9a0b-1c2d3e4f5a6b'
     Author            = 'Galvnyz'
     CompanyName       = 'Community'
@@ -197,7 +197,7 @@
             IconUri      = 'https://raw.githubusercontent.com/Galvnyz/M365-Assess/main/src/M365-Assess/assets/m365-assess-logo.png'
             LicenseUri   = 'https://github.com/Galvnyz/M365-Assess/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/Galvnyz/M365-Assess'
-            ReleaseNotes = 'v1.9.0 - Fix .onmicrosoft.com false-positive DNS failures; QuickScan now auto-applies triage report format (no cover page, exec summary, or compliance matrix)'
+            ReleaseNotes = 'v1.10.0 - Remediation Action Plan, Purview checks, CheckID v2.0.0, XLSX enrichment, registry gaps restored, collector error hardening'
         }
     }
 }


### PR DESCRIPTION
## Summary
- Bumps `ModuleVersion` from `1.9.0` to `1.10.0` in `M365-Assess.psd1`
- Updates `ReleaseNotes` in `M365-Assess.psd1`
- Updates version badge in `README.md`
- Adds `## [1.10.0] - 2026-04-15` section to `CHANGELOG.md`

This covers all work merged to main since v1.9.0: Remediation Action Plan (#401), CheckID v2.0.0 (#405), XLSX enrichment (#408), Purview (#409), registry gaps + CLAUDE.md (#411), and report UI + collector fixes (#429).

## Test plan
- [x] `ModuleVersion` field reads `1.10.0` in PSD1
- [ ] README badge shows `version-1.10.0`
- [ ] CHANGELOG has `## [1.10.0] - 2026-04-15` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)