### PR TITLE
fix: remove PowerBI countdown timer, make connections consistent

### DIFF
--- a/src/M365-Assess/Common/Connect-Service.ps1
+++ b/src/M365-Assess/Common/Connect-Service.ps1
@@ -247,7 +247,10 @@ try {
             if ($ManagedIdentity) {
                 throw "Power BI (Connect-PowerBIServiceAccount) does not support managed identity auth. Use -ClientId and -CertificateThumbprint for non-interactive auth."
             }
-            elseif ($ClientId -and $CertificateThumbprint) {
+            if ($UseDeviceCode) {
+                Write-Warning "Power BI (Connect-PowerBIServiceAccount) does not support device code auth. Falling back to interactive login."
+            }
+            if ($ClientId -and $CertificateThumbprint) {
                 $connectParams['ServicePrincipal'] = $true
                 $connectParams['ApplicationId'] = $ClientId
                 $connectParams['CertificateThumbprint'] = $CertificateThumbprint

--- a/src/M365-Assess/Invoke-M365Assessment.ps1
+++ b/src/M365-Assess/Invoke-M365Assessment.ps1
@@ -855,6 +855,7 @@ foreach ($sectionName in $Section) {
             # ships Microsoft.Identity.Client 4.64 while Microsoft.Graph loads 4.78;
             # a child process gets its own AppDomain and avoids the clash.
             if ($collector.ContainsKey('IsChildProcess') -and $collector.IsChildProcess) {
+                Write-Host "    Connecting to Power BI..." -ForegroundColor Yellow
                 Write-Host "    Running in isolated process (assembly compatibility)..." -ForegroundColor Gray
                 Write-AssessmentLog -Level INFO -Message "Running $($collector.Label) in child process to avoid MSAL assembly conflict" -Section $sectionName -Collector $collector.Label
                 $childCsvPath = $csvPath
@@ -908,16 +909,7 @@ foreach ($sectionName in $Section) {
                             -NoNewWindow -PassThru
                     }
 
-                    # Poll with countdown so the user sees progress instead of a frozen screen
-                    $exited = $false
-                    for ($waited = 0; $waited -lt $childTimeoutSec; $waited += 5) {
-                        $exited = $childProc.WaitForExit(5000)
-                        if ($exited) { break }
-                        $remaining = $childTimeoutSec - $waited - 5
-                        if ($remaining -gt 0 -and -not $childNeedsConsole) {
-                            Write-Host "    Waiting for Power BI response... (${remaining}s until timeout)" -ForegroundColor Gray
-                        }
-                    }
+                    $exited = $childProc.WaitForExit($childTimeoutSec * 1000)
 
                     if (-not $exited) {
                         $childProc.Kill()


### PR DESCRIPTION
## Summary
- Removes the 9-line polling countdown loop (`Waiting for Power BI response... (Xs until timeout)`) — replaced with a single blocking `WaitForExit` call
- Adds `Connecting to Power BI...` message before the child process starts, matching the standard `Connecting to X...` pattern used by Graph/EXO/Purview
- Adds `UseDeviceCode` warning to `Connect-Service.ps1` PowerBI block — consistent with how Purview handles unsupported auth modes

## Test plan
- [ ] Run full assessment including PowerBI section — confirm `Connecting to Power BI...` appears, no countdown messages
- [ ] Confirm PowerBI collector still completes successfully
- [ ] Pass `-UseDeviceCode` — confirm warning is shown for PowerBI

Closes #463 (partially — this is a UX consistency fix, not the full auth model research)

🤖 Generated with [Claude Code](https://claude.com/claude-code)