### PR TITLE
fix: correct Windows-1252 encoding in cmmc/hipaa/stig framework JSONs

### DIFF
--- a/.github/workflows/sync-checkid.yml
+++ b/.github/workflows/sync-checkid.yml
@@ -35,6 +35,33 @@ jobs:
             curl -sL "$BASE/frameworks/$f.json" -o "src/M365-Assess/controls/frameworks/$f.json"
           done
 
+      - name: Normalize encoding in downloaded files
+        run: |
+          python3 - <<'EOF'
+          import os, glob
+
+          # Some CheckID releases ship framework JSONs with Windows-1252 bytes.
+          # Replace known offenders with their UTF-8 equivalents before committing.
+          cp1252_fixes = {
+              bytes([0x97]): '\u2014'.encode('utf-8'),  # em dash
+              bytes([0x96]): '\u2013'.encode('utf-8'),  # en dash
+              bytes([0xa7]): '\u00a7'.encode('utf-8'),  # section sign
+              bytes([0xa9]): '\u00a9'.encode('utf-8'),  # copyright
+              bytes([0xae]): '\u00ae'.encode('utf-8'),  # registered
+          }
+
+          files = glob.glob('src/M365-Assess/controls/frameworks/*.json')
+          files.append('src/M365-Assess/controls/registry.json')
+          for path in files:
+              raw = open(path, 'rb').read()
+              fixed = raw
+              for bad, good in cp1252_fixes.items():
+                  fixed = fixed.replace(bad, good)
+              if fixed != raw:
+                  open(path, 'wb').write(fixed)
+                  print(f'Encoding fixed: {path}')
+          EOF
+
       - name: Merge local extension checks
         run: |
           python3 - <<'EOF'

--- a/src/M365-Assess/controls/frameworks/cmmc.json
+++ b/src/M365-Assess/controls/frameworks/cmmc.json
@@ -11,17 +11,17 @@
     "method": "maturity-level",
     "maturityLevels": {
       "L1": {
-        "label": "Level 1 — Foundational",
+        "label": "Level 1 â€” Foundational",
         "description": "Basic safeguarding of Federal Contract Information (FCI)",
         "practiceCount": 17
       },
       "L2": {
-        "label": "Level 2 — Advanced",
+        "label": "Level 2 â€” Advanced",
         "description": "Protection of Controlled Unclassified Information (CUI), aligned with NIST SP 800-171 Rev 2",
         "practiceCount": 110
       },
       "L3": {
-        "label": "Level 3 — Expert",
+        "label": "Level 3 â€” Expert",
         "description": "Enhanced protection against Advanced Persistent Threats (APTs), adds NIST SP 800-172 requirements",
         "practiceCount": 134
       }

--- a/src/M365-Assess/controls/frameworks/hipaa.json
+++ b/src/M365-Assess/controls/frameworks/hipaa.json
@@ -10,23 +10,23 @@
   "scoring": {
     "method": "criteria-coverage",
     "criteria": {
-      "ง164.308": {
+      "ยง164.308": {
         "label": "Administrative Safeguards",
         "description": "Security management, access management, training, and contingency planning"
       },
-      "ง164.310": {
+      "ยง164.310": {
         "label": "Physical Safeguards",
         "description": "Facility access controls, workstation use, and device/media controls"
       },
-      "ง164.312": {
+      "ยง164.312": {
         "label": "Technical Safeguards",
         "description": "Access control, audit controls, integrity, transmission security"
       },
-      "ง164.314": {
+      "ยง164.314": {
         "label": "Organizational Requirements",
         "description": "Business associate contracts and group health plan requirements"
       },
-      "ง164.316": {
+      "ยง164.316": {
         "label": "Policies and Procedures",
         "description": "Documentation requirements and record retention"
       }

--- a/src/M365-Assess/controls/frameworks/stig.json
+++ b/src/M365-Assess/controls/frameworks/stig.json
@@ -11,15 +11,15 @@
     "method": "severity-coverage",
     "categories": {
       "CAT-I": {
-        "label": "CAT I — High",
+        "label": "CAT I â€” High",
         "description": "Vulnerabilities that allow an attacker to directly gain privileged access or bypass security"
       },
       "CAT-II": {
-        "label": "CAT II — Medium",
+        "label": "CAT II â€” Medium",
         "description": "Vulnerabilities that provide information or capability that could lead to compromise"
       },
       "CAT-III": {
-        "label": "CAT III — Low",
+        "label": "CAT III â€” Low",
         "description": "Vulnerabilities that degrade security measures or provide limited exposure"
       }
     }


### PR DESCRIPTION
## Summary

- Fixes `0x97` (Windows-1252 em dash) in `cmmc.json` Level 1/2/3 labels and `stig.json` CAT I/II/III labels
- Fixes `0xa7` (Windows-1252 section sign) in `hipaa.json` HIPAA criteria keys (`§164.308`, `§164.310`, `§164.312`, `§164.314`, `§164.316`)
- Adds a **Normalize encoding** step to `sync-checkid.yml` that auto-corrects CP1252 bytes on every future sync, preventing recurrence

## Root Cause

CheckID v2.6.0 shipped `cmmc.json`, `hipaa.json`, and `stig.json` with Windows-1252 byte sequences instead of proper UTF-8. This is the second time this has occurred (PR #450 fixed the same issue after v2.4.0). A breaking change issue has been filed upstream: [Galvnyz/CheckID#183](https://github.com/Galvnyz/CheckID/issues/183).

## Test plan

- [ ] All framework JSONs parse as valid UTF-8 JSON after merge
- [ ] `Invoke-Pester` passes (no framework loading failures)
- [ ] Future `sync-checkid` runs auto-fix any CP1252 bytes before committing

🤖 Generated with [Claude Code](https://claude.com/claude-code)