### PR TITLE
fix: use github.token fallback when CROSS_REPO_TOKEN is unset

### DIFF
--- a/.github/workflows/sync-checkid.yml
+++ b/.github/workflows/sync-checkid.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Fetch CheckID data
         env:
-          GH_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}
+          GH_TOKEN: ${{ secrets.CROSS_REPO_TOKEN || github.token }}
         run: |
           TAG="${{ github.event.client_payload.tag || github.event.inputs.tag }}"
           echo "Syncing from CheckID $TAG"
@@ -44,7 +44,7 @@ jobs:
       - name: Create PR if changed
         if: steps.diff.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}
+          GH_TOKEN: ${{ secrets.CROSS_REPO_TOKEN || github.token }}
         run: |
           TAG="${{ github.event.client_payload.tag || github.event.inputs.tag }}"
           BRANCH="chore/sync-checkid-$TAG"


### PR DESCRIPTION
## Summary
- The `Sync CheckID on Release` workflow was failing with exit code 4 because `secrets.CROSS_REPO_TOKEN` is not configured in this repo, leaving `GH_TOKEN` empty for `gh pr create`
- The workflow already declares `permissions: contents: write, pull-requests: write`, so `github.token` has everything needed
- Use `${{ secrets.CROSS_REPO_TOKEN || github.token }}` as a fallback in both the Fetch and Create PR steps

## Context
This was discovered when the v2.4.0 CheckID tag fired the cascade — the branch `chore/sync-checkid-v2.4.0` was created and pushed successfully, but `gh pr create` failed. That PR is being created manually as part of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)