### PR TITLE
chore: bump version to v1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to M365 Assess are documented here. This project uses [Conve
 
 ## [Unreleased]
 
+## [1.13.0] - 2026-04-17
+
+### Added
+- Compliance Overview filter panel revamped: collapsible `<details>` panel with severity chips (Critical/High/Medium/Low/Info), all filter groups unified, localStorage persistence across page reloads (#465)
+- CIS profile/level sub-filters in Compliance Overview framework selector: E3 L1 / E3 L2 / E5 L1 / E5 L2 pill buttons, visible only when CIS M365 v6 filter is active (#452)
+- Appendix enriched with impact/risk metadata columns (ImpactRationale, SCFWeighting, SCFDomain, SCFControl, Collector, LicensingMin), column picker to toggle visibility, status/severity/collector chip filters, and per-table CSV export (#456)
+- Intune Overview dashboard page with metric cards, category coverage grid, and filterable findings table; auto-skips when Intune not in assessment scope (#470)
+- DNS SERVFAIL detection: `Test-DnsZoneAvailable` emits DNS-ZONE-001 (High) and suppresses all downstream DNS checks to prevent false positives on broken zones (#460)
+- RFC 7505 null MX and defensive lockdown pattern recognized: null SPF + null MX + DMARC reject/quarantine emits DNS-LOCKDOWN-001 (Pass) instead of cascading failures (#461)
+
+### Changed
+- Framework Catalog scoring method labels now display human-readable names (e.g. "Profile Compliance" instead of "profile-compliance") (#457)
+- Framework Catalog summary stats enriched with descriptive `title` tooltips and plain-language labels ("Checks Assessed", "Pass Rate", "Coverage") (#458)
+- Sections with a single table automatically expand to fill available viewport height; expand button hidden (#459)
+- Collaboration Settings dashboard tiles updated with status badges, group headers (SharePoint & OneDrive / Microsoft Teams), and descriptive tooltips (#464)
+- CheckID registry synced to v2.6.1 (4 new CMMC L2 Phase 4 checks: INTUNE-VPNCONFIG-001, INTUNE-WIFI-001, CA-REMOTEDEVICE-001, INTUNE-REMOTEVPN-001) (#482)
+- Sync workflow now normalizes Windows-1252 bytes to UTF-8 after each CheckID download, preventing recurrence of encoding corruption
+
+### Fixed
+- CIS assessed check count now consistent between Compliance Overview card and Framework Catalog — both deduplicate by parent CheckId (strips sub-number suffix) (#453)
+- Compliance Overview no longer shows unmapped rows (—) when a framework filter chip is active (#451)
+- `cmmc.json`, `hipaa.json`, and `stig.json` corrected from Windows-1252 encoding (0x97 em dash, 0xa7 section sign) to proper UTF-8 (#485)
+- Identity collectors 02-07d missing `RequiredServices` annotation — Graph connected too late, causing up to 6 collectors to be silently skipped (#473)
+
 ## [1.12.0] - 2026-04-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [![Coverage](https://img.shields.io/badge/coverage-check%20CI-informational)](https://github.com/Galvnyz/M365-Assess/actions/workflows/ci.yml)
 [![PowerShell 7.x](https://img.shields.io/badge/PowerShell-7.x-blue?logo=powershell&logoColor=white)](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows)
 [![Read-Only](https://img.shields.io/badge/Operations-Read--Only-brightgreen)](.)
-[![Version](https://img.shields.io/badge/version-1.12.0-blue)](.)
+[![Version](https://img.shields.io/badge/version-1.13.0-blue)](.)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 </div>

--- a/src/M365-Assess/M365-Assess.psd1
+++ b/src/M365-Assess/M365-Assess.psd1
@@ -3,7 +3,7 @@
     # Generated: 2026-03-08
 
     RootModule        = 'M365-Assess.psm1'
-    ModuleVersion     = '1.12.0'
+    ModuleVersion     = '1.13.0'
     GUID              = 'f7e3b2a1-4c5d-6e8f-9a0b-1c2d3e4f5a6b'
     Author            = 'Galvnyz'
     CompanyName       = 'Community'
@@ -213,7 +213,7 @@
             IconUri      = 'https://raw.githubusercontent.com/Galvnyz/M365-Assess/main/src/M365-Assess/assets/m365-assess-logo.png'
             LicenseUri   = 'https://github.com/Galvnyz/M365-Assess/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/Galvnyz/M365-Assess'
-            ReleaseNotes = 'v1.12.0 - Policy drift detection (-SaveBaseline/-CompareBaseline), impactRationale for all 254 checks surfaced in Remediation Action Plan'
+            ReleaseNotes = 'v1.13.0 - Compliance Overview filter revamp (severity chips, collapsible panel, localStorage), CIS profile sub-filters, Appendix enrichment (column picker, filters, CSV), Framework Catalog label/tooltip fixes, CheckID v2.6.1 sync'
         }
     }
 }


### PR DESCRIPTION
## Summary

- Bumps `ModuleVersion` to `1.13.0` in `M365-Assess.psd1`
- Updates `ReleaseNotes` in manifest
- Updates version badge in `README.md`
- Adds `[1.13.0]` section to `CHANGELOG.md` with full release notes

## What's in v1.13.0

See `CHANGELOG.md` for the full list. Highlights:
- Compliance Overview filter revamp + CIS sub-filters (#465, #452)
- Appendix enrichment: column picker, filters, CSV export (#456)
- Framework Catalog label/tooltip fixes (#457, #458)
- Single-table viewport fill (#459), Collaboration dashboard (#464)
- Count consistency fix (#453), unmapped row filter fix (#451)
- Intune Overview dashboard (#470)
- DNS SERVFAIL detection + defensive lockdown (#460, #461)
- CheckID v2.6.1 sync + encoding normalization

## Test plan
- [ ] `Invoke-Pester -Path './tests' -Output Normal` passes
- [ ] Module version reads `1.13.0` at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)