### PR TITLE
fix: emit Skipped on Graph errors in EntraUserGroupChecks (#462)

### DIFF
--- a/src/M365-Assess/Common/SecurityConfigHelper.ps1
+++ b/src/M365-Assess/Common/SecurityConfigHelper.ps1
@@ -88,7 +88,7 @@ function Add-SecuritySetting {
         [string]$RecommendedValue,
 
         [Parameter(Mandatory)]
-        [ValidateSet('Pass', 'Fail', 'Warning', 'Review', 'Info', 'Unknown')]
+        [ValidateSet('Pass', 'Fail', 'Warning', 'Review', 'Info', 'Skipped', 'Unknown')]
         [string]$Status,
 
         [Parameter()]

--- a/src/M365-Assess/Entra/EntraUserGroupChecks.ps1
+++ b/src/M365-Assess/Entra/EntraUserGroupChecks.ps1
@@ -43,6 +43,16 @@ if ($authPolicy) {
     }
     catch {
         Write-Warning "Could not check user consent policy: $_"
+        $settingParams = @{
+            CheckId          = 'ENTRA-CONSENT-001'
+            Category         = 'Application Consent'
+            Setting          = 'User Consent for Applications'
+            CurrentValue     = "Error: $($_.Exception.Message)"
+            RecommendedValue = 'Do not allow user consent'
+            Status           = 'Skipped'
+            Remediation      = 'Check Graph API permissions and retry.'
+        }
+        Add-Setting @settingParams
     }
 
     # 4. Users Can Register Applications
@@ -62,6 +72,16 @@ if ($authPolicy) {
     }
     catch {
         Write-Warning "Could not check app registration policy: $_"
+        $settingParams = @{
+            CheckId          = 'ENTRA-APPREG-001'
+            Category         = 'Application Consent'
+            Setting          = 'Users Can Register Applications'
+            CurrentValue     = "Error: $($_.Exception.Message)"
+            RecommendedValue = 'False'
+            Status           = 'Skipped'
+            Remediation      = 'Check Graph API permissions and retry.'
+        }
+        Add-Setting @settingParams
     }
 
     # 5. Users Can Create Security Groups
@@ -80,6 +100,16 @@ if ($authPolicy) {
     }
     catch {
         Write-Warning "Could not check group creation policy: $_"
+        $settingParams = @{
+            CheckId          = 'ENTRA-GROUP-001'
+            Category         = 'Directory Settings'
+            Setting          = 'Users Can Create Security Groups'
+            CurrentValue     = "Error: $($_.Exception.Message)"
+            RecommendedValue = 'False'
+            Status           = 'Skipped'
+            Remediation      = 'Check Graph API permissions and retry.'
+        }
+        Add-Setting @settingParams
     }
 
     # 5b. Restrict Non-Admin Tenant Creation (CIS 5.1.2.3)
@@ -98,6 +128,16 @@ if ($authPolicy) {
     }
     catch {
         Write-Warning "Could not check tenant creation policy: $_"
+        $settingParams = @{
+            CheckId          = 'ENTRA-TENANT-001'
+            Category         = 'Directory Settings'
+            Setting          = 'Non-Admin Tenant Creation Restricted'
+            CurrentValue     = "Error: $($_.Exception.Message)"
+            RecommendedValue = 'False'
+            Status           = 'Skipped'
+            Remediation      = 'Check Graph API permissions and retry.'
+        }
+        Add-Setting @settingParams
     }
 }
 
@@ -127,6 +167,16 @@ try {
 }
 catch {
     Write-Warning "Could not check admin consent workflow: $_"
+    $settingParams = @{
+        CheckId          = 'ENTRA-CONSENT-002'
+        Category         = 'Application Consent'
+        Setting          = 'Admin Consent Workflow Enabled'
+        CurrentValue     = "Error: $($_.Exception.Message)"
+        RecommendedValue = 'True'
+        Status           = 'Skipped'
+        Remediation      = 'Check Graph API permissions and retry.'
+    }
+    Add-Setting @settingParams
 }
 
 # ------------------------------------------------------------------
@@ -159,6 +209,16 @@ try {
 }
 catch {
     Write-Warning "Could not check verified publisher consent restriction: $_"
+    $settingParams = @{
+        CheckId          = 'ENTRA-CONSENT-003'
+        Category         = 'Application Consent'
+        Setting          = 'User Consent Requires Verified Publisher'
+        CurrentValue     = "Error: $($_.Exception.Message)"
+        RecommendedValue = 'User consent restricted to verified publishers or fully blocked'
+        Status           = 'Skipped'
+        Remediation      = 'Check Graph API permissions and retry.'
+    }
+    Add-Setting @settingParams
 }
 
 # ------------------------------------------------------------------
@@ -187,6 +247,16 @@ try {
 }
 catch {
     Write-Warning "Could not check tenant-wide consent grants: $_"
+    $settingParams = @{
+        CheckId          = 'ENTRA-CONSENT-004'
+        Category         = 'Application Consent'
+        Setting          = 'Tenant-Wide Admin Consent Grants'
+        CurrentValue     = "Error: $($_.Exception.Message)"
+        RecommendedValue = 'Review and minimize tenant-wide admin consent grants'
+        Status           = 'Skipped'
+        Remediation      = 'Check Graph API permissions and retry.'
+    }
+    Add-Setting @settingParams
 }
 
 # ------------------------------------------------------------------
@@ -245,6 +315,26 @@ if ($authPolicy) {
     }
     catch {
         Write-Warning "Could not check external collaboration: $_"
+        $settingParams = @{
+            CheckId          = 'ENTRA-GUEST-002'
+            Category         = 'External Collaboration'
+            Setting          = 'Guest Invitation Policy'
+            CurrentValue     = "Error: $($_.Exception.Message)"
+            RecommendedValue = 'Admins and guest inviters only'
+            Status           = 'Skipped'
+            Remediation      = 'Check Graph API permissions and retry.'
+        }
+        Add-Setting @settingParams
+        $settingParams = @{
+            CheckId          = 'ENTRA-GUEST-001'
+            Category         = 'External Collaboration'
+            Setting          = 'Guest User Access Restriction'
+            CurrentValue     = "Error: $($_.Exception.Message)"
+            RecommendedValue = 'Restricted access'
+            Status           = 'Skipped'
+            Remediation      = 'Check Graph API permissions and retry.'
+        }
+        Add-Setting @settingParams
     }
 }
 
@@ -273,6 +363,16 @@ try {
 }
 catch {
     Write-Warning "Could not count guest users: $_"
+    $settingParams = @{
+        CheckId          = 'ENTRA-GUEST-003'
+        Category         = 'External Collaboration'
+        Setting          = 'Guest User Count'
+        CurrentValue     = "Error: $($_.Exception.Message)"
+        RecommendedValue = 'Review periodically'
+        Status           = 'Skipped'
+        Remediation      = 'Check Graph API permissions and retry.'
+    }
+    Add-Setting @settingParams
 }
 
 # ------------------------------------------------------------------
@@ -306,6 +406,16 @@ try {
 }
 catch {
     Write-Warning "Could not check LinkedIn account connections: $_"
+    $settingParams = @{
+        CheckId          = 'ENTRA-LINKEDIN-001'
+        Category         = 'Directory Settings'
+        Setting          = 'LinkedIn Account Connections'
+        CurrentValue     = "Error: $($_.Exception.Message)"
+        RecommendedValue = 'Disabled'
+        Status           = 'Skipped'
+        Remediation      = 'Check Graph API permissions and retry.'
+    }
+    Add-Setting @settingParams
 }
 
 # ------------------------------------------------------------------
@@ -368,6 +478,16 @@ if ($authPolicy) {
     }
     catch {
         Write-Warning "Could not check third-party app restrictions: $_"
+        $settingParams = @{
+            CheckId          = 'ENTRA-APPS-001'
+            Category         = 'Application Consent'
+            Setting          = 'Third-party Integrated Apps Restricted'
+            CurrentValue     = "Error: $($_.Exception.Message)"
+            RecommendedValue = 'Restricted'
+            Status           = 'Skipped'
+            Remediation      = 'Check Graph API permissions and retry.'
+        }
+        Add-Setting @settingParams
     }
 }
 
@@ -407,6 +527,16 @@ try {
 }
 catch {
     Write-Warning "Could not check guest invitation restrictions: $_"
+    $settingParams = @{
+        CheckId          = 'ENTRA-GUEST-004'
+        Category         = 'External Collaboration'
+        Setting          = 'Guest Invitation Domain Restrictions'
+        CurrentValue     = "Error: $($_.Exception.Message)"
+        RecommendedValue = 'Restricted to allowed domains only'
+        Status           = 'Skipped'
+        Remediation      = 'Check Graph API permissions and retry.'
+    }
+    Add-Setting @settingParams
 }
 
 # ------------------------------------------------------------------
@@ -453,6 +583,16 @@ try {
 }
 catch {
     Write-Warning "Could not check dynamic guest groups: $_"
+    $settingParams = @{
+        CheckId          = 'ENTRA-GROUP-002'
+        Category         = 'External Collaboration'
+        Setting          = 'Dynamic Group for Guest Users'
+        CurrentValue     = "Error: $($_.Exception.Message)"
+        RecommendedValue = 'At least 1 dynamic group for guests'
+        Status           = 'Skipped'
+        Remediation      = 'Check Graph API permissions and retry.'
+    }
+    Add-Setting @settingParams
 }
 
 # ------------------------------------------------------------------
@@ -515,6 +655,16 @@ try {
 }
 catch {
     Write-Warning "Could not check public group owners: $_"
+    $settingParams = @{
+        CheckId          = 'ENTRA-GROUP-003'
+        Category         = 'Group Management'
+        Setting          = 'Public Groups Have Owners'
+        CurrentValue     = "Error: $($_.Exception.Message)"
+        RecommendedValue = 'All public groups have assigned owners'
+        Status           = 'Skipped'
+        Remediation      = 'Check Graph API permissions and retry.'
+    }
+    Add-Setting @settingParams
 }
 
 # ------------------------------------------------------------------
@@ -546,6 +696,16 @@ try {
 }
 catch {
     Write-Warning "Could not check user app consent: $_"
+    $settingParams = @{
+        CheckId          = 'ENTRA-ORGSETTING-001'
+        Category         = 'Organization Settings'
+        Setting          = 'Org-Level App Consent Restriction'
+        CurrentValue     = "Error: $($_.Exception.Message)"
+        RecommendedValue = 'Do not allow user consent'
+        Status           = 'Skipped'
+        Remediation      = 'Check Graph API permissions and retry.'
+    }
+    Add-Setting @settingParams
 }
 
 # ------------------------------------------------------------------

--- a/src/M365-Assess/Entra/Get-EntraSecurityConfig.ps1
+++ b/src/M365-Assess/Entra/Get-EntraSecurityConfig.ps1
@@ -56,7 +56,7 @@ function Add-Setting {
     param(
         [string]$Category, [string]$Setting, [string]$CurrentValue,
         [string]$RecommendedValue,
-        [ValidateSet('Pass', 'Fail', 'Warning', 'Review', 'Info', 'Unknown')]
+        [ValidateSet('Pass', 'Fail', 'Warning', 'Review', 'Info', 'Skipped', 'Unknown')]
         [string]$Status,
         [string]$CheckId = '', [string]$Remediation = ''
     )

--- a/src/M365-Assess/Exchange-Online/Get-ExoSecurityConfig.ps1
+++ b/src/M365-Assess/Exchange-Online/Get-ExoSecurityConfig.ps1
@@ -42,7 +42,7 @@ function Add-Setting {
     param(
         [string]$Category, [string]$Setting, [string]$CurrentValue,
         [string]$RecommendedValue,
-        [ValidateSet('Pass', 'Fail', 'Warning', 'Review', 'Info', 'Unknown')]
+        [ValidateSet('Pass', 'Fail', 'Warning', 'Review', 'Info', 'Skipped', 'Unknown')]
         [string]$Status,
         [string]$CheckId = '', [string]$Remediation = ''
     )

--- a/tests/Entra/EntraUserGroupChecks.Tests.ps1
+++ b/tests/Entra/EntraUserGroupChecks.Tests.ps1
@@ -134,7 +134,7 @@ Describe 'EntraUserGroupChecks' {
     }
 
     It 'All Status values are valid' {
-        $validStatuses = @('Pass', 'Fail', 'Warning', 'Review', 'Info', 'N/A')
+        $validStatuses = @('Pass', 'Fail', 'Warning', 'Review', 'Info', 'N/A', 'Skipped')
         foreach ($s in $settings) {
             $s.Status | Should -BeIn $validStatuses `
                 -Because "Setting '$($s.Setting)' has status '$($s.Status)'"
@@ -321,6 +321,125 @@ Describe 'EntraUserGroupChecks - Insecure Settings' {
         $check = $settings | Where-Object { $_.Setting -eq 'LinkedIn Account Connections' }
         $check | Should -Not -BeNullOrEmpty
         $check.Status | Should -Be 'Fail'
+    }
+
+    AfterAll {
+        Remove-Item Function:\Update-CheckProgress -ErrorAction SilentlyContinue
+        Remove-Item Function:\Get-MgContext -ErrorAction SilentlyContinue
+        Remove-Item Function:\Add-Setting -ErrorAction SilentlyContinue
+    }
+}
+
+Describe 'EntraUserGroupChecks - Skipped fallback on API error' {
+    BeforeAll {
+        function global:Update-CheckProgress {
+            param($CheckId, $Setting, $Status)
+        }
+
+        function global:Get-MgContext {
+            return @{ TenantId = 'test-tenant-id' }
+        }
+
+        Mock Import-Module { }
+
+        # Every Graph call throws to simulate throttle/auth failures
+        Mock Invoke-MgGraphRequest {
+            throw 'Simulated Graph API error'
+        }
+
+        . "$PSScriptRoot/../../src/M365-Assess/Orchestrator/AssessmentHelpers.ps1"
+        . "$PSScriptRoot/../../src/M365-Assess/Common/SecurityConfigHelper.ps1"
+
+        $ctx            = Initialize-SecurityConfig
+        $settings       = $ctx.Settings
+        $checkIdCounter = $ctx.CheckIdCounter
+
+        function Add-Setting {
+            param([string]$Category, [string]$Setting, [string]$CurrentValue,
+                  [string]$RecommendedValue, [string]$Status,
+                  [string]$CheckId = '', [string]$Remediation = '')
+            Add-SecuritySetting -Settings $settings -CheckIdCounter $checkIdCounter `
+                -Category $Category -Setting $Setting -CurrentValue $CurrentValue `
+                -RecommendedValue $RecommendedValue -Status $Status `
+                -CheckId $CheckId -Remediation $Remediation
+        }
+
+        $authPolicy = $null
+        $context    = @{ TenantId = 'test-tenant-id' }
+
+        . "$PSScriptRoot/../../src/M365-Assess/Entra/EntraUserGroupChecks.ps1"
+    }
+
+    It 'should not throw when all Graph calls fail' {
+        $settings | Should -Not -BeNullOrEmpty
+    }
+
+    It 'should emit a Skipped result for ENTRA-CONSENT-002 when admin consent API fails' {
+        $check = $settings | Where-Object { $_.Setting -eq 'Admin Consent Workflow Enabled' }
+        $check | Should -Not -BeNullOrEmpty
+        $check.Status | Should -Be 'Skipped'
+    }
+
+    It 'should emit a Skipped result for ENTRA-CONSENT-003 when verified publisher check fails' {
+        $check = $settings | Where-Object { $_.Setting -eq 'User Consent Requires Verified Publisher' }
+        $check | Should -Not -BeNullOrEmpty
+        $check.Status | Should -Be 'Skipped'
+    }
+
+    It 'should emit a Skipped result for ENTRA-CONSENT-004 when tenant-wide consent grants fail' {
+        $check = $settings | Where-Object { $_.Setting -eq 'Tenant-Wide Admin Consent Grants' }
+        $check | Should -Not -BeNullOrEmpty
+        $check.Status | Should -Be 'Skipped'
+    }
+
+    It 'should emit a Skipped result for ENTRA-GUEST-003 when guest count fails' {
+        $check = $settings | Where-Object { $_.Setting -eq 'Guest User Count' }
+        $check | Should -Not -BeNullOrEmpty
+        $check.Status | Should -Be 'Skipped'
+    }
+
+    It 'should emit a Skipped result for ENTRA-LINKEDIN-001 when LinkedIn API fails' {
+        $check = $settings | Where-Object { $_.Setting -eq 'LinkedIn Account Connections' }
+        $check | Should -Not -BeNullOrEmpty
+        $check.Status | Should -Be 'Skipped'
+    }
+
+    It 'should emit a Skipped result for ENTRA-GUEST-004 when cross-tenant policy fails' {
+        $check = $settings | Where-Object { $_.Setting -eq 'Guest Invitation Domain Restrictions' }
+        $check | Should -Not -BeNullOrEmpty
+        $check.Status | Should -Be 'Skipped'
+    }
+
+    It 'should emit a Skipped result for ENTRA-GROUP-002 when dynamic group query fails' {
+        $check = $settings | Where-Object { $_.Setting -eq 'Dynamic Group for Guest Users' }
+        $check | Should -Not -BeNullOrEmpty
+        $check.Status | Should -Be 'Skipped'
+    }
+
+    It 'should emit a Skipped result for ENTRA-GROUP-003 when group owners query fails' {
+        $check = $settings | Where-Object { $_.Setting -eq 'Public Groups Have Owners' }
+        $check | Should -Not -BeNullOrEmpty
+        $check.Status | Should -Be 'Skipped'
+    }
+
+    It 'should emit a Skipped result for ENTRA-ORGSETTING-001 when app consent policy fails' {
+        $check = $settings | Where-Object { $_.Setting -eq 'Org-Level App Consent Restriction' }
+        $check | Should -Not -BeNullOrEmpty
+        $check.Status | Should -Be 'Skipped'
+    }
+
+    It 'should include the error message in CurrentValue for skipped checks' {
+        $skipped = @($settings | Where-Object { $_.Status -eq 'Skipped' })
+        $skipped.Count | Should -BeGreaterThan 0
+        foreach ($s in $skipped) {
+            $s.CurrentValue | Should -Match 'Error:'
+        }
+    }
+
+    It 'should still emit Review result for ENTRA-PERUSER-001 even when API call fails' {
+        $check = $settings | Where-Object { $_.Setting -eq 'Per-user MFA (Legacy)' }
+        $check | Should -Not -BeNullOrEmpty
+        $check.Status | Should -Be 'Review'
     }
 
     AfterAll {


### PR DESCRIPTION
## Summary

- Adds `Skipped` fallback `Add-Setting` calls to all 15 bare `catch` blocks in `EntraUserGroupChecks.ps1` — checks that hit Graph API throttle or auth errors now appear in the report as `Skipped` instead of silently vanishing
- Adds `'Skipped'` to the `[ValidateSet]` in `SecurityConfigHelper.ps1`, `Get-EntraSecurityConfig.ps1`, and `Get-ExoSecurityConfig.ps1`
- Fixes the `@{...}` vs `@variableName` PowerShell splatting pitfall (inline hashtable is a positional argument, not a splat)
- 12 new Pester tests in a third `Describe` block that mocks all Graph calls to throw and verifies every affected CheckId emits `Status = 'Skipped'` with an error message in `CurrentValue`

**Observed trigger:** `ENTRA-CONSENT-002` hit Graph's `accessreviews.app.1m` rate limit and disappeared entirely from the CSV output.

## Test plan

- [ ] `Invoke-Pester -Path './tests/Entra/EntraUserGroupChecks.Tests.ps1' -Output Detailed` — all 31 tests pass
- [ ] `Invoke-Pester -Path './tests' -Output Normal` — all 1802 tests pass, no regressions
- [ ] Run assessment against throttle-prone tenant and verify throttled checks appear as `Skipped` in report

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)