### PR TITLE
chore: bump version to 1.12.0, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to M365 Assess are documented here. This project uses [Conve
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-04-16
+
+### Added
+- Policy drift detection: `-SaveBaseline <label>` saves the current assessment as a named JSON snapshot; `-CompareBaseline <label>` compares the next run against it and adds a "Drift Analysis" page to the HTML report with Regressed/Improved/Modified/New/Removed classification (#370)
+- `impactRationale` surfaced in Remediation Action Plan — "Why it matters:" sub-line rendered below each remediation cell, drawn from `registry.json` for all 254 checks (#424)
+
 ## [1.11.0] - 2026-04-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [![Coverage](https://img.shields.io/badge/coverage-check%20CI-informational)](https://github.com/Galvnyz/M365-Assess/actions/workflows/ci.yml)
 [![PowerShell 7.x](https://img.shields.io/badge/PowerShell-7.x-blue?logo=powershell&logoColor=white)](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows)
 [![Read-Only](https://img.shields.io/badge/Operations-Read--Only-brightgreen)](.)
-[![Version](https://img.shields.io/badge/version-1.11.0-blue)](.)
+[![Version](https://img.shields.io/badge/version-1.12.0-blue)](.)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 </div>

--- a/src/M365-Assess/M365-Assess.psd1
+++ b/src/M365-Assess/M365-Assess.psd1
@@ -3,7 +3,7 @@
     # Generated: 2026-03-08
 
     RootModule        = 'M365-Assess.psm1'
-    ModuleVersion     = '1.11.0'
+    ModuleVersion     = '1.12.0'
     GUID              = 'f7e3b2a1-4c5d-6e8f-9a0b-1c2d3e4f5a6b'
     Author            = 'Galvnyz'
     CompanyName       = 'Community'
@@ -200,7 +200,7 @@
             IconUri      = 'https://raw.githubusercontent.com/Galvnyz/M365-Assess/main/src/M365-Assess/assets/m365-assess-logo.png'
             LicenseUri   = 'https://github.com/Galvnyz/M365-Assess/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/Galvnyz/M365-Assess'
-            ReleaseNotes = 'v1.11.0 - DNS-MX-001 MX record check, ENTRA-ENTAPP-020 false positive fix, status filter + column picker UI overhaul, hybrid nav demotion, styled expand button, per-table CSV export'
+            ReleaseNotes = 'v1.12.0 - Policy drift detection (-SaveBaseline/-CompareBaseline), impactRationale for all 254 checks surfaced in Remediation Action Plan'
         }
     }
 }


### PR DESCRIPTION
## Summary

- Bumps `ModuleVersion` to `1.12.0` in `M365-Assess.psd1`
- Updates `ReleaseNotes` in `M365-Assess.psd1`
- Updates version badge in `README.md`
- Adds `[1.12.0]` section to `CHANGELOG.md`

## Changes in this release

- **#370** Policy drift detection (`-SaveBaseline`/`-CompareBaseline` params + Drift Analysis HTML page)
- **#424** `impactRationale` for all 254 checks surfaced in the Remediation Action Plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)