### PR TITLE
fix: Intune overview in section + Identity connection ordering

### DIFF
--- a/src/M365-Assess/Common/Build-SectionHtml.ps1
+++ b/src/M365-Assess/Common/Build-SectionHtml.ps1
@@ -366,6 +366,13 @@ foreach ($sectionName in $sections) {
     }
 
     # ------------------------------------------------------------------
+    # Intune Dashboard — placeholder replaced after $allCisFindings is built
+    # ------------------------------------------------------------------
+    if ($sectionName -eq 'Intune') {
+        $null = $sectionHtml.AppendLine('<!-- INTUNE-OVERVIEW-PLACEHOLDER -->')
+    }
+
+    # ------------------------------------------------------------------
     # Identity Dashboard — combined overview panel
     # ------------------------------------------------------------------
     if ($sectionName -eq 'Identity') {
@@ -1458,6 +1465,20 @@ foreach ($c in $summary) {
         })
     }
 }
+
+# ------------------------------------------------------------------
+# Intune Dashboard — replace placeholder now that $allCisFindings is populated
+# ------------------------------------------------------------------
+$intuneOverviewInsert = ''
+$intuneFindings4Overview = @($allCisFindings | Where-Object { $_.CheckId -like 'INTUNE-*' })
+if ($intuneFindings4Overview.Count -gt 0) {
+    if (-not (Get-Command -Name Build-IntuneOverviewHtml -ErrorAction SilentlyContinue)) {
+        . (Join-Path -Path $PSScriptRoot -ChildPath 'Build-IntuneOverviewHtml.ps1')
+    }
+    $intuneOverviewInsert = Build-IntuneOverviewHtml -Findings $intuneFindings4Overview -AssessmentFolder $AssessmentFolder
+}
+$sectionHtmlStr = $sectionHtml.ToString().Replace('<!-- INTUNE-OVERVIEW-PLACEHOLDER -->', $intuneOverviewInsert)
+$sectionHtml = [System.Text.StringBuilder]::new($sectionHtmlStr)
 
 # ------------------------------------------------------------------
 # Compute per-section status counts for the service-area breakdown chart

--- a/src/M365-Assess/Common/Export-AssessmentReport.ps1
+++ b/src/M365-Assess/Common/Export-AssessmentReport.ps1
@@ -91,9 +91,6 @@ param(
     [switch]$SkipComplianceOverview,
 
     [Parameter()]
-    [switch]$SkipIntuneOverview,
-
-    [Parameter()]
     [switch]$SkipCoverPage,
 
     [Parameter()]
@@ -367,13 +364,6 @@ if ((Test-Path -Path $voLicensePath) -and (Test-Path -Path $voAdoptionPath) -and
 
 # Build remediation plan page (requires $allCisFindings set by Build-SectionHtml.ps1)
 $remediationPlanHtml = Build-RemediationPlanHtml -Findings $allCisFindings -IsQuickScan:$QuickScan
-
-# Build Intune overview page (requires $allCisFindings set by Build-SectionHtml.ps1)
-$intuneOverviewHtml = ''
-if (-not $SkipIntuneOverview -and ($allCisFindings | Where-Object { $_.CheckId -like 'INTUNE-*' })) {
-    . (Join-Path -Path $PSScriptRoot -ChildPath 'Build-IntuneOverviewHtml.ps1')
-    $intuneOverviewHtml = Build-IntuneOverviewHtml -Findings $allCisFindings -AssessmentFolder $AssessmentFolder
-}
 
 # Build drift analysis page (if a baseline comparison was run)
 $driftHtml = ''

--- a/src/M365-Assess/Common/Get-ReportTemplate.ps1
+++ b/src/M365-Assess/Common/Get-ReportTemplate.ps1
@@ -2738,10 +2738,6 @@ if ($complianceHtml) {
     $navIconCompliance = $navIcons['compliance overview']
     $html += "                <li class='nav-item' data-page='compliance-overview'><a href='#compliance-overview'>$navIconCompliance Compliance Overview</a></li>`n"
 }
-if ($intuneOverviewHtml) {
-    $navIconIntune = '<svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path d="M7 2a1 1 0 0 0-1 1v1H4a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2h-2V3a1 1 0 0 0-1-1H7Zm0 2h6v1H7V4ZM4 8h12v8H4V8Zm2 2v2h2v-2H6Zm4 0v2h2v-2h-2Zm4 0v2h2v-2h-2Z"/></svg>'
-    $html += "                <li class='nav-item' data-page='intune-overview'><a href='#intune-overview'>$navIconIntune Intune Overview</a></li>`n"
-}
 if ($catalogHtml) {
     $navIconCatalogs = $navIcons['framework catalogs']
     $html += "                <li class='nav-item' data-page='framework-catalogs'><a href='#framework-catalogs'>$navIconCatalogs Framework Catalogs</a></li>`n"
@@ -2953,17 +2949,6 @@ if ($complianceHtml) {
         <a id="compliance-overview"></a>
         <h1>Compliance Overview</h1>
         $complianceHtml
-        </div>
-"@
-}
-
-if ($intuneOverviewHtml) {
-    $html += @"
-
-        <div class="report-page" data-page="intune-overview" id="intune-overview">
-        <a id="intune-overview-anchor"></a>
-        <h1>Intune Overview</h1>
-        $intuneOverviewHtml
         </div>
 "@
 }

--- a/src/M365-Assess/Invoke-M365Assessment.ps1
+++ b/src/M365-Assess/Invoke-M365Assessment.ps1
@@ -182,9 +182,6 @@ param(
     [switch]$SkipComplianceOverview,
 
     [Parameter()]
-    [switch]$SkipIntuneOverview,
-
-    [Parameter()]
     [switch]$SkipCoverPage,
 
     [Parameter()]
@@ -1197,7 +1194,6 @@ if (Test-Path -Path $reportScriptPath) {
         elseif ($TenantId)        { $reportParams['TenantName'] = $TenantId }
         if ($NoBranding) { $reportParams['NoBranding'] = $true }
         if ($SkipComplianceOverview) { $reportParams['SkipComplianceOverview'] = $true }
-        if ($SkipIntuneOverview -or 'Intune' -notin $Section) { $reportParams['SkipIntuneOverview'] = $true }
         if ($SkipCoverPage) { $reportParams['SkipCoverPage'] = $true }
         if ($SkipExecutiveSummary) { $reportParams['SkipExecutiveSummary'] = $true }
         if ($SkipPdf) { $reportParams['SkipPdf'] = $true }


### PR DESCRIPTION
## Summary

Two fixes shipped together:

### 1. Move Intune overview into existing Intune section
The Intune dashboard was rendering as a separate sidebar nav item ("Intune Overview") instead of inside the Intune section where the check results live.

Switches to a two-phase injection in `Build-SectionHtml.ps1`: drop a placeholder during the sections loop, then replace it after `$allCisFindings` is populated. Removes the standalone page infrastructure (`$SkipIntuneOverview`, nav item, separate page div).

### 2. Fix Identity collectors running before Graph connects
**Root cause:** Identity collectors `02`–`07d` had no `RequiredServices` annotation. The orchestrator's dispatch logic only connects section-level services upfront when NO collectors have `RequiredServices`. Since `07e`–`07g` had the annotation, the orchestrator used per-collector mode — and collectors `02`–`07d` ran with zero Graph connection, logging "Not connected to Microsoft Graph."

**Fix 1** (`AssessmentMaps.ps1`): Add `RequiredServices = @('Graph')` to all 12 Identity collectors. The first collector (User Summary) now triggers the connection.

**Fix 2** (`Invoke-M365Assessment.ps1`): Harden dispatch logic so mixed sections (some annotated, some not) always connect section-level services upfront first. Per-collector calls remain and are idempotent.

## Test plan
- [ ] Run Identity-only assessment — confirm no "Prerequisite not met" / "Not connected to Microsoft Graph" warnings in issues log
- [ ] Run full assessment — confirm Identity section collectors all complete with data
- [ ] Intune section shows overview dashboard inline (metric cards, category grid, findings table) with no separate "Intune Overview" nav item
- [ ] Run assessment without Intune section — confirm no errors, no empty placeholder rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)