### PR TITLE
fix: make sync-checkid workflow idempotent on re-run

### DIFF
--- a/.github/workflows/sync-checkid.yml
+++ b/.github/workflows/sync-checkid.yml
@@ -76,17 +76,22 @@ jobs:
         run: |
           TAG="${{ github.event.client_payload.tag || github.event.inputs.tag }}"
           BRANCH="chore/sync-checkid-$TAG"
-          git checkout -b "$BRANCH"
+          git checkout -B "$BRANCH"
           git add src/M365-Assess/controls/
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -m "chore: sync CheckID registry to $TAG"
-          git push origin "$BRANCH"
-          gh pr create \
-            --title "chore: sync CheckID registry to $TAG" \
-            --body "Automated PR triggered by CheckID $TAG release. Updates controls/registry.json and framework definitions from upstream CheckID. Review the diff and merge when ready." \
-            --base main \
-            --head "$BRANCH"
+          git push --force origin "$BRANCH"
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number // empty')
+          if [ -z "$EXISTING_PR" ]; then
+            gh pr create \
+              --title "chore: sync CheckID registry to $TAG" \
+              --body "Automated PR triggered by CheckID $TAG release. Updates controls/registry.json and framework definitions from upstream CheckID. Review the diff and merge when ready." \
+              --base main \
+              --head "$BRANCH"
+          else
+            echo "PR #$EXISTING_PR already exists for $BRANCH — skipping creation"
+          fi
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Summary
- Switch `git checkout -b` → `git checkout -B` so reruns reset the branch instead of failing
- Add `--force` to `git push` so an already-existing remote branch doesn't block the push
- Check for an existing PR with `gh pr list --head` before calling `gh pr create`, so repeated workflow runs skip creation silently rather than erroring

## Root Cause
Every CheckID release triggers `sync-checkid.yml` via `repository_dispatch`. The first run created branch `chore/sync-checkid-v2.6.0` and then failed at `gh pr create` (Actions lacked write permissions). After fixing the repo-level Actions permissions, a re-run hit a second failure: the branch already existed remotely, so `git push` was rejected with `[rejected] (fetch first)`.

## Test Plan
- [ ] Trigger a `workflow_dispatch` run with an existing tag (e.g. `v2.6.0`) — should complete without errors
- [ ] Verify the existing `chore/sync-checkid-v2.6.0` branch/PR is reused (not duplicated)
- [ ] Trigger a second run — idempotent check should log "PR already exists" and skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)