### PR TITLE
fix: report bugs and quick wins (#451, #453, #457, #458, #459, #464)

### DIFF
--- a/src/M365-Assess/Common/Build-SectionHtml.ps1
+++ b/src/M365-Assess/Common/Build-SectionHtml.ps1
@@ -268,6 +268,7 @@ foreach ($sectionName in $sections) {
     }
 
     $sectionId = ($sectionName -replace '[^a-zA-Z0-9]', '-').ToLower()
+    $sectionPageStart = $sectionHtml.Length
     $null = $sectionHtml.AppendLine("<div class='report-page' data-page='section-$sectionId'>")
     $null = $sectionHtml.AppendLine("<details class='section' id='section-$sectionId' open>")
     $null = $sectionHtml.AppendLine("<summary><h2>$([System.Web.HttpUtility]::HtmlEncode($sectionName))</h2></summary>")
@@ -846,6 +847,24 @@ foreach ($sectionName in $sections) {
             $null = $sectionHtml.AppendLine("<div class='email-dashboard'>")
             $null = $sectionHtml.AppendLine("<div class='email-dash-top'>")
 
+            # Helper: build status badge HTML from CSS class
+            $collabBadge = {
+                param($cls)
+                switch ($cls) {
+                    'success' { "<span class='badge badge-success'>Pass</span>" }
+                    'warning' { "<span class='badge badge-warning'>Warning</span>" }
+                    'danger'  { "<span class='badge badge-failed'>Fail</span>" }
+                    default   { "<span class='badge badge-neutral'>Unknown</span>" }
+                }
+            }
+
+            # Helper: build a collab tile
+            $collabTile = {
+                param($cls, $icon, $value, $label, $tooltip)
+                $badge = & $collabBadge $cls
+                "<div class='email-metric-card id-metric-$cls' title='$(ConvertTo-HtmlSafe -Text $tooltip)'><div class='email-metric-icon'>$icon</div><div class='email-metric-body'><div class='email-metric-value'>$(ConvertTo-HtmlSafe -Text $value)</div><div class='email-metric-label'>$label</div>$badge</div></div>"
+            }
+
             # --- Left column: SharePoint & Teams settings as icon metric cards ---
             $null = $sectionHtml.AppendLine("<div class='email-dash-col'>")
             $null = $sectionHtml.AppendLine("<div class='email-dash-heading'>Collaboration Settings</div>")
@@ -854,6 +873,8 @@ foreach ($sectionName in $sections) {
             if ($spoData.Count -gt 0) {
                 $spo = $spoData[0]
                 $spoProps = @($spo.PSObject.Properties.Name)
+
+                $null = $sectionHtml.AppendLine("<div class='collab-group-header'>SharePoint &amp; OneDrive</div>")
 
                 # Sharing Capability
                 $sharingCap = if ($spoProps -contains 'SharingCapability') { $spo.SharingCapability } else { 'Unknown' }
@@ -871,7 +892,7 @@ foreach ($sectionName in $sections) {
                     'ExternalUserAndGuestSharing'      { 'danger' }
                     default { '' }
                 }
-                $null = $sectionHtml.AppendLine("<div class='email-metric-card id-metric-$sharingClass'><div class='email-metric-icon'>&#128279;</div><div class='email-metric-body'><div class='email-metric-value'>$(ConvertTo-HtmlSafe -Text $sharingDisplay)</div><div class='email-metric-label'>External Sharing</div></div></div>")
+                $null = $sectionHtml.AppendLine((& $collabTile $sharingClass '&#128279;' $sharingDisplay 'External Sharing' 'External Sharing — Recommended: Disabled or Existing Guests only'))
 
                 # Domain Restriction
                 $domainRestrict = if ($spoProps -contains 'SharingDomainRestrictionMode') { $spo.SharingDomainRestrictionMode } else { 'Unknown' }
@@ -882,43 +903,44 @@ foreach ($sectionName in $sections) {
                     'None'       { 'None' }
                     default      { $domainRestrict }
                 }
-                $null = $sectionHtml.AppendLine("<div class='email-metric-card id-metric-$drClass'><div class='email-metric-icon'>&#127760;</div><div class='email-metric-body'><div class='email-metric-value'>$(ConvertTo-HtmlSafe -Text $drDisplay)</div><div class='email-metric-label'>Domain Restriction</div></div></div>")
+                $null = $sectionHtml.AppendLine((& $collabTile $drClass '&#127760;' $drDisplay 'Domain Restriction' 'Domain Restriction — Recommended: Allow List or Block List configured'))
 
                 # Resharing
                 $resharing = if ($spoProps -contains 'IsResharingByExternalUsersEnabled') { $spo.IsResharingByExternalUsersEnabled } else { 'Unknown' }
                 $reshareClass = if ($resharing -eq 'False') { 'success' } else { 'danger' }
-                $reshareIcon = if ($resharing -eq 'False') { '&#128683;' } else { '&#9888;' }
-                $null = $sectionHtml.AppendLine("<div class='email-metric-card id-metric-$reshareClass'><div class='email-metric-icon'>$reshareIcon</div><div class='email-metric-body'><div class='email-metric-value'>$(ConvertTo-HtmlSafe -Text $resharing)</div><div class='email-metric-label'>External Resharing</div></div></div>")
+                $null = $sectionHtml.AppendLine((& $collabTile $reshareClass '&#128279;' $resharing 'External Resharing' 'External Resharing — Recommended: False (guests cannot reshare)'))
 
                 # Sync Client Restriction
                 $syncRestrict = if ($spoProps -contains 'IsUnmanagedSyncClientRestricted') { $spo.IsUnmanagedSyncClientRestricted } else { 'Unknown' }
                 $syncClass = if ($syncRestrict -eq 'True') { 'success' } else { 'warning' }
-                $null = $sectionHtml.AppendLine("<div class='email-metric-card id-metric-$syncClass'><div class='email-metric-icon'>&#128260;</div><div class='email-metric-body'><div class='email-metric-value'>$(ConvertTo-HtmlSafe -Text $syncRestrict)</div><div class='email-metric-label'>Unmanaged Sync Blocked</div></div></div>")
+                $null = $sectionHtml.AppendLine((& $collabTile $syncClass '&#128260;' $syncRestrict 'Unmanaged Sync Blocked' 'Unmanaged Sync — Recommended: True (restrict unmanaged devices)'))
             }
 
             if ($teamAccData.Count -gt 0) {
                 $team = $teamAccData[0]
                 $tProps = @($team.PSObject.Properties.Name)
 
+                $null = $sectionHtml.AppendLine("<div class='collab-group-header'>Microsoft Teams</div>")
+
                 # Guest Access
                 $guestAccess = if ($tProps -contains 'AllowGuestAccess') { $team.AllowGuestAccess } else { 'Unknown' }
                 $guestClass = if ($guestAccess -eq 'False') { 'success' } else { 'warning' }
-                $null = $sectionHtml.AppendLine("<div class='email-metric-card id-metric-$guestClass'><div class='email-metric-icon'>&#128101;</div><div class='email-metric-body'><div class='email-metric-value'>$(ConvertTo-HtmlSafe -Text $guestAccess)</div><div class='email-metric-label'>Teams Guest Access</div></div></div>")
+                $null = $sectionHtml.AppendLine((& $collabTile $guestClass '&#128101;' $guestAccess 'Guest Access' 'Guest Access — Recommended: False or controlled via CA policy'))
 
                 # Third Party Apps
                 $thirdParty = if ($tProps -contains 'AllowThirdPartyApps') { $team.AllowThirdPartyApps } else { 'Unknown' }
                 $tpClass = if ($thirdParty -eq 'False') { 'success' } else { 'warning' }
-                $null = $sectionHtml.AppendLine("<div class='email-metric-card id-metric-$tpClass'><div class='email-metric-icon'>&#128268;</div><div class='email-metric-body'><div class='email-metric-value'>$(ConvertTo-HtmlSafe -Text $thirdParty)</div><div class='email-metric-label'>Third-Party Apps</div></div></div>")
+                $null = $sectionHtml.AppendLine((& $collabTile $tpClass '&#128268;' $thirdParty 'Third-Party Apps' 'Third-Party Apps — Recommended: False (restrict external app access)'))
 
                 # Side Loading
                 $sideLoad = if ($tProps -contains 'AllowSideLoading') { $team.AllowSideLoading } else { 'Unknown' }
                 $slClass = if ($sideLoad -eq 'False') { 'success' } else { 'danger' }
-                $null = $sectionHtml.AppendLine("<div class='email-metric-card id-metric-$slClass'><div class='email-metric-icon'>&#128230;</div><div class='email-metric-body'><div class='email-metric-value'>$(ConvertTo-HtmlSafe -Text $sideLoad)</div><div class='email-metric-label'>Side Loading</div></div></div>")
+                $null = $sectionHtml.AppendLine((& $collabTile $slClass '&#128230;' $sideLoad 'App Sideloading' 'App Sideloading — Recommended: False (prevent unapproved app installs)'))
 
                 # Resource-Specific Consent
                 $rscConsent = if ($tProps -contains 'IsUserPersonalScopeResourceSpecificConsentEnabled') { $team.IsUserPersonalScopeResourceSpecificConsentEnabled } else { 'Unknown' }
                 $rscClass = if ($rscConsent -eq 'False') { 'success' } else { 'warning' }
-                $null = $sectionHtml.AppendLine("<div class='email-metric-card id-metric-$rscClass'><div class='email-metric-icon'>&#128273;</div><div class='email-metric-body'><div class='email-metric-value'>$(ConvertTo-HtmlSafe -Text $rscConsent)</div><div class='email-metric-label'>Resource Consent</div></div></div>")
+                $null = $sectionHtml.AppendLine((& $collabTile $rscClass '&#128273;' $rscConsent 'Resource Consent' 'Resource-Specific Consent — Recommended: False (control app data access)'))
             }
 
             $null = $sectionHtml.AppendLine("</div>") # end email-metrics-grid
@@ -1389,6 +1411,15 @@ foreach ($sectionName in $sections) {
 
     $null = $sectionHtml.AppendLine("</details>")
     $null = $sectionHtml.AppendLine("</div>") # close report-page wrapper
+
+    # Single-table sections: remove height constraint so table fills viewport
+    $sectionChunk = $sectionHtml.ToString().Substring($sectionPageStart)
+    $tableWrapperCount = ([regex]::Matches($sectionChunk, "class='table-wrapper'")).Count
+    if ($tableWrapperCount -eq 1) {
+        $null = $sectionHtml.Replace(
+            "<div class='report-page' data-page='section-$sectionId'>",
+            "<div class='report-page' data-page='section-$sectionId' data-solo-table='true'>")
+    }
 }
 
 # ------------------------------------------------------------------

--- a/src/M365-Assess/Common/Export-ComplianceOverview.ps1
+++ b/src/M365-Assess/Common/Export-ComplianceOverview.ps1
@@ -144,8 +144,10 @@ function Export-ComplianceOverview {
         if ($isProfileBased -and $fw.profiles) {
             # Profile-based card (CIS, NIST) -- pass rate as primary, coverage bar as secondary
             $profileFindings = @($Findings | Where-Object { $_.Frameworks -and $_.Frameworks.ContainsKey($fwId) })
-            $profilePass = @($profileFindings | Where-Object { $_.Status -eq 'Pass' }).Count
-            $profileScored = @($profileFindings | Where-Object { $_.Status -ne 'Info' }).Count
+            $profilePass = ($profileFindings | Where-Object { $_.Status -eq 'Pass' } |
+                ForEach-Object { $_.CheckId -replace '\.\d+$', '' } | Sort-Object -Unique).Count
+            $profileScored = ($profileFindings | Where-Object { $_.Status -ne 'Info' } |
+                ForEach-Object { $_.CheckId -replace '\.\d+$', '' } | Sort-Object -Unique).Count
             $profileScore = if ($profileScored -gt 0) { [math]::Round(($profilePass / $profileScored) * 100, 1) } else { 0 }
             $scoreDisplay = if ($profileScored -gt 0) { "$profileScore%" } else { 'N/A' }
             $scoreClass = if ($profileScored -eq 0) { '' } elseif ($profileScore -ge 80) { 'success' } elseif ($profileScore -ge 60) { 'warning' } else { 'danger' }
@@ -187,8 +189,10 @@ function Export-ComplianceOverview {
                 if ($fwData.controlId) { $fwData.controlId -split ';' | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne '' } }
             } | Sort-Object -Unique)
             $mappedCount = $mappedControls.Count
-            $mappedPass = @($mappedFindings | Where-Object { $_.Status -eq 'Pass' }).Count
-            $mappedTotal = @($mappedFindings | Where-Object { $_.Status -ne 'Info' }).Count
+            $mappedPass = ($mappedFindings | Where-Object { $_.Status -eq 'Pass' } |
+                ForEach-Object { $_.CheckId -replace '\.\d+$', '' } | Sort-Object -Unique).Count
+            $mappedTotal = ($mappedFindings | Where-Object { $_.Status -ne 'Info' } |
+                ForEach-Object { $_.CheckId -replace '\.\d+$', '' } | Sort-Object -Unique).Count
             $passRate = if ($mappedTotal -gt 0) { [math]::Round(($mappedPass / $mappedTotal) * 100, 1) } else { 0 }
             $passDisplay = if ($mappedTotal -gt 0) { "$passRate%" } else { 'N/A' }
             $passClass = if ($mappedTotal -eq 0) { '' } elseif ($passRate -ge 80) { 'success' } elseif ($passRate -ge 60) { 'warning' } else { 'danger' }

--- a/src/M365-Assess/Common/Export-FrameworkCatalog.ps1
+++ b/src/M365-Assess/Common/Export-FrameworkCatalog.ps1
@@ -197,6 +197,22 @@ function ConvertTo-CatalogInlineHtml {
     $summary = $ScoredResult.Summary
     $groups = $ScoredResult.Groups
 
+    $scoringMethodLabels = @{
+        'profile-compliance'     = 'Profile Compliance'
+        'control-coverage'       = 'Control Coverage'
+        'maturity-level'         = 'Maturity Level'
+        'severity-coverage'      = 'Severity Coverage'
+        'function-coverage'      = 'Function Coverage'
+        'technique-coverage'     = 'Technique Coverage'
+        'requirement-compliance' = 'Requirement Compliance'
+        'criteria-coverage'      = 'Criteria Coverage'
+        'policy-compliance'      = 'Policy Compliance'
+    }
+    $scoringLabel = if ($scoringMethodLabels.ContainsKey($Framework.scoringMethod)) {
+        $scoringMethodLabels[$Framework.scoringMethod]
+    }
+    else { $Framework.scoringMethod }
+
     $html = [System.Text.StringBuilder]::new(4096)
 
     # Outer collapsible section
@@ -218,12 +234,12 @@ function ConvertTo-CatalogInlineHtml {
 
     $null = $html.AppendLine("<div class='catalog-summary'>")
     $null = $html.AppendLine("<div class='catalog-stats'>")
-    $null = $html.AppendLine("<span class='catalog-stat'><strong>Pass Rate:</strong> <span class='badge badge-$passClass'>$passRatePct%</span></span>")
+    $null = $html.AppendLine("<span class='catalog-stat'><strong>Pass Rate:</strong> <span class='badge badge-$passClass' title='Percentage of assessed checks that returned Pass'>$passRatePct%</span></span>")
     if ($summary.TotalControls -gt 0) {
-        $null = $html.AppendLine("<span class='catalog-stat'><strong>Coverage:</strong> $coveredCount of $($summary.TotalControls) controls</span>")
+        $null = $html.AppendLine("<span class='catalog-stat' title='Distinct framework controls with at least one mapped check'><strong>Coverage:</strong> $coveredCount of $($summary.TotalControls) controls</span>")
     }
-    $null = $html.AppendLine("<span class='catalog-stat'><strong>Automated Checks:</strong> $($summary.MappedControls) assessed</span>")
-    $null = $html.AppendLine("<span class='catalog-stat'><strong>Scoring:</strong> $($Framework.scoringMethod)</span>")
+    $null = $html.AppendLine("<span class='catalog-stat' title='Automated checks mapped to this framework'><strong>Checks Assessed:</strong> $($summary.MappedControls)</span>")
+    $null = $html.AppendLine("<span class='catalog-stat catalog-scoring' title='Scoring method: $scoringLabel'>&#9432; $scoringLabel</span>")
     $null = $html.AppendLine("</div>")
     if ($summary.TotalControls -gt 0) {
         $null = $html.AppendLine("<div class='coverage-bar'><div class='coverage-fill' style='width: $coveragePct%'></div></div>")
@@ -320,6 +336,22 @@ function ConvertTo-CatalogStandaloneHtml {
     $groups = $ScoredResult.Groups
     $assessmentDate = Get-Date -Format 'yyyy-MM-dd HH:mm'
 
+    $scoringMethodLabels = @{
+        'profile-compliance'     = 'Profile Compliance'
+        'control-coverage'       = 'Control Coverage'
+        'maturity-level'         = 'Maturity Level'
+        'severity-coverage'      = 'Severity Coverage'
+        'function-coverage'      = 'Function Coverage'
+        'technique-coverage'     = 'Technique Coverage'
+        'requirement-compliance' = 'Requirement Compliance'
+        'criteria-coverage'      = 'Criteria Coverage'
+        'policy-compliance'      = 'Policy Compliance'
+    }
+    $scoringLabel = if ($scoringMethodLabels.ContainsKey($Framework.scoringMethod)) {
+        $scoringMethodLabels[$Framework.scoringMethod]
+    }
+    else { $Framework.scoringMethod }
+
     # Get the inline body content (reuse the inline renderer's table logic)
     $passRatePct = [math]::Round($summary.PassRate * 100, 1)
     $passClass = if ($passRatePct -ge 80) { 'success' } elseif ($passRatePct -ge 60) { 'warning' } else { 'danger' }
@@ -331,17 +363,17 @@ function ConvertTo-CatalogStandaloneHtml {
     # Cover / header section
     $null = $body.AppendLine("<div class='catalog-header'>")
     $null = $body.AppendLine("<h1><span class='fw-tag $fwCss' style='font-size: 0.9em; padding: 4px 12px;'>$fwLabel</span> Framework Catalog</h1>")
-    $null = $body.AppendLine("<p class='catalog-meta'>Tenant: <strong>$TenantName</strong> &bull; Generated: $assessmentDate &bull; Scoring: $($Framework.scoringMethod)</p>")
+    $null = $body.AppendLine("<p class='catalog-meta'>Tenant: <strong>$TenantName</strong> &bull; Generated: $assessmentDate &bull; Scoring: $scoringLabel</p>")
     $null = $body.AppendLine("</div>")
 
     # Summary stats
     $null = $body.AppendLine("<div class='catalog-summary'>")
     $null = $body.AppendLine("<div class='catalog-stats'>")
-    $null = $body.AppendLine("<span class='catalog-stat'><strong>Pass Rate:</strong> <span class='badge badge-$passClass'>$passRatePct%</span></span>")
+    $null = $body.AppendLine("<span class='catalog-stat'><strong>Pass Rate:</strong> <span class='badge badge-$passClass' title='Percentage of assessed checks that returned Pass'>$passRatePct%</span></span>")
     if ($summary.TotalControls -gt 0) {
-        $null = $body.AppendLine("<span class='catalog-stat'><strong>Coverage:</strong> $coveredCount of $($summary.TotalControls) controls</span>")
+        $null = $body.AppendLine("<span class='catalog-stat' title='Distinct framework controls with at least one mapped check'><strong>Coverage:</strong> $coveredCount of $($summary.TotalControls) controls</span>")
     }
-    $null = $body.AppendLine("<span class='catalog-stat'><strong>Automated Checks:</strong> $($summary.MappedControls) assessed</span>")
+    $null = $body.AppendLine("<span class='catalog-stat' title='Automated checks mapped to this framework'><strong>Checks Assessed:</strong> $($summary.MappedControls)</span>")
     $null = $body.AppendLine("</div>")
     if ($summary.TotalControls -gt 0) {
         $null = $body.AppendLine("<div class='coverage-bar'><div class='coverage-fill' style='width: $coveragePct%'></div></div>")

--- a/src/M365-Assess/Common/Get-ReportTemplate.ps1
+++ b/src/M365-Assess/Common/Get-ReportTemplate.ps1
@@ -1330,6 +1330,19 @@ $html = @"
             margin-top: 1px;
         }
 
+        /* Collaboration dashboard group headers */
+        .collab-group-header {
+            grid-column: 1 / -1;
+            font-size: 8pt;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.6px;
+            color: var(--m365a-medium-gray);
+            padding: 4px 0 2px;
+            border-bottom: 1px solid var(--m365a-border);
+            margin-top: 4px;
+        }
+
         /* Dashboard card hover — subtle highlight for presentations */
         .email-metric-card,
         .id-donut-item,
@@ -1746,6 +1759,8 @@ $html = @"
         .collector-detail .table-wrapper.expanded { max-height: none; }
         .table-expand-btn { display: flex; align-items: center; justify-content: center; gap: 5px; width: 100%; padding: 6px 0; border: 1px solid var(--m365a-accent); border-top: none; border-radius: 0 0 4px 4px; background: var(--m365a-hover-bg); color: var(--m365a-accent); cursor: pointer; font-size: 0.82em; font-weight: 500; text-align: center; transition: background 0.15s, color 0.15s; letter-spacing: 0.02em; }
         .table-expand-btn:hover { background: var(--m365a-accent); color: #fff; }
+        .report-page[data-solo-table='true'] .collector-detail .table-wrapper { max-height: none; overflow-y: visible; }
+        .report-page[data-solo-table='true'] .table-expand-btn { display: none; }
 
         .collector-detail .data-table thead th {
             position: sticky;
@@ -2900,7 +2915,7 @@ if (-not $SkipExecutiveSummary) {
                 </div>
                 <div class="exec-hero-metric">
                     <div class="exec-hero-metric-value">$($allCisFindings.Count)</div>
-                    <div class="exec-hero-metric-label">CIS Controls</div>
+                    <div class="exec-hero-metric-label">Security Checks</div>
                 </div>
                 <div class="exec-hero-metric">
                     <div class="exec-hero-metric-value">$($allFrameworks.Count)</div>
@@ -3408,7 +3423,7 @@ $html += @"
                     card.style.display = activeFw.indexOf(fw) !== -1 ? '' : 'none';
                 });
 
-                // 2. Filter rows by status + section
+                // 2. Filter rows by status + section + framework mapping
                 var visibleCount = 0;
                 compRows.forEach(function(row) {
                     var sec = row.getAttribute('data-section') || '';
@@ -3417,7 +3432,16 @@ $html += @"
                     for (var i = 0; i < activeStatus.length; i++) {
                         if ((row.className || '').indexOf('cis-row-' + activeStatus[i]) !== -1) { statusOk = true; break; }
                     }
-                    var show = sectionOk && statusOk;
+                    // Hide rows where every active framework column is unmapped (—)
+                    var fwOk = activeFw.length === 0;
+                    if (!fwOk) {
+                        var fwCells = Array.from(row.querySelectorAll('td.fw-col'));
+                        fwOk = fwCells.some(function(td) {
+                            return activeFw.indexOf(td.getAttribute('data-fw')) !== -1 &&
+                                   td.querySelector('.fw-unmapped') === null;
+                        });
+                    }
+                    var show = sectionOk && statusOk && fwOk;
                     row.style.display = show ? '' : 'none';
                     if (show) visibleCount++;
                 });


### PR DESCRIPTION
## Summary

- **#451** — Compliance Overview: hide rows where ALL active framework columns are unmapped (`—`). Integrated into the existing `applyAllFilters()` row loop using `fwCells.some()` — no extra pass needed.
- **#453** — Fix CIS check count inconsistency. `profileScored`/`profilePass`/`mappedTotal` now deduplicate by unique parent CheckId (strip `.N` suffix) so the Compliance Overview and Framework Catalog show the same count.
- **#457** — Framework Catalog scoring method label now maps raw keys (`profile-compliance`, `control-coverage`, etc.) to human-readable strings (`Profile Compliance`, `Control Coverage`, etc.) in both Inline and Standalone render modes.
- **#458** — Catalog stats: added `title` tooltips explaining each metric; renamed "Automated Checks" → "Checks Assessed"; Scoring stat replaced with a `ⓘ scoringLabel` pattern.
- **#459** — Sections with exactly one data table now fill available viewport height. Build-SectionHtml.ps1 records StringBuilder position before each section, counts `table-wrapper` occurrences in the section chunk post-build, and injects `data-solo-table="true"` via `StringBuilder.Replace()`. CSS overrides remove the 260px cap and hide the expand button for solo-table pages.
- **#464** — Collaboration Settings dashboard: added SharePoint/Teams group headers (`collab-group-header`), status badges (`badge-success/warning/failed`) on each metric card, and recommended-value tooltips. Extracted `$collabTile` and `$collabBadge` script block helpers to eliminate repetition.
- **Bonus** — Executive Summary "CIS Controls" metric card renamed to "Security Checks" (the variable `$allCisFindings` holds all findings, not just CIS-mapped ones).

## Test plan

- [ ] 1816 Pester tests pass (`Invoke-Pester -Path './tests' -Output Normal`)
- [ ] Compliance Overview: select one framework → rows without that framework mapping disappear
- [ ] Framework Catalog: scoring label shows "Profile Compliance" not "profile-compliance"
- [ ] Framework Catalog stat tooltips appear on hover
- [ ] Section with a single collector table (e.g., Forms, Power BI) auto-expands to fill height; no "Expand table" button shown
- [ ] Collaboration section dashboard shows group headers and Pass/Warning/Fail badges on each tile
- [ ] Executive Summary hero metric shows "Security Checks" not "CIS Controls"

🤖 Generated with [Claude Code](https://claude.com/claude-code)