### PR TITLE
fix: connect Graph before Identity collectors run

### DIFF
--- a/src/M365-Assess/Invoke-M365Assessment.ps1
+++ b/src/M365-Assess/Invoke-M365Assessment.ps1
@@ -740,9 +740,13 @@ foreach ($sectionName in $Section) {
 
     # Connect to services: use per-collector RequiredServices if defined,
     # otherwise connect all section-level services up front.
-    # This ensures only one non-Graph service is active at a time.
+    # If the section is MIXED (some collectors have RequiredServices, others do not),
+    # connect section-level services upfront so un-annotated collectors are never
+    # dispatched without a connection. Per-collector Connect-RequiredService calls
+    # below are idempotent and will no-op if already connected.
     $hasPerCollectorRequirements = ($collectors | Where-Object { $_.ContainsKey('RequiredServices') }).Count -gt 0
-    if (-not $SkipConnection -and -not $hasPerCollectorRequirements) {
+    $hasMixedRequirements        = $hasPerCollectorRequirements -and ($collectors | Where-Object { -not $_.ContainsKey('RequiredServices') }).Count -gt 0
+    if (-not $SkipConnection -and (-not $hasPerCollectorRequirements -or $hasMixedRequirements)) {
         $sectionServices = $sectionServiceMap[$sectionName]
         Connect-RequiredService -Services $sectionServices -SectionName $sectionName
     }

--- a/src/M365-Assess/Orchestrator/AssessmentMaps.ps1
+++ b/src/M365-Assess/Orchestrator/AssessmentMaps.ps1
@@ -64,18 +64,18 @@ $collectorMap = [ordered]@{
         @{ Name = '01-Tenant-Info';   Script = 'Entra\Get-TenantInfo.ps1'; Label = 'Tenant Information' }
     )
     'Identity' = @(
-        @{ Name = '02-User-Summary';           Script = 'Entra\Get-UserSummary.ps1';              Label = 'User Summary' }
-        @{ Name = '03-MFA-Report';             Script = 'Entra\Get-MfaReport.ps1';                Label = 'MFA Report' }
-        @{ Name = '04-Admin-Roles';            Script = 'Entra\Get-AdminRoleReport.ps1';           Label = 'Admin Roles' }
-        @{ Name = '05-Conditional-Access';     Script = 'Entra\Get-ConditionalAccessReport.ps1';   Label = 'Conditional Access' }
-        @{ Name = '06-App-Registrations';      Script = 'Entra\Get-AppRegistrationReport.ps1';     Label = 'App Registrations' }
-        @{ Name = '07-Password-Policy';        Script = 'Entra\Get-PasswordPolicyReport.ps1';      Label = 'Password Policy' }
-        @{ Name = '07b-Entra-Security-Config'; Script = 'Entra\Get-EntraSecurityConfig.ps1';       Label = 'Entra Security Config' }
-        @{ Name = '07c-CA-Security-Config';   Script = 'Entra\Get-CASecurityConfig.ps1';         Label = 'CA Policy Evaluation' }
-        @{ Name = '07d-EntApp-Security-Config'; Script = 'Entra\Get-EntAppSecurityConfig.ps1';   Label = 'Enterprise App Security' }
-        @{ Name = '07e-Entra-SoD-Config';    Script = 'Entra\Get-EntraSoDConfig.ps1';         Label = 'Separation of Duties'; RequiredServices = @('Graph') }
-        @{ Name = '07f-Entra-ToU-Config';    Script = 'Entra\Get-EntraTouConfig.ps1';         Label = 'Terms of Use'; RequiredServices = @('Graph') }
-        @{ Name = '07g-Entra-PrivRemote';    Script = 'Entra\Get-EntraPrivRemoteConfig.ps1';  Label = 'Privileged Remote Access'; RequiredServices = @('Graph') }
+        @{ Name = '02-User-Summary';           Script = 'Entra\Get-UserSummary.ps1';              Label = 'User Summary';              RequiredServices = @('Graph') }
+        @{ Name = '03-MFA-Report';             Script = 'Entra\Get-MfaReport.ps1';                Label = 'MFA Report';                RequiredServices = @('Graph') }
+        @{ Name = '04-Admin-Roles';            Script = 'Entra\Get-AdminRoleReport.ps1';           Label = 'Admin Roles';               RequiredServices = @('Graph') }
+        @{ Name = '05-Conditional-Access';     Script = 'Entra\Get-ConditionalAccessReport.ps1';   Label = 'Conditional Access';        RequiredServices = @('Graph') }
+        @{ Name = '06-App-Registrations';      Script = 'Entra\Get-AppRegistrationReport.ps1';     Label = 'App Registrations';         RequiredServices = @('Graph') }
+        @{ Name = '07-Password-Policy';        Script = 'Entra\Get-PasswordPolicyReport.ps1';      Label = 'Password Policy';           RequiredServices = @('Graph') }
+        @{ Name = '07b-Entra-Security-Config'; Script = 'Entra\Get-EntraSecurityConfig.ps1';       Label = 'Entra Security Config';     RequiredServices = @('Graph') }
+        @{ Name = '07c-CA-Security-Config';    Script = 'Entra\Get-CASecurityConfig.ps1';          Label = 'CA Policy Evaluation';      RequiredServices = @('Graph') }
+        @{ Name = '07d-EntApp-Security-Config'; Script = 'Entra\Get-EntAppSecurityConfig.ps1';     Label = 'Enterprise App Security';   RequiredServices = @('Graph') }
+        @{ Name = '07e-Entra-SoD-Config';      Script = 'Entra\Get-EntraSoDConfig.ps1';            Label = 'Separation of Duties';      RequiredServices = @('Graph') }
+        @{ Name = '07f-Entra-ToU-Config';      Script = 'Entra\Get-EntraTouConfig.ps1';            Label = 'Terms of Use';              RequiredServices = @('Graph') }
+        @{ Name = '07g-Entra-PrivRemote';      Script = 'Entra\Get-EntraPrivRemoteConfig.ps1';     Label = 'Privileged Remote Access';  RequiredServices = @('Graph') }
     )
     'Licensing' = @(
         @{ Name = '08-License-Summary'; Script = 'Entra\Get-LicenseReport.ps1'; Label = 'License Summary'; Params = @{} }

--- a/src/M365-Assess/Orchestrator/Test-GraphPermissions.ps1
+++ b/src/M365-Assess/Orchestrator/Test-GraphPermissions.ps1
@@ -86,7 +86,11 @@ function Test-GraphPermissions {
         $scopeList = ($affectedSections[$section] | Sort-Object) -join ', '
         Write-Host "      ${section}: $scopeList" -ForegroundColor Yellow
     }
-    Write-Host '    Tip: re-run consent or update app registration to include these scopes' -ForegroundColor DarkGray
+    $scopeArg = ($missingScopes | Sort-Object) -join ','
+    Write-Host "    To fix: close this session and re-run the assessment. When the browser opens," -ForegroundColor DarkGray
+    Write-Host "    sign in as a Global Admin and click 'Accept' to grant the missing permission(s)." -ForegroundColor DarkGray
+    Write-Host "    If consent was already granted by an admin, run in a new PowerShell session:" -ForegroundColor DarkGray
+    Write-Host "      Disconnect-MgGraph; Connect-MgGraph -Scopes '$scopeArg'" -ForegroundColor Cyan
     Write-Host ''
 
     Write-AssessmentLog -Level WARN -Message "Missing Graph scopes: $($missingScopes -join ', ')" -Section 'Setup'

--- a/src/M365-Assess/Orchestrator/Test-GraphPermissions.ps1
+++ b/src/M365-Assess/Orchestrator/Test-GraphPermissions.ps1
@@ -86,11 +86,19 @@ function Test-GraphPermissions {
         $scopeList = ($affectedSections[$section] | Sort-Object) -join ', '
         Write-Host "      ${section}: $scopeList" -ForegroundColor Yellow
     }
-    $scopeArg = ($missingScopes | Sort-Object) -join ','
-    Write-Host "    To fix: close this session and re-run the assessment. When the browser opens," -ForegroundColor DarkGray
-    Write-Host "    sign in as a Global Admin and click 'Accept' to grant the missing permission(s)." -ForegroundColor DarkGray
-    Write-Host "    If consent was already granted by an admin, run in a new PowerShell session:" -ForegroundColor DarkGray
-    Write-Host "      Disconnect-MgGraph; Connect-MgGraph -Scopes '$scopeArg'" -ForegroundColor Cyan
+    if ($context.AuthType -eq 'AppOnly') {
+        Write-Host "    To fix: add the missing permission(s) to your app registration, then grant admin consent." -ForegroundColor DarkGray
+        Write-Host "    Entra ID > App registrations > [your app] > API permissions >" -ForegroundColor DarkGray
+        Write-Host "      Add a permission > Microsoft Graph > Application permissions" -ForegroundColor DarkGray
+        Write-Host "    Then click 'Grant admin consent for [tenant]' and re-run." -ForegroundColor DarkGray
+    }
+    else {
+        $scopeArg = ($missingScopes | Sort-Object) -join ','
+        Write-Host "    To fix: close this session and re-run the assessment. When the browser opens," -ForegroundColor DarkGray
+        Write-Host "    sign in as a Global Admin and click 'Accept' to grant the missing permission(s)." -ForegroundColor DarkGray
+        Write-Host "    If consent was already granted by an admin, run in a new PowerShell session:" -ForegroundColor DarkGray
+        Write-Host "      Disconnect-MgGraph; Connect-MgGraph -Scopes '$scopeArg'" -ForegroundColor Cyan
+    }
     Write-Host ''
 
     Write-AssessmentLog -Level WARN -Message "Missing Graph scopes: $($missingScopes -join ', ')" -Section 'Setup'


### PR DESCRIPTION
## Summary

Identity collectors `02`–`07d` had no `RequiredServices` annotation. The orchestrator's dispatch logic only connects section-level services upfront when *no* collectors have `RequiredServices`. Since `07e`–`07g` had the annotation, the orchestrator used per-collector lazy mode — and `02`–`07d` ran with zero Graph connection, failing with "Not connected to Microsoft Graph."

Observed in assessment log: User Summary, MFA Report, Admin Roles, Conditional Access, App Registrations, and Password Policy all skipped with "Prerequisite not met" before `07e` finally triggered the connection.

## Changes

### `AssessmentMaps.ps1`
Add `RequiredServices = @('Graph')` to all 12 Identity collectors. The first collector (User Summary) now triggers the connection before any data collection begins.

### `Invoke-M365Assessment.ps1`
Harden dispatch logic: if a section is mixed (some collectors annotated, some not), connect section-level services upfront so un-annotated collectors are never dispatched without a connection. Per-collector `Connect-RequiredService` calls are idempotent and no-op if already connected.

## Test plan
- [ ] Run `-Section Identity`-only assessment — no "Prerequisite not met" warnings in issues log
- [ ] User Summary, MFA Report, Admin Roles, Conditional Access, App Registrations, Password Policy all return data
- [ ] Full assessment unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)