### PR TITLE
feat: migrate ValueOpportunity to CheckID v2.6.2 featureGroups schema

### DIFF
--- a/src/M365-Assess/ValueOpportunity/Get-FeatureAdoption.ps1
+++ b/src/M365-Assess/ValueOpportunity/Get-FeatureAdoption.ps1
@@ -4,7 +4,7 @@
 .DESCRIPTION
     For each feature in sku-feature-map.json, determines adoption state by
     cross-referencing signals accumulated by Add-SecuritySetting against
-    the feature's checkIds. Reads sibling License Utilization CSV for
+    the feature's detectionChecks. Reads sibling License Utilization CSV for
     license gating. Zero new API calls.
 .PARAMETER ProjectRoot
     Path to the module root (contains controls/).
@@ -40,18 +40,14 @@ function Get-FeatureAdoption {
         [string]$OutputPath
     )
 
-    $categories = @{}
-    foreach ($cat in $FeatureMap.categories) {
-        $categories[$cat.id] = $cat.name
-    }
-
     $licenseLookup = @{}
     foreach ($lic in $LicenseUtilization) {
         $licenseLookup[$lic.FeatureId] = $lic.IsLicensed
     }
 
-    $results = foreach ($feature in $FeatureMap.features) {
-        $featureId = $feature.featureId
+    $results = foreach ($entry in $FeatureMap.featureGroups.PSObject.Properties) {
+        $featureId = $entry.Name
+        $feature   = $entry.Value
         $isLicensed = $false
         if ($licenseLookup.ContainsKey($featureId)) {
             $isLicensed = $licenseLookup[$featureId]
@@ -60,8 +56,8 @@ function Get-FeatureAdoption {
         if (-not $isLicensed) {
             [PSCustomObject]@{
                 FeatureId     = $featureId
-                FeatureName   = $feature.name
-                Category      = $categories[$feature.category]
+                FeatureName   = $feature.displayName
+                Category      = $feature.category
                 AdoptionState = 'NotLicensed'
                 AdoptionScore = 0
                 PassedChecks  = 0
@@ -74,7 +70,7 @@ function Get-FeatureAdoption {
         $passedCount = 0
         $totalCount = 0
 
-        foreach ($baseId in $feature.checkIds) {
+        foreach ($baseId in $feature.detectionChecks) {
             $prefix = "$baseId."
             foreach ($signalKey in $AdoptionSignals.Keys) {
                 if ($signalKey.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
@@ -140,8 +136,8 @@ function Get-FeatureAdoption {
 
         [PSCustomObject]@{
             FeatureId     = $featureId
-            FeatureName   = $feature.name
-            Category      = $categories[$feature.category]
+            FeatureName   = $feature.displayName
+            Category      = $feature.category
             AdoptionState = $adoptionState
             AdoptionScore = $adoptionScore
             PassedChecks  = $passedCount
@@ -176,7 +172,6 @@ if ($ProjectRoot -and $AssessmentFolder) {
         $signals = $global:AdoptionSignals.Clone()
     }
 
-    # Read sibling License Utilization CSV
     $licCsvPath = Join-Path -Path $AssessmentFolder -ChildPath '40-License-Utilization.csv'
     $licenseData = @()
     if (Test-Path -Path $licCsvPath) {

--- a/src/M365-Assess/ValueOpportunity/Get-FeatureReadiness.ps1
+++ b/src/M365-Assess/ValueOpportunity/Get-FeatureReadiness.ps1
@@ -36,9 +36,6 @@ function Get-FeatureReadiness {
         [string]$OutputPath
     )
 
-    $categories = @{}
-    foreach ($cat in $FeatureMap.categories) { $categories[$cat.id] = $cat.name }
-
     $licenseLookup = @{}
     foreach ($lic in $LicenseUtilization) { $licenseLookup[$lic.FeatureId] = $lic }
 
@@ -46,18 +43,22 @@ function Get-FeatureReadiness {
     foreach ($adp in $FeatureAdoption) { $adoptionLookup[$adp.FeatureId] = $adp }
 
     $featureNameLookup = @{}
-    foreach ($f in $FeatureMap.features) { $featureNameLookup[$f.featureId] = $f.name }
+    foreach ($entry in $FeatureMap.featureGroups.PSObject.Properties) {
+        $featureNameLookup[$entry.Name] = $entry.Value.displayName
+    }
 
-    $results = foreach ($feature in $FeatureMap.features) {
-        $lic = $licenseLookup[$feature.featureId]
+    $results = foreach ($entry in $FeatureMap.featureGroups.PSObject.Properties) {
+        $featureId = $entry.Name
+        $feature   = $entry.Value
+        $lic = $licenseLookup[$featureId]
         $blockers = @()
 
         if (-not $lic -or -not $lic.IsLicensed) {
-            $planNames = $feature.requiredServicePlans -join ', '
+            $planNames = $feature.servicePlans -join ', '
             [PSCustomObject]@{
-                FeatureId      = $feature.featureId
-                FeatureName    = $feature.name
-                Category       = $categories[$feature.category]
+                FeatureId      = $featureId
+                FeatureName    = $feature.displayName
+                Category       = $feature.category
                 ReadinessState = 'NotLicensed'
                 Blockers       = "Requires $planNames"
                 EffortTier     = $feature.effortTier
@@ -78,9 +79,9 @@ function Get-FeatureReadiness {
         $state = if ($blockers.Count -gt 0) { 'Blocked' } else { 'Ready' }
 
         [PSCustomObject]@{
-            FeatureId      = $feature.featureId
-            FeatureName    = $feature.name
-            Category       = $categories[$feature.category]
+            FeatureId      = $featureId
+            FeatureName    = $feature.displayName
+            Category       = $feature.category
             ReadinessState = $state
             Blockers       = ($blockers -join '; ')
             EffortTier     = $feature.effortTier
@@ -106,7 +107,6 @@ if ($ProjectRoot -and $AssessmentFolder) {
     }
     $featureMap = Get-Content -Path $featureMapPath -Raw | ConvertFrom-Json
 
-    # Read sibling CSVs
     $licCsvPath = Join-Path -Path $AssessmentFolder -ChildPath '40-License-Utilization.csv'
     $licenseData = @()
     if (Test-Path -Path $licCsvPath) {

--- a/src/M365-Assess/ValueOpportunity/Get-LicenseUtilization.ps1
+++ b/src/M365-Assess/ValueOpportunity/Get-LicenseUtilization.ps1
@@ -35,16 +35,13 @@ function Get-LicenseUtilization {
         [string]$OutputPath
     )
 
-    $categories = @{}
-    foreach ($cat in $FeatureMap.categories) {
-        $categories[$cat.id] = $cat.name
-    }
-
-    $results = foreach ($feature in $FeatureMap.features) {
+    $results = foreach ($entry in $FeatureMap.featureGroups.PSObject.Properties) {
+        $featureId = $entry.Name
+        $feature   = $entry.Value
         $isLicensed = $false
         $sourceSkus = @()
 
-        foreach ($plan in $feature.requiredServicePlans) {
+        foreach ($plan in $feature.servicePlans) {
             if ($TenantLicenses.ActiveServicePlans.Contains($plan)) {
                 $isLicensed = $true
                 $sourceSkus += $plan
@@ -52,9 +49,9 @@ function Get-LicenseUtilization {
         }
 
         [PSCustomObject]@{
-            FeatureId   = $feature.featureId
-            FeatureName = $feature.name
-            Category    = $categories[$feature.category]
+            FeatureId   = $featureId
+            FeatureName = $feature.displayName
+            Category    = $feature.category
             IsLicensed  = $isLicensed
             SourcePlans = ($sourceSkus -join ', ')
             EffortTier  = $feature.effortTier

--- a/src/M365-Assess/ValueOpportunity/Measure-ValueOpportunity.ps1
+++ b/src/M365-Assess/ValueOpportunity/Measure-ValueOpportunity.ps1
@@ -47,14 +47,8 @@ function Measure-ValueOpportunity {
     }
 
     $featureMapLookup = @{}
-    foreach ($item in $FeatureMap.features) {
-        $featureMapLookup[$item.featureId] = $item
-    }
-
-    # Build category name lookup from FeatureMap
-    $categoryNameLookup = @{}
-    foreach ($cat in $FeatureMap.categories) {
-        $categoryNameLookup[$cat.id] = $cat.name
+    foreach ($entry in $FeatureMap.featureGroups.PSObject.Properties) {
+        $featureMapLookup[$entry.Name] = $entry.Value
     }
 
     # Identify licensed feature IDs
@@ -192,7 +186,7 @@ function Measure-ValueOpportunity {
                 FeatureName          = if ($adoption) { $adoption.FeatureName } else { '' }
                 Category             = if ($adoption) { $adoption.Category } else { '' }
                 EffortTier           = if ($readiness) { $readiness.EffortTier } else { '' }
-                RequiredServicePlans = if ($mapEntry) { $mapEntry.requiredServicePlans } else { @() }
+                RequiredServicePlans = if ($mapEntry) { $mapEntry.servicePlans } else { @() }
             }
         }
     }

--- a/src/M365-Assess/controls/sku-feature-map.json
+++ b/src/M365-Assess/controls/sku-feature-map.json
@@ -1,690 +1,739 @@
 {
-  "version": "1.0.0",
-  "description": "Maps M365 features to SKU service plans, assessment CheckIds, effort tiers, and documentation links",
-  "categories": [
-    { "id": "identity-access", "name": "Identity & Access", "icon": "Person" },
-    { "id": "email-security", "name": "Email Security", "icon": "Shield" },
-    { "id": "data-protection", "name": "Data Protection", "icon": "Lock" },
-    { "id": "device-management", "name": "Device Management", "icon": "Phone" },
-    { "id": "collaboration", "name": "Collaboration Security", "icon": "People" },
-    { "id": "threat-protection", "name": "Threat Protection", "icon": "Warning" }
-  ],
-  "features": [
-    {
-      "featureId": "mfa-registration",
-      "name": "MFA Registration & Enforcement",
-      "category": "identity-access",
-      "description": "Require all users to register for and use multi-factor authentication",
+  "$schema": "./sku-feature-map.schema.json",
+  "version": "2.1.0",
+  "featureGroups": {
+    "conditional-access": {
+      "displayName": "Conditional Access",
+      "description": "Policy-based access controls that evaluate sign-in conditions (location, device, risk) to enforce MFA, block access, or require compliant devices.",
+      "category": "Identity",
+      "servicePlans": [
+        "AAD_PREMIUM"
+      ],
+      "detectionChecks": [
+        "ENTRA-CA-001",
+        "ENTRA-CA-002",
+        "ENTRA-CA-003",
+        "CA-EXCLUSION-001",
+        "CA-DEVICE-001",
+        "CA-DEVICE-002",
+        "CA-DEVICECODE-001",
+        "CA-LEGACYAUTH-001",
+        "CA-INTUNE-001",
+        "CA-RISKPOLICY-001",
+        "CA-ROLECOVERAGE-001",
+        "CA-SIGNIN-FREQ-001"
+      ],
+      "valueCategory": "Security",
+      "estimatedEffort": "High",
+      "quickWin": false,
       "effortTier": "Quick Win",
-      "requiredServicePlans": ["AAD_PREMIUM"],
-      "checkIds": ["ENTRA-MFA-001", "ENTRA-MFA-002", "ENTRA-PERUSER-001"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/entra/identity/authentication/howto-mfa-getstarted",
-      "tags": ["E3", "identity"]
-    },
-    {
-      "featureId": "conditional-access-mfa",
-      "name": "Conditional Access MFA Policies",
-      "category": "identity-access",
-      "description": "Enforce MFA for admins and all users via Conditional Access policies",
-      "effortTier": "Medium",
-      "requiredServicePlans": ["AAD_PREMIUM"],
-      "checkIds": ["CA-MFA-ADMIN-001", "CA-MFA-ALL-001"],
-      "csvSignals": [],
-      "prerequisites": ["mfa-registration"],
-      "learnUrl": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/howto-conditional-access-policy-all-users-mfa",
-      "tags": ["E3", "identity", "conditional-access"]
-    },
-    {
-      "featureId": "conditional-access-legacy-auth",
-      "name": "Block Legacy Authentication",
-      "category": "identity-access",
-      "description": "Block legacy authentication protocols that bypass MFA via Conditional Access",
-      "effortTier": "Quick Win",
-      "requiredServicePlans": ["AAD_PREMIUM"],
-      "checkIds": ["CA-LEGACYAUTH-001"],
-      "csvSignals": [],
-      "prerequisites": [],
       "learnUrl": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/howto-conditional-access-policy-block-legacy",
-      "tags": ["E3", "identity", "conditional-access"]
+      "prerequisites": [
+        "device-management",
+        "identity-protection"
+      ]
     },
-    {
-      "featureId": "conditional-access-device",
-      "name": "Device-Based Conditional Access",
-      "category": "identity-access",
-      "description": "Require compliant or hybrid-joined devices for access",
-      "effortTier": "Medium",
-      "requiredServicePlans": ["AAD_PREMIUM"],
-      "checkIds": ["CA-DEVICE-001", "CA-DEVICE-002"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/howto-conditional-access-policy-compliant-device",
-      "tags": ["E3", "identity", "conditional-access"]
-    },
-    {
-      "featureId": "conditional-access-signin-frequency",
-      "name": "Sign-In Frequency & Session Controls",
-      "category": "identity-access",
-      "description": "Control sign-in frequency and persistent browser sessions",
-      "effortTier": "Medium",
-      "requiredServicePlans": ["AAD_PREMIUM"],
-      "checkIds": ["CA-SIGNIN-FREQ-001"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/howto-conditional-access-session-lifetime",
-      "tags": ["E3", "identity", "conditional-access"]
-    },
-    {
-      "featureId": "conditional-access-phishres",
-      "name": "Phishing-Resistant Authentication",
-      "category": "identity-access",
-      "description": "Require phishing-resistant MFA methods for sensitive operations",
-      "effortTier": "Strategic",
-      "requiredServicePlans": ["AAD_PREMIUM_P2"],
-      "checkIds": ["CA-PHISHRES-001"],
-      "csvSignals": [],
-      "prerequisites": ["mfa-registration"],
-      "learnUrl": "https://learn.microsoft.com/en-us/entra/identity/authentication/concept-authentication-strengths",
-      "tags": ["E3", "identity", "conditional-access"]
-    },
-    {
-      "featureId": "pim",
-      "name": "Privileged Identity Management",
-      "category": "identity-access",
-      "description": "Enable just-in-time privileged access with approval workflows and time-bound role assignments",
-      "effortTier": "Strategic",
-      "requiredServicePlans": ["AAD_PREMIUM_P2"],
-      "checkIds": ["ENTRA-PIM-001", "ENTRA-PIM-002", "ENTRA-PIM-003", "ENTRA-PIM-004", "ENTRA-PIM-005", "ENTRA-PIM-006", "ENTRA-PIM-007", "ENTRA-PIM-008", "ENTRA-PIM-009", "ENTRA-PIM-010"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-configure",
-      "tags": ["E5", "identity", "governance"]
-    },
-    {
-      "featureId": "risk-based-ca-signin",
-      "name": "Risk-Based Conditional Access (Sign-in Risk)",
-      "category": "identity-access",
-      "description": "Automatically respond to risky sign-ins with step-up authentication or blocking",
-      "effortTier": "Strategic",
-      "requiredServicePlans": ["AAD_PREMIUM_P2"],
-      "checkIds": ["CA-SIGNINRISK-001", "CA-SIGNINRISK-002"],
-      "csvSignals": [],
-      "prerequisites": ["conditional-access-mfa"],
-      "learnUrl": "https://learn.microsoft.com/en-us/entra/id-protection/howto-identity-protection-configure-risk-policies",
-      "tags": ["E5", "identity", "conditional-access"]
-    },
-    {
-      "featureId": "risk-based-ca-user",
-      "name": "Risk-Based Conditional Access (User Risk)",
-      "category": "identity-access",
-      "description": "Require password change or block access when user risk is detected",
-      "effortTier": "Strategic",
-      "requiredServicePlans": ["AAD_PREMIUM_P2"],
-      "checkIds": ["CA-USERRISK-001"],
-      "csvSignals": [],
-      "prerequisites": ["conditional-access-mfa"],
-      "learnUrl": "https://learn.microsoft.com/en-us/entra/id-protection/howto-identity-protection-configure-risk-policies",
-      "tags": ["E5", "identity", "conditional-access"]
-    },
-    {
-      "featureId": "risk-based-ca-policy",
-      "name": "Risk-Based Policy Enforcement",
-      "category": "identity-access",
-      "description": "Combine sign-in and user risk signals into comprehensive risk-based policies",
-      "effortTier": "Strategic",
-      "requiredServicePlans": ["AAD_PREMIUM_P2"],
-      "checkIds": ["CA-RISKPOLICY-001"],
-      "csvSignals": [],
-      "prerequisites": ["risk-based-ca-signin", "risk-based-ca-user"],
-      "learnUrl": "https://learn.microsoft.com/en-us/entra/id-protection/concept-identity-protection-policies",
-      "tags": ["E5", "identity", "conditional-access"]
-    },
-    {
-      "featureId": "sspr",
-      "name": "Self-Service Password Reset",
-      "category": "identity-access",
-      "description": "Enable users to reset their own passwords securely without helpdesk calls",
+    "mfa-enforcement": {
+      "displayName": "Multi-Factor Authentication",
+      "description": "Enforce MFA for all users and administrators through Conditional Access policies and per-user MFA settings.",
+      "category": "Identity",
+      "servicePlans": [
+        "AAD_PREMIUM",
+        "MFA_PREMIUM"
+      ],
+      "detectionChecks": [
+        "ENTRA-MFA-001",
+        "ENTRA-MFA-002",
+        "CA-MFA-ADMIN-001",
+        "CA-MFA-ALL-001",
+        "CA-PHISHRES-001",
+        "ENTRA-PERUSER-001",
+        "ENTRA-SECDEFAULT-001"
+      ],
+      "valueCategory": "Security",
+      "estimatedEffort": "Medium",
+      "quickWin": false,
       "effortTier": "Quick Win",
-      "requiredServicePlans": ["AAD_PREMIUM"],
-      "checkIds": ["ENTRA-SSPR-001", "ENTRA-SSPR-002"],
-      "csvSignals": [],
-      "prerequisites": [],
+      "learnUrl": "https://learn.microsoft.com/en-us/entra/identity/authentication/howto-mfa-getstarted",
+      "prerequisites": []
+    },
+    "authentication-methods": {
+      "displayName": "Authentication Methods and Password Protection",
+      "description": "Configure strong authentication methods, disable weak methods, enable password protection with custom banned password lists, and configure SSPR.",
+      "category": "Identity",
+      "servicePlans": [
+        "AAD_PREMIUM"
+      ],
+      "detectionChecks": [
+        "ENTRA-AUTHMETHOD-001",
+        "ENTRA-AUTHMETHOD-002",
+        "ENTRA-AUTHMETHOD-003",
+        "ENTRA-AUTHMETHOD-004",
+        "ENTRA-PASSWORD-001",
+        "ENTRA-PASSWORD-002",
+        "ENTRA-PASSWORD-003",
+        "ENTRA-PASSWORD-004",
+        "ENTRA-PASSWORD-005",
+        "ENTRA-SSPR-001",
+        "ENTRA-SSPR-002"
+      ],
+      "valueCategory": "Security",
+      "estimatedEffort": "Medium",
+      "quickWin": false,
+      "effortTier": "Quick Win",
       "learnUrl": "https://learn.microsoft.com/en-us/entra/identity/authentication/howto-sspr-deployment",
-      "tags": ["E3", "identity"]
+      "prerequisites": []
     },
-    {
-      "featureId": "emergency-access",
-      "name": "Emergency Access Accounts",
-      "category": "identity-access",
-      "description": "Maintain break-glass accounts to prevent tenant lockout scenarios",
+    "privileged-identity-management": {
+      "displayName": "Privileged Identity Management",
+      "description": "Just-in-time role activation, access reviews for privileged roles and guest users, and approval workflows for critical role assignments.",
+      "category": "Identity",
+      "servicePlans": [
+        "AAD_PREMIUM_P2"
+      ],
+      "detectionChecks": [
+        "ENTRA-PIM-001",
+        "ENTRA-PIM-002",
+        "ENTRA-PIM-003",
+        "ENTRA-PIM-004",
+        "ENTRA-PIM-005",
+        "ENTRA-PIM-006",
+        "ENTRA-PIM-007",
+        "ENTRA-PIM-008",
+        "ENTRA-PIM-009",
+        "ENTRA-PIM-010"
+      ],
+      "valueCategory": "Security",
+      "estimatedEffort": "High",
+      "quickWin": false,
+      "effortTier": "Strategic",
+      "learnUrl": "https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-configure",
+      "prerequisites": []
+    },
+    "identity-protection": {
+      "displayName": "Identity Protection Risk Policies",
+      "description": "Automated detection and remediation of identity-based risks using sign-in risk and user risk policies powered by Entra ID P2.",
+      "category": "Identity",
+      "servicePlans": [
+        "AAD_PREMIUM_P2"
+      ],
+      "detectionChecks": [
+        "CA-SIGNINRISK-001",
+        "CA-SIGNINRISK-002",
+        "CA-USERRISK-001"
+      ],
+      "valueCategory": "Security",
+      "estimatedEffort": "Medium",
+      "quickWin": false,
+      "effortTier": "Strategic",
+      "learnUrl": "https://learn.microsoft.com/en-us/entra/id-protection/howto-identity-protection-configure-risk-policies",
+      "prerequisites": [
+        "mfa-enforcement"
+      ]
+    },
+    "admin-governance": {
+      "displayName": "Administrative Account Governance",
+      "description": "Controls for global admin count, cloud-only admin accounts, break-glass accounts, restricted admin center access, and stale admin detection.",
+      "category": "Identity",
+      "servicePlans": [
+        "AAD_PREMIUM"
+      ],
+      "detectionChecks": [
+        "ENTRA-ADMIN-001",
+        "ENTRA-ADMIN-002",
+        "ENTRA-ADMIN-003",
+        "ENTRA-BREAKGLASS-001",
+        "ENTRA-CLOUDADMIN-001",
+        "ENTRA-CLOUDADMIN-002",
+        "ENTRA-STALEADMIN-001",
+        "ENTRA-SYNCADMIN-001",
+        "ENTRA-HYBRID-001",
+        "ENTRA-HYBRID-002"
+      ],
+      "valueCategory": "Security",
+      "estimatedEffort": "Medium",
+      "quickWin": false,
       "effortTier": "Quick Win",
-      "requiredServicePlans": ["AAD_PREMIUM"],
-      "checkIds": ["ENTRA-ADMIN-003", "ENTRA-BREAKGLASS-001"],
-      "csvSignals": [],
-      "prerequisites": [],
       "learnUrl": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/security-emergency-access",
-      "tags": ["E3", "identity", "admin"]
+      "prerequisites": []
     },
-    {
-      "featureId": "security-defaults",
-      "name": "Security Defaults",
-      "category": "identity-access",
-      "description": "Enable baseline security defaults for tenants without Conditional Access",
-      "effortTier": "Quick Win",
-      "requiredServicePlans": ["AAD_PREMIUM"],
-      "checkIds": ["ENTRA-SECDEFAULT-001", "ENTRA-SECDEFAULT-002"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/entra/fundamentals/security-defaults",
-      "tags": ["E3", "identity"]
-    },
-    {
-      "featureId": "admin-mfa-strength",
-      "name": "Admin MFA Authentication Strength",
-      "category": "identity-access",
-      "description": "Ensure administrators use strong MFA methods resistant to phishing",
-      "effortTier": "Quick Win",
-      "requiredServicePlans": ["AAD_PREMIUM"],
-      "checkIds": ["ENTRA-ADMIN-004"],
-      "csvSignals": [],
-      "prerequisites": ["mfa-registration"],
-      "learnUrl": "https://learn.microsoft.com/en-us/entra/identity/authentication/concept-authentication-strengths",
-      "tags": ["E3", "identity", "admin"]
-    },
-    {
-      "featureId": "password-protection",
-      "name": "Password Protection & Policies",
-      "category": "identity-access",
-      "description": "Configure banned password lists and smart lockout to prevent weak passwords",
+    "guest-and-external-access": {
+      "displayName": "Guest and External Access Controls",
+      "description": "Restrict guest user access, limit invitation permissions, enforce domain restrictions, and control external collaboration settings.",
+      "category": "Identity",
+      "servicePlans": [
+        "AAD_PREMIUM"
+      ],
+      "detectionChecks": [
+        "ENTRA-GUEST-001",
+        "ENTRA-GUEST-002",
+        "ENTRA-GUEST-003",
+        "ENTRA-GUEST-004",
+        "ENTRA-GROUP-001",
+        "ENTRA-GROUP-002",
+        "ENTRA-GROUP-003",
+        "ENTRA-GROUP-004",
+        "ENTRA-GROUP-005",
+        "ENTRA-GROUP-006"
+      ],
+      "valueCategory": "Security",
+      "estimatedEffort": "Medium",
+      "quickWin": false,
       "effortTier": "Medium",
-      "requiredServicePlans": ["AAD_PREMIUM"],
-      "checkIds": ["ENTRA-PASSWORD-001", "ENTRA-PASSWORD-002", "ENTRA-PASSWORD-003", "ENTRA-PASSWORD-004", "ENTRA-PASSWORD-005"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/entra/identity/authentication/concept-password-ban-bad",
-      "tags": ["E3", "identity"]
-    },
-    {
-      "featureId": "device-registration",
-      "name": "Device Registration & Join Settings",
-      "category": "identity-access",
-      "description": "Control which users can register and join devices to Entra ID",
-      "effortTier": "Medium",
-      "requiredServicePlans": ["AAD_PREMIUM"],
-      "checkIds": ["ENTRA-DEVICE-001", "ENTRA-DEVICE-002", "ENTRA-DEVICE-003", "ENTRA-DEVICE-004", "ENTRA-DEVICE-005", "ENTRA-DEVICE-006"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/entra/identity/devices/manage-device-identities",
-      "tags": ["E3", "identity", "devices"]
-    },
-    {
-      "featureId": "safe-links",
-      "name": "Safe Links",
-      "category": "email-security",
-      "description": "Protect users from malicious URLs in email and Office documents with time-of-click verification",
-      "effortTier": "Medium",
-      "requiredServicePlans": ["ATP_ENTERPRISE"],
-      "checkIds": ["DEFENDER-SAFELINKS-001"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/defender-office-365/safe-links-about",
-      "tags": ["E5", "email", "defender"]
-    },
-    {
-      "featureId": "safe-attachments",
-      "name": "Safe Attachments",
-      "category": "email-security",
-      "description": "Scan email attachments in a sandbox environment before delivery",
-      "effortTier": "Medium",
-      "requiredServicePlans": ["ATP_ENTERPRISE"],
-      "checkIds": ["DEFENDER-SAFEATTACH-001", "DEFENDER-SAFEATTACH-002"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/defender-office-365/safe-attachments-about",
-      "tags": ["E5", "email", "defender"]
-    },
-    {
-      "featureId": "anti-phishing",
-      "name": "Anti-Phishing Policies",
-      "category": "email-security",
-      "description": "Configure impersonation protection, mailbox intelligence, and spoof settings",
-      "effortTier": "Medium",
-      "requiredServicePlans": ["ATP_ENTERPRISE"],
-      "checkIds": ["DEFENDER-ANTIPHISH-001"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/defender-office-365/anti-phishing-policies-about",
-      "tags": ["E5", "email", "defender"]
-    },
-    {
-      "featureId": "dmarc-enforcement",
-      "name": "DMARC Enforcement",
-      "category": "email-security",
-      "description": "Publish DMARC records to prevent email spoofing and receive aggregate reports",
-      "effortTier": "Quick Win",
-      "requiredServicePlans": ["EXCHANGE_S_ENTERPRISE"],
-      "checkIds": ["DNS-DMARC-001"],
-      "csvSignals": [],
-      "prerequisites": ["spf", "dkim"],
-      "learnUrl": "https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/email-authentication-dmarc-configure",
-      "tags": ["E3", "email", "dns"]
-    },
-    {
-      "featureId": "dkim",
-      "name": "DKIM Signing",
-      "category": "email-security",
-      "description": "Enable DomainKeys Identified Mail signing for outbound email authentication",
-      "effortTier": "Quick Win",
-      "requiredServicePlans": ["EXCHANGE_S_ENTERPRISE"],
-      "checkIds": ["DNS-DKIM-001"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/email-authentication-dkim-configure",
-      "tags": ["E3", "email", "dns"]
-    },
-    {
-      "featureId": "spf",
-      "name": "SPF Records",
-      "category": "email-security",
-      "description": "Configure Sender Policy Framework records to authorize legitimate email senders",
-      "effortTier": "Quick Win",
-      "requiredServicePlans": ["EXCHANGE_S_ENTERPRISE"],
-      "checkIds": ["DNS-SPF-001"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/email-authentication-spf-configure",
-      "tags": ["E3", "email", "dns"]
-    },
-    {
-      "featureId": "mailbox-auditing",
-      "name": "Mailbox Auditing",
-      "category": "email-security",
-      "description": "Ensure mailbox audit logging is enabled for all mailboxes",
-      "effortTier": "Quick Win",
-      "requiredServicePlans": ["EXCHANGE_S_ENTERPRISE"],
-      "checkIds": ["EXO-AUDIT-001", "EXO-AUDIT-002", "EXO-AUDIT-003"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/purview/audit-mailboxes",
-      "tags": ["E3", "email", "audit"]
-    },
-    {
-      "featureId": "external-forwarding-block",
-      "name": "External Email Forwarding Block",
-      "category": "email-security",
-      "description": "Block automatic email forwarding to external recipients to prevent data exfiltration",
-      "effortTier": "Quick Win",
-      "requiredServicePlans": ["EXCHANGE_S_ENTERPRISE"],
-      "checkIds": ["EXO-FORWARD-001"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/outbound-spam-policies-external-email-forwarding",
-      "tags": ["E3", "email"]
-    },
-    {
-      "featureId": "anti-spam",
-      "name": "Anti-Spam Policies",
-      "category": "email-security",
-      "description": "Configure inbound and outbound anti-spam filtering and connection filter policies",
-      "effortTier": "Quick Win",
-      "requiredServicePlans": ["EXCHANGE_S_ENTERPRISE"],
-      "checkIds": ["DEFENDER-ANTISPAM-001", "DEFENDER-ANTISPAM-002", "DEFENDER-OUTBOUND-001", "EXO-CONNFILTER-001", "EXO-CONNFILTER-002"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/defender-office-365/anti-spam-protection-about",
-      "tags": ["E3", "email", "defender"]
-    },
-    {
-      "featureId": "anti-malware",
-      "name": "Anti-Malware Policies",
-      "category": "email-security",
-      "description": "Configure malware filtering policies for email attachments",
-      "effortTier": "Quick Win",
-      "requiredServicePlans": ["EXCHANGE_S_ENTERPRISE"],
-      "checkIds": ["DEFENDER-ANTIMALWARE-001", "DEFENDER-ANTIMALWARE-002", "DEFENDER-MALWARE-002"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/defender-office-365/anti-malware-protection-about",
-      "tags": ["E3", "email", "defender"]
-    },
-    {
-      "featureId": "modern-auth-exchange",
-      "name": "Modern Authentication for Exchange",
-      "category": "email-security",
-      "description": "Ensure modern authentication is enabled and basic auth is blocked for Exchange Online",
-      "effortTier": "Quick Win",
-      "requiredServicePlans": ["EXCHANGE_S_ENTERPRISE"],
-      "checkIds": ["EXO-AUTH-001", "EXO-AUTH-002"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/exchange/clients-and-mobile-in-exchange-online/enable-or-disable-modern-authentication-in-exchange-online",
-      "tags": ["E3", "email"]
-    },
-    {
-      "featureId": "dlp-policies",
-      "name": "Data Loss Prevention Policies",
-      "category": "data-protection",
-      "description": "Create DLP policies to detect and protect sensitive information across M365 services",
-      "effortTier": "Strategic",
-      "requiredServicePlans": ["INFORMATION_PROTECTION_COMPLIANCE"],
-      "checkIds": ["COMPLIANCE-DLP-001", "COMPLIANCE-DLP-002"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/purview/dlp-learn-about-dlp",
-      "tags": ["E5", "data-protection", "compliance"]
-    },
-    {
-      "featureId": "sensitivity-labels",
-      "name": "Sensitivity Labels",
-      "category": "data-protection",
-      "description": "Classify and protect documents and emails with sensitivity labels",
-      "effortTier": "Strategic",
-      "requiredServicePlans": ["INFORMATION_PROTECTION_COMPLIANCE"],
-      "checkIds": ["COMPLIANCE-LABELS-001"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/purview/sensitivity-labels",
-      "tags": ["E5", "data-protection", "compliance"]
-    },
-    {
-      "featureId": "customer-lockbox",
-      "name": "Customer Lockbox",
-      "category": "data-protection",
-      "description": "Require approval before Microsoft support engineers can access tenant data",
-      "effortTier": "Medium",
-      "requiredServicePlans": ["LOCKBOX_ENTERPRISE"],
-      "checkIds": ["EXO-LOCKBOX-001"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/purview/customer-lockbox-requests",
-      "tags": ["E5", "data-protection"]
-    },
-    {
-      "featureId": "retention-policies",
-      "name": "Retention Policies",
-      "category": "data-protection",
-      "description": "Configure data retention policies to meet compliance and legal requirements",
-      "effortTier": "Medium",
-      "requiredServicePlans": ["EXCHANGE_S_ENTERPRISE"],
-      "checkIds": ["PURVIEW-RETENTION-001", "PURVIEW-RETENTION-002", "PURVIEW-RETENTION-003", "PURVIEW-RETENTION-004", "PURVIEW-RETENTION-005"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/purview/retention-policies-exchange",
-      "tags": ["E3", "data-protection", "compliance"]
-    },
-    {
-      "featureId": "audit-logging",
-      "name": "Unified Audit Logging",
-      "category": "data-protection",
-      "description": "Enable unified audit logging for security investigations and compliance",
-      "effortTier": "Quick Win",
-      "requiredServicePlans": ["EXCHANGE_S_ENTERPRISE"],
-      "checkIds": ["COMPLIANCE-AUDIT-001"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/purview/audit-log-enable-disable",
-      "tags": ["E3", "data-protection", "audit"]
-    },
-    {
-      "featureId": "intune-enrollment",
-      "name": "Intune Device Enrollment",
-      "category": "device-management",
-      "description": "Configure Intune enrollment settings and MDM authority for device management",
-      "effortTier": "Strategic",
-      "requiredServicePlans": ["INTUNE_A"],
-      "checkIds": ["INTUNE-ENROLL-001", "INTUNE-COMPLIANCE-001"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/mem/intune/enrollment/device-enrollment",
-      "tags": ["E3", "devices", "intune"]
-    },
-    {
-      "featureId": "intune-compliance",
-      "name": "Intune Compliance Policies with CA",
-      "category": "device-management",
-      "description": "Require device compliance before granting access via Conditional Access integration",
-      "effortTier": "Medium",
-      "requiredServicePlans": ["INTUNE_A"],
-      "checkIds": ["INTUNE-MAA-001", "CA-INTUNE-001"],
-      "csvSignals": [],
-      "prerequisites": ["intune-enrollment"],
-      "learnUrl": "https://learn.microsoft.com/en-us/mem/intune/protect/conditional-access-intune-common-ways-use",
-      "tags": ["E3", "devices", "intune", "conditional-access"]
-    },
-    {
-      "featureId": "intune-rbac",
-      "name": "Intune RBAC & Remote Wipe Audit",
-      "category": "device-management",
-      "description": "Configure role-based access control for Intune administration and audit remote wipe actions",
-      "effortTier": "Medium",
-      "requiredServicePlans": ["INTUNE_A"],
-      "checkIds": ["INTUNE-RBAC-001", "INTUNE-WIPEAUDIT-001"],
-      "csvSignals": [],
-      "prerequisites": ["intune-enrollment"],
-      "learnUrl": "https://learn.microsoft.com/en-us/mem/intune/fundamentals/role-based-access-control",
-      "tags": ["E3", "devices", "intune"]
-    },
-    {
-      "featureId": "spo-external-sharing",
-      "name": "SharePoint External Sharing Controls",
-      "category": "collaboration",
-      "description": "Configure external sharing limits for SharePoint Online and OneDrive",
-      "effortTier": "Medium",
-      "requiredServicePlans": ["SHAREPOINTENTERPRISE"],
-      "checkIds": ["SPO-SHARING-001", "SPO-SHARING-002", "SPO-SHARING-003", "SPO-SHARING-004", "SPO-SHARING-005", "SPO-SHARING-006", "SPO-SHARING-007", "SPO-SHARING-008"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/sharepoint/turn-external-sharing-on-or-off",
-      "tags": ["E3", "collaboration", "sharepoint"]
-    },
-    {
-      "featureId": "spo-malware-scanning",
-      "name": "SharePoint Safe Attachments",
-      "category": "collaboration",
-      "description": "Enable Safe Attachments for SharePoint, OneDrive, and Teams to scan uploaded files",
-      "effortTier": "Quick Win",
-      "requiredServicePlans": ["ATP_ENTERPRISE"],
-      "checkIds": ["SPO-MALWARE-002"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/defender-office-365/safe-attachments-for-spo-odfb-teams-about",
-      "tags": ["E5", "collaboration", "defender"]
-    },
-    {
-      "featureId": "spo-script-control",
-      "name": "SharePoint Custom Script Control",
-      "category": "collaboration",
-      "description": "Restrict custom script execution on SharePoint sites to prevent malicious code",
-      "effortTier": "Quick Win",
-      "requiredServicePlans": ["SHAREPOINTENTERPRISE"],
-      "checkIds": ["SPO-SCRIPT-001", "SPO-SCRIPT-002"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/sharepoint/allow-or-prevent-custom-script",
-      "tags": ["E3", "collaboration", "sharepoint"]
-    },
-    {
-      "featureId": "spo-auth-sync",
-      "name": "SharePoint Authentication & Sync",
-      "category": "collaboration",
-      "description": "Configure SharePoint authentication policies, B2B integration, and sync client restrictions",
-      "effortTier": "Medium",
-      "requiredServicePlans": ["SHAREPOINTENTERPRISE"],
-      "checkIds": ["SPO-AUTH-001", "SPO-B2B-001", "SPO-SYNC-001", "SPO-SYNC-002", "SPO-SESSION-001"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/sharepoint/control-access-from-unmanaged-devices",
-      "tags": ["E3", "collaboration", "sharepoint"]
-    },
-    {
-      "featureId": "teams-external-access",
-      "name": "Teams External Access Controls",
-      "category": "collaboration",
-      "description": "Configure external and federated access settings for Teams communication",
-      "effortTier": "Medium",
-      "requiredServicePlans": ["TEAMS1"],
-      "checkIds": ["TEAMS-EXTACCESS-001", "TEAMS-EXTACCESS-002", "TEAMS-EXTACCESS-003", "TEAMS-EXTACCESS-004"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/microsoftteams/manage-external-access",
-      "tags": ["E3", "collaboration", "teams"]
-    },
-    {
-      "featureId": "teams-meeting-security",
-      "name": "Teams Meeting Security",
-      "category": "collaboration",
-      "description": "Configure meeting policies for lobby, recording, transcription, and external presenters",
-      "effortTier": "Medium",
-      "requiredServicePlans": ["TEAMS1"],
-      "checkIds": ["TEAMS-MEETING-001", "TEAMS-MEETING-002", "TEAMS-MEETING-003", "TEAMS-MEETING-004", "TEAMS-MEETING-005", "TEAMS-MEETING-006", "TEAMS-MEETING-007", "TEAMS-MEETING-008", "TEAMS-MEETING-009"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/microsoftteams/meeting-policies-overview",
-      "tags": ["E3", "collaboration", "teams"]
-    },
-    {
-      "featureId": "teams-apps-client",
-      "name": "Teams App & Client Security",
-      "category": "collaboration",
-      "description": "Control third-party app installation and client-side security settings in Teams",
-      "effortTier": "Medium",
-      "requiredServicePlans": ["TEAMS1"],
-      "checkIds": ["TEAMS-APPS-001", "TEAMS-APPS-002", "TEAMS-CLIENT-001", "TEAMS-CLIENT-002", "TEAMS-INFO-001", "TEAMS-REPORTING-001"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/microsoftteams/admin-settings",
-      "tags": ["E3", "collaboration", "teams"]
-    },
-    {
-      "featureId": "forms-security",
-      "name": "Microsoft Forms Security",
-      "category": "collaboration",
-      "description": "Configure Forms settings to control external sharing and data collection",
-      "effortTier": "Quick Win",
-      "requiredServicePlans": ["FORMS_PLAN_E3"],
-      "checkIds": ["FORMS-CONFIG-001", "FORMS-CONFIG-002", "FORMS-CONFIG-003", "FORMS-CONFIG-004", "FORMS-CONFIG-005", "FORMS-CONFIG-006"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/microsoft-forms/administrator-settings-microsoft-forms",
-      "tags": ["E3", "collaboration", "forms"]
-    },
-    {
-      "featureId": "powerbi-security",
-      "name": "Power BI Security & Sharing",
-      "category": "collaboration",
-      "description": "Configure Power BI authentication, guest access, sharing, and information protection settings",
-      "effortTier": "Medium",
-      "requiredServicePlans": ["BI_AZURE_P2"],
-      "checkIds": ["POWERBI-AUTH-001", "POWERBI-AUTH-002", "POWERBI-AUTH-003", "POWERBI-GUEST-001", "POWERBI-GUEST-002", "POWERBI-GUEST-003", "POWERBI-INFOPROT-001", "POWERBI-SHARING-001", "POWERBI-SHARING-002", "POWERBI-SHARING-003", "POWERBI-SHARING-004"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/power-bi/admin/service-admin-portal",
-      "tags": ["E3", "collaboration", "powerbi"]
-    },
-    {
-      "featureId": "defender-preset-policies",
-      "name": "Defender Preset Security Policies",
-      "category": "threat-protection",
-      "description": "Enable Standard or Strict preset policies for baseline Defender for Office 365 protection",
-      "effortTier": "Quick Win",
-      "requiredServicePlans": ["EXCHANGE_S_ENTERPRISE"],
-      "checkIds": ["EXO-EXTTAG-001"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/defender-office-365/preset-security-policies",
-      "tags": ["E3", "threat-protection", "defender"]
-    },
-    {
-      "featureId": "zap",
-      "name": "Zero-hour Auto Purge (ZAP)",
-      "category": "threat-protection",
-      "description": "Enable zero-hour auto purge to retroactively remove malicious messages from mailboxes",
-      "effortTier": "Quick Win",
-      "requiredServicePlans": ["ATP_ENTERPRISE"],
-      "checkIds": ["DEFENDER-ZAP-001"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/defender-office-365/zero-hour-auto-purge",
-      "tags": ["E5", "threat-protection", "defender"]
-    },
-    {
-      "featureId": "priority-account-protection",
-      "name": "Priority Account Protection",
-      "category": "threat-protection",
-      "description": "Tag and apply enhanced protection to priority accounts (executives, finance, IT admins)",
-      "effortTier": "Medium",
-      "requiredServicePlans": ["ATP_ENTERPRISE"],
-      "checkIds": ["DEFENDER-PRIORITY-001", "DEFENDER-PRIORITY-002"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/defender-office-365/priority-accounts-security-recommendations",
-      "tags": ["E5", "threat-protection", "defender"]
-    },
-    {
-      "featureId": "app-consent-governance",
-      "name": "Application Consent & Governance",
-      "category": "threat-protection",
-      "description": "Control user consent grants and enforce admin approval workflows for application permissions",
-      "effortTier": "Medium",
-      "requiredServicePlans": ["AAD_PREMIUM"],
-      "checkIds": ["ENTRA-CONSENT-001", "ENTRA-CONSENT-002", "ENTRA-CONSENT-003", "ENTRA-CONSENT-004"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/configure-user-consent",
-      "tags": ["E3", "threat-protection", "identity"]
-    },
-    {
-      "featureId": "app-registration-security",
-      "name": "Application Registration Security",
-      "category": "threat-protection",
-      "description": "Restrict app registration, enforce credential hygiene, and monitor enterprise app configurations",
-      "effortTier": "Medium",
-      "requiredServicePlans": ["AAD_PREMIUM"],
-      "checkIds": ["ENTRA-APPREG-001", "ENTRA-APPREG-002", "ENTRA-APPREG-003", "ENTRA-APPREG-004", "ENTRA-APPS-001", "ENTRA-APPS-002"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/application-management-fundamentals",
-      "tags": ["E3", "threat-protection", "identity"]
-    },
-    {
-      "featureId": "enterprise-app-security",
-      "name": "Enterprise Application Security",
-      "category": "threat-protection",
-      "description": "Audit enterprise app permissions, credential hygiene, reply URIs, and impersonation risks",
-      "effortTier": "Strategic",
-      "requiredServicePlans": ["AAD_PREMIUM"],
-      "checkIds": ["ENTRA-ENTAPP-001", "ENTRA-ENTAPP-002", "ENTRA-ENTAPP-003", "ENTRA-ENTAPP-004", "ENTRA-ENTAPP-005", "ENTRA-ENTAPP-006", "ENTRA-ENTAPP-007", "ENTRA-ENTAPP-008", "ENTRA-ENTAPP-009", "ENTRA-ENTAPP-010", "ENTRA-ENTAPP-011", "ENTRA-ENTAPP-012", "ENTRA-ENTAPP-013", "ENTRA-ENTAPP-014", "ENTRA-ENTAPP-015", "ENTRA-ENTAPP-016", "ENTRA-ENTAPP-017", "ENTRA-ENTAPP-018", "ENTRA-ENTAPP-019", "ENTRA-ENTAPP-020", "ENTRA-ENTAPP-021"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/overview-application-gallery",
-      "tags": ["E3", "threat-protection", "identity", "app-security"]
-    },
-    {
-      "featureId": "exchange-transport-security",
-      "name": "Exchange Transport & Sharing Rules",
-      "category": "email-security",
-      "description": "Configure mail flow rules, OWA policies, shared mailbox auth, and calendar sharing controls",
-      "effortTier": "Medium",
-      "requiredServicePlans": ["EXCHANGE_S_ENTERPRISE"],
-      "checkIds": ["EXO-TRANSPORT-001", "EXO-OWA-001", "EXO-SHAREDMBX-001", "EXO-SHARING-001", "EXO-MAILTIPS-001", "EXO-ADDINS-001", "EXO-HIDDEN-001", "EXO-DIRECTSEND-001"],
-      "csvSignals": [],
-      "prerequisites": [],
-      "learnUrl": "https://learn.microsoft.com/en-us/exchange/security-and-compliance/mail-flow-rules/mail-flow-rules",
-      "tags": ["E3", "email"]
-    },
-    {
-      "featureId": "guest-access-governance",
-      "name": "Guest Access Governance",
-      "category": "identity-access",
-      "description": "Control guest user invitations, access restrictions, and cross-tenant collaboration settings",
-      "effortTier": "Medium",
-      "requiredServicePlans": ["AAD_PREMIUM"],
-      "checkIds": ["ENTRA-GUEST-001", "ENTRA-GUEST-002", "ENTRA-GUEST-003", "ENTRA-GUEST-004"],
-      "csvSignals": [],
-      "prerequisites": [],
       "learnUrl": "https://learn.microsoft.com/en-us/entra/external-id/external-identities-overview",
-      "tags": ["E3", "identity", "governance"]
+      "prerequisites": []
+    },
+    "app-registration-governance": {
+      "displayName": "Application and Enterprise App Governance",
+      "description": "Control user app registrations, consent flows, enterprise app permissions, and detect overprivileged or inactive applications.",
+      "category": "Identity",
+      "servicePlans": [
+        "AAD_PREMIUM"
+      ],
+      "detectionChecks": [
+        "ENTRA-APPREG-001",
+        "ENTRA-APPS-001",
+        "ENTRA-APPS-002",
+        "ENTRA-CONSENT-001",
+        "ENTRA-CONSENT-002",
+        "ENTRA-ENTAPP-001",
+        "ENTRA-ENTAPP-002",
+        "ENTRA-ENTAPP-003",
+        "ENTRA-ENTAPP-004",
+        "ENTRA-ENTAPP-005",
+        "ENTRA-ENTAPP-006",
+        "ENTRA-ENTAPP-007",
+        "ENTRA-ENTAPP-008",
+        "ENTRA-ENTAPP-009"
+      ],
+      "valueCategory": "Security",
+      "estimatedEffort": "Medium",
+      "quickWin": false,
+      "effortTier": "Medium",
+      "learnUrl": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/configure-user-consent",
+      "prerequisites": []
+    },
+    "device-management": {
+      "displayName": "Device Management and Compliance",
+      "description": "Intune device enrollment, compliance policies, encryption, update rings, and Entra device join restrictions.",
+      "category": "Security",
+      "servicePlans": [
+        "INTUNE_A"
+      ],
+      "detectionChecks": [
+        "ENTRA-DEVICE-001",
+        "ENTRA-DEVICE-002",
+        "ENTRA-DEVICE-003",
+        "ENTRA-DEVICE-004",
+        "ENTRA-DEVICE-005",
+        "ENTRA-DEVICE-006",
+        "INTUNE-COMPLIANCE-001",
+        "INTUNE-ENCRYPTION-001",
+        "INTUNE-ENROLL-001",
+        "INTUNE-ENROLLMENT-001",
+        "INTUNE-MAA-001",
+        "INTUNE-RBAC-001",
+        "INTUNE-SECURITY-001",
+        "INTUNE-UPDATE-001",
+        "INTUNE-WIPEAUDIT-001"
+      ],
+      "valueCategory": "Security",
+      "estimatedEffort": "High",
+      "quickWin": false,
+      "effortTier": "Medium",
+      "learnUrl": "https://learn.microsoft.com/en-us/entra/identity/devices/manage-device-identities",
+      "prerequisites": []
+    },
+    "defender-antimalware": {
+      "displayName": "Defender Anti-Malware and Anti-Spam",
+      "description": "Exchange Online Protection policies for malware filtering, common attachment type blocking, anti-spam, outbound spam limits, and administrator notifications.",
+      "category": "Security",
+      "servicePlans": [
+        "EXCHANGE_S_ENTERPRISE"
+      ],
+      "detectionChecks": [
+        "DEFENDER-ANTIMALWARE-001",
+        "DEFENDER-ANTIMALWARE-002",
+        "DEFENDER-ANTISPAM-001",
+        "DEFENDER-ANTISPAM-002",
+        "DEFENDER-MALWARE-002",
+        "DEFENDER-OUTBOUND-001",
+        "DEFENDER-ZAP-001"
+      ],
+      "valueCategory": "Security",
+      "estimatedEffort": "Medium",
+      "quickWin": true,
+      "effortTier": "Quick Win",
+      "learnUrl": "https://learn.microsoft.com/en-us/defender-office-365/anti-spam-protection-about",
+      "prerequisites": []
+    },
+    "defender-safe-attachments": {
+      "displayName": "Safe Attachments",
+      "description": "Defender for Office 365 Safe Attachments policies that scan email attachments and files in SharePoint, OneDrive, and Teams for malware.",
+      "category": "Security",
+      "servicePlans": [
+        "ATP_ENTERPRISE"
+      ],
+      "detectionChecks": [
+        "DEFENDER-SAFEATTACH-001",
+        "DEFENDER-SAFEATTACH-002"
+      ],
+      "valueCategory": "Security",
+      "estimatedEffort": "Low",
+      "quickWin": true,
+      "effortTier": "Medium",
+      "learnUrl": "https://learn.microsoft.com/en-us/defender-office-365/safe-attachments-about",
+      "prerequisites": []
+    },
+    "defender-safe-links": {
+      "displayName": "Safe Links",
+      "description": "Defender for Office 365 Safe Links policies providing time-of-click URL scanning and rewriting for email messages and Office applications.",
+      "category": "Security",
+      "servicePlans": [
+        "ATP_ENTERPRISE"
+      ],
+      "detectionChecks": [
+        "DEFENDER-SAFELINKS-001"
+      ],
+      "valueCategory": "Security",
+      "estimatedEffort": "Low",
+      "quickWin": true,
+      "effortTier": "Medium",
+      "learnUrl": "https://learn.microsoft.com/en-us/defender-office-365/safe-links-about",
+      "prerequisites": []
+    },
+    "defender-antiphishing": {
+      "displayName": "Anti-Phishing Protection",
+      "description": "Advanced anti-phishing policies including impersonation protection, mailbox intelligence, and spoof settings in Defender for Office 365.",
+      "category": "Security",
+      "servicePlans": [
+        "ATP_ENTERPRISE"
+      ],
+      "detectionChecks": [
+        "DEFENDER-ANTIPHISH-001",
+        "EXO-ANTIPHISH-001",
+        "EXO-ANTISPAM-001"
+      ],
+      "valueCategory": "Security",
+      "estimatedEffort": "Medium",
+      "quickWin": false,
+      "effortTier": "Medium",
+      "learnUrl": "https://learn.microsoft.com/en-us/defender-office-365/anti-phishing-policies-about",
+      "prerequisites": []
+    },
+    "defender-priority-accounts": {
+      "displayName": "Priority Account Protection",
+      "description": "Enable priority account tagging and apply strict protection presets for high-value user accounts.",
+      "category": "Security",
+      "servicePlans": [
+        "ATP_ENTERPRISE"
+      ],
+      "detectionChecks": [
+        "DEFENDER-PRIORITY-001",
+        "DEFENDER-PRIORITY-002"
+      ],
+      "valueCategory": "Security",
+      "estimatedEffort": "Low",
+      "quickWin": true,
+      "effortTier": "Medium",
+      "learnUrl": "https://learn.microsoft.com/en-us/defender-office-365/priority-accounts-security-recommendations",
+      "prerequisites": []
+    },
+    "defender-cloud-apps": {
+      "displayName": "Defender for Cloud Apps",
+      "description": "Microsoft Defender for Cloud Apps providing visibility, data control, and threat protection across cloud services.",
+      "category": "Security",
+      "servicePlans": [
+        "ADALLOM_S_STANDALONE"
+      ],
+      "detectionChecks": [
+        "DEFENDER-CLOUDAPPS-001"
+      ],
+      "valueCategory": "Security",
+      "estimatedEffort": "High",
+      "quickWin": false,
+      "effortTier": "Strategic",
+      "learnUrl": "https://learn.microsoft.com/en-us/defender-cloud-apps/what-is-defender-for-cloud-apps",
+      "prerequisites": []
+    },
+    "defender-endpoint": {
+      "displayName": "Defender for Endpoint",
+      "description": "Microsoft Defender for Endpoint providing endpoint detection and response, threat hunting, and automated investigation and remediation.",
+      "category": "Security",
+      "servicePlans": [
+        "WINDEFATP"
+      ],
+      "detectionChecks": [
+        "DEFENDER-SECURESCORE-001"
+      ],
+      "valueCategory": "Security",
+      "estimatedEffort": "High",
+      "quickWin": false,
+      "effortTier": "Strategic",
+      "learnUrl": "https://learn.microsoft.com/en-us/defender-endpoint/microsoft-defender-endpoint",
+      "prerequisites": []
+    },
+    "email-authentication": {
+      "displayName": "Email Authentication (SPF/DKIM/DMARC)",
+      "description": "DNS-based email authentication records including SPF, DKIM signing, and DMARC policies for all Exchange Online domains.",
+      "category": "Security",
+      "servicePlans": [
+        "EXCHANGE_S_ENTERPRISE"
+      ],
+      "detectionChecks": [
+        "DNS-SPF-001",
+        "DNS-DKIM-001",
+        "DNS-DMARC-001",
+        "EXO-DKIM-001"
+      ],
+      "valueCategory": "Security",
+      "estimatedEffort": "Medium",
+      "quickWin": false,
+      "effortTier": "Quick Win",
+      "learnUrl": "https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/email-authentication-dmarc-configure",
+      "prerequisites": []
+    },
+    "exchange-transport-security": {
+      "displayName": "Exchange Transport and Mail Flow Security",
+      "description": "Exchange Online mail flow rules, forwarding controls, external sender tagging, connection filters, modern authentication, and shared mailbox hardening.",
+      "category": "Security",
+      "servicePlans": [
+        "EXCHANGE_S_ENTERPRISE"
+      ],
+      "detectionChecks": [
+        "EXO-AUTH-001",
+        "EXO-AUTH-002",
+        "EXO-CONNFILTER-001",
+        "EXO-CONNFILTER-002",
+        "EXO-DIRECTSEND-001",
+        "EXO-EXTTAG-001",
+        "EXO-FORWARD-001",
+        "EXO-MAILTIPS-001",
+        "EXO-MALWARE-001",
+        "EXO-OWA-001",
+        "EXO-SHAREDMBX-001",
+        "EXO-TRANSPORT-001",
+        "EXO-TRANSPORT-002",
+        "EXO-ADDINS-001"
+      ],
+      "valueCategory": "Security",
+      "estimatedEffort": "Medium",
+      "quickWin": false,
+      "effortTier": "Quick Win",
+      "learnUrl": "https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/outbound-spam-policies-external-email-forwarding",
+      "prerequisites": []
+    },
+    "dlp-policies": {
+      "displayName": "Data Loss Prevention",
+      "description": "DLP policies across Exchange, SharePoint, OneDrive, and Teams to detect and prevent sharing of sensitive information.",
+      "category": "Compliance",
+      "servicePlans": [
+        "MIP_S_CLP1"
+      ],
+      "detectionChecks": [
+        "COMPLIANCE-DLP-001",
+        "COMPLIANCE-DLP-002"
+      ],
+      "valueCategory": "Compliance",
+      "estimatedEffort": "High",
+      "quickWin": false,
+      "effortTier": "Strategic",
+      "learnUrl": "https://learn.microsoft.com/en-us/purview/dlp-learn-about-dlp",
+      "prerequisites": []
+    },
+    "sensitivity-labels": {
+      "displayName": "Sensitivity Labels and Information Protection",
+      "description": "Publish sensitivity label policies for classifying and protecting documents and emails with encryption and access restrictions.",
+      "category": "Compliance",
+      "servicePlans": [
+        "MIP_S_CLP1"
+      ],
+      "detectionChecks": [
+        "COMPLIANCE-LABELS-001"
+      ],
+      "valueCategory": "Compliance",
+      "estimatedEffort": "High",
+      "quickWin": false,
+      "effortTier": "Strategic",
+      "learnUrl": "https://learn.microsoft.com/en-us/purview/sensitivity-labels",
+      "prerequisites": []
+    },
+    "audit-logging": {
+      "displayName": "Audit Logging",
+      "description": "Unified audit log search, mailbox auditing, and advanced audit capabilities for forensic investigation and compliance monitoring.",
+      "category": "Compliance",
+      "servicePlans": [
+        "EXCHANGE_S_ENTERPRISE"
+      ],
+      "detectionChecks": [
+        "COMPLIANCE-AUDIT-001",
+        "COMPLIANCE-ALERTPOLICY-001",
+        "EXO-AUDIT-001",
+        "EXO-AUDIT-002",
+        "EXO-AUDIT-003",
+        "PURVIEW-AUDIT-001"
+      ],
+      "valueCategory": "Compliance",
+      "estimatedEffort": "Low",
+      "quickWin": true,
+      "effortTier": "Quick Win",
+      "learnUrl": "https://learn.microsoft.com/en-us/purview/audit-mailboxes",
+      "prerequisites": []
+    },
+    "customer-lockbox": {
+      "displayName": "Customer Lockbox",
+      "description": "Require approval before Microsoft support engineers can access tenant data during service requests.",
+      "category": "Compliance",
+      "servicePlans": [
+        "LOCKBOX_ENTERPRISE"
+      ],
+      "detectionChecks": [
+        "EXO-LOCKBOX-001"
+      ],
+      "valueCategory": "Compliance",
+      "estimatedEffort": "Low",
+      "quickWin": true,
+      "effortTier": "Medium",
+      "learnUrl": "https://learn.microsoft.com/en-us/purview/customer-lockbox-requests",
+      "prerequisites": []
+    },
+    "data-retention": {
+      "displayName": "Data Retention Policies",
+      "description": "Retention policies covering Exchange, Teams, and SharePoint/OneDrive to ensure compliance with data retention requirements.",
+      "category": "Compliance",
+      "servicePlans": [
+        "EXCHANGE_S_ENTERPRISE",
+        "SHAREPOINTENTERPRISE",
+        "TEAMS1"
+      ],
+      "detectionChecks": [
+        "PURVIEW-RETENTION-001",
+        "PURVIEW-RETENTION-002",
+        "PURVIEW-RETENTION-003",
+        "PURVIEW-RETENTION-004",
+        "PURVIEW-RETENTION-005"
+      ],
+      "valueCategory": "Compliance",
+      "estimatedEffort": "Medium",
+      "quickWin": false,
+      "effortTier": "Medium",
+      "learnUrl": "https://learn.microsoft.com/en-us/purview/retention-policies-exchange",
+      "prerequisites": []
+    },
+    "sharepoint-external-sharing": {
+      "displayName": "SharePoint and OneDrive External Sharing",
+      "description": "Control external content sharing, guest access expiration, sharing link defaults, domain restrictions, and sync restrictions for unmanaged devices.",
+      "category": "Collaboration",
+      "servicePlans": [
+        "SHAREPOINTENTERPRISE"
+      ],
+      "detectionChecks": [
+        "SPO-SHARING-001",
+        "SPO-SHARING-002",
+        "SPO-SHARING-003",
+        "SPO-SHARING-004",
+        "SPO-SHARING-005",
+        "SPO-SHARING-006",
+        "SPO-SHARING-007",
+        "SPO-SHARING-008",
+        "SPO-OD-001",
+        "SPO-AUTH-001",
+        "SPO-B2B-001",
+        "SPO-SESSION-001",
+        "SPO-SYNC-001",
+        "SPO-SYNC-002",
+        "SPO-MALWARE-002",
+        "SPO-SCRIPT-001",
+        "SPO-SCRIPT-002",
+        "SPO-SWAY-001",
+        "SPO-LOOP-001",
+        "SPO-LOOP-002"
+      ],
+      "valueCategory": "Collaboration",
+      "estimatedEffort": "Medium",
+      "quickWin": false,
+      "effortTier": "Medium",
+      "learnUrl": "https://learn.microsoft.com/en-us/sharepoint/turn-external-sharing-on-or-off",
+      "prerequisites": []
+    },
+    "teams-security": {
+      "displayName": "Teams Meeting and Collaboration Security",
+      "description": "Teams meeting policies, external access controls, guest access settings, app permissions, and security reporting.",
+      "category": "Collaboration",
+      "servicePlans": [
+        "TEAMS1"
+      ],
+      "detectionChecks": [
+        "TEAMS-MEETING-001",
+        "TEAMS-MEETING-002",
+        "TEAMS-MEETING-003",
+        "TEAMS-MEETING-004",
+        "TEAMS-MEETING-005",
+        "TEAMS-MEETING-006",
+        "TEAMS-MEETING-007",
+        "TEAMS-MEETING-008",
+        "TEAMS-MEETING-009",
+        "TEAMS-EXTACCESS-001",
+        "TEAMS-EXTACCESS-002",
+        "TEAMS-EXTACCESS-003",
+        "TEAMS-EXTACCESS-004",
+        "TEAMS-GUEST-001",
+        "TEAMS-APPS-001",
+        "TEAMS-APPS-002",
+        "TEAMS-CLIENT-001",
+        "TEAMS-CLIENT-002",
+        "TEAMS-REPORTING-001",
+        "TEAMS-INFO-001"
+      ],
+      "valueCategory": "Collaboration",
+      "estimatedEffort": "Medium",
+      "quickWin": false,
+      "effortTier": "Medium",
+      "learnUrl": "https://learn.microsoft.com/en-us/microsoftteams/manage-external-access",
+      "prerequisites": []
+    },
+    "forms-security": {
+      "displayName": "Microsoft Forms Security",
+      "description": "Restrict external access to Forms, enable phishing protection, control collaboration and result visibility for surveys and forms.",
+      "category": "Collaboration",
+      "servicePlans": [
+        "FORMS_PLAN_E3"
+      ],
+      "detectionChecks": [
+        "FORMS-CONFIG-001",
+        "FORMS-CONFIG-002",
+        "FORMS-CONFIG-003",
+        "FORMS-CONFIG-004",
+        "FORMS-CONFIG-005",
+        "FORMS-CONFIG-006"
+      ],
+      "valueCategory": "Security",
+      "estimatedEffort": "Low",
+      "quickWin": true,
+      "effortTier": "Quick Win",
+      "learnUrl": "https://learn.microsoft.com/en-us/microsoft-forms/administrator-settings-microsoft-forms",
+      "prerequisites": []
+    },
+    "power-bi-security": {
+      "displayName": "Power BI Tenant Security",
+      "description": "Power BI sharing restrictions, guest access controls, publish-to-web restrictions, service principal controls, and sensitivity label enforcement.",
+      "category": "Collaboration",
+      "servicePlans": [
+        "EXCHANGE_S_ENTERPRISE"
+      ],
+      "detectionChecks": [
+        "PBI-AUTH-001",
+        "PBI-API-001",
+        "PBI-CONTENT-001",
+        "PBI-GUEST-001",
+        "PBI-INVITE-001",
+        "PBI-LABELS-001",
+        "PBI-LINK-001",
+        "PBI-PROFILE-001",
+        "PBI-PUBLISH-001",
+        "PBI-SCRIPT-001",
+        "PBI-SHARING-001",
+        "PBI-TENANT-001",
+        "PBI-TENANT-002",
+        "PBI-TENANT-003",
+        "POWERBI-AUTH-001",
+        "POWERBI-AUTH-002",
+        "POWERBI-AUTH-003",
+        "POWERBI-GUEST-001",
+        "POWERBI-GUEST-002",
+        "POWERBI-GUEST-003",
+        "POWERBI-INFOPROT-001",
+        "POWERBI-SHARING-001",
+        "POWERBI-SHARING-002",
+        "POWERBI-SHARING-003",
+        "POWERBI-SHARING-004"
+      ],
+      "valueCategory": "Security",
+      "estimatedEffort": "Medium",
+      "quickWin": false,
+      "effortTier": "Medium",
+      "learnUrl": "https://learn.microsoft.com/en-us/power-bi/admin/service-admin-portal",
+      "prerequisites": []
+    },
+    "tenant-and-org-settings": {
+      "displayName": "Tenant and Organization Settings",
+      "description": "Tenant-wide settings including restricting tenant creation, LinkedIn connections, third-party storage, session timeout, and org-wide security controls.",
+      "category": "Security",
+      "servicePlans": [
+        "AAD_PREMIUM"
+      ],
+      "detectionChecks": [
+        "ENTRA-TENANT-001",
+        "ENTRA-LINKEDIN-001",
+        "ENTRA-ORGSETTING-001",
+        "ENTRA-ORGSETTING-002",
+        "ENTRA-ORGSETTING-003",
+        "ENTRA-ORGSETTING-004",
+        "ENTRA-SESSION-001",
+        "ENTRA-ROLEGROUP-001",
+        "EXO-SHARING-001"
+      ],
+      "valueCategory": "Security",
+      "estimatedEffort": "Low",
+      "quickWin": true,
+      "effortTier": "Medium",
+      "learnUrl": "https://learn.microsoft.com/en-us/exchange/security-and-compliance/mail-flow-rules/mail-flow-rules",
+      "prerequisites": []
     }
-  ]
+  },
+  "skuTiers": {
+    "E3": {
+      "includedPlans": [
+        "AAD_PREMIUM",
+        "MFA_PREMIUM",
+        "INTUNE_A",
+        "EXCHANGE_S_ENTERPRISE",
+        "SHAREPOINTENTERPRISE",
+        "TEAMS1",
+        "MIP_S_CLP1",
+        "MDE_LITE",
+        "FORMS_PLAN_E3",
+        "ContentExplorer_Standard",
+        "RMS_S_ENTERPRISE",
+        "RMS_S_PREMIUM",
+        "ADALLOM_S_DISCOVERY"
+      ]
+    },
+    "E5": {
+      "includedPlans": [
+        "AAD_PREMIUM",
+        "AAD_PREMIUM_P2",
+        "MFA_PREMIUM",
+        "INTUNE_A",
+        "EXCHANGE_S_ENTERPRISE",
+        "SHAREPOINTENTERPRISE",
+        "TEAMS1",
+        "MIP_S_CLP1",
+        "MIP_S_CLP2",
+        "ATP_ENTERPRISE",
+        "THREAT_INTELLIGENCE",
+        "WINDEFATP",
+        "LOCKBOX_ENTERPRISE",
+        "ADALLOM_S_STANDALONE",
+        "ADALLOM_S_DISCOVERY",
+        "MICROSOFTENDPOINTDLP",
+        "COMMUNICATIONS_DLP",
+        "INFORMATION_BARRIERS",
+        "EQUIVIO_ANALYTICS",
+        "M365_ADVANCED_AUDITING",
+        "SAFEDOCS",
+        "PREMIUM_ENCRYPTION",
+        "FORMS_PLAN_E5",
+        "ContentExplorer_Standard",
+        "Content_Explorer",
+        "RMS_S_ENTERPRISE",
+        "RMS_S_PREMIUM",
+        "RMS_S_PREMIUM2",
+        "MDE_LITE",
+        "MTP",
+        "ATA"
+      ]
+    }
+  },
+  "$comment": "featureGroups schema v2.1.0: restored effortTier, learnUrl, prerequisites fields for downstream compatibility"
 }

--- a/tests/ValueOpportunity/Get-FeatureAdoption.Tests.ps1
+++ b/tests/ValueOpportunity/Get-FeatureAdoption.Tests.ps1
@@ -4,19 +4,19 @@ BeforeAll {
 
 Describe 'Get-FeatureAdoption' {
     BeforeAll {
-        # Use a small mock feature map with known structure
-        $script:mockFeatureMap = @{
-            features = @(
-                @{
-                    featureId = 'test-feature'
-                    name = 'Test Feature'
-                    category = 'identity-access'
-                    checkIds = @('TEST-001', 'TEST-002')
-                    csvSignals = @()
-                    requiredServicePlans = @('PLAN_A')
+        $script:mockFeatureMap = [PSCustomObject]@{
+            featureGroups = [PSCustomObject]@{
+                'test-feature' = [PSCustomObject]@{
+                    displayName     = 'Test Feature'
+                    category        = 'Identity & Access'
+                    effortTier      = 'Quick Win'
+                    servicePlans    = @('PLAN_A')
+                    detectionChecks = @('TEST-001', 'TEST-002')
+                    prerequisites   = @()
+                    learnUrl        = 'https://learn.microsoft.com/test'
+                    csvSignals      = $null
                 }
-            )
-            categories = @(@{ id = 'identity-access'; name = 'Identity & Access' })
+            }
         }
     }
 
@@ -99,29 +99,29 @@ Describe 'Get-FeatureAdoption' {
     }
 
     It 'Should handle multiple features in the map' {
-        $multiMap = @{
-            features = @(
-                @{
-                    featureId = 'feature-a'
-                    name = 'Feature A'
-                    category = 'identity-access'
-                    checkIds = @('A-001')
-                    csvSignals = @()
-                    requiredServicePlans = @('PLAN_A')
-                },
-                @{
-                    featureId = 'feature-b'
-                    name = 'Feature B'
-                    category = 'email-security'
-                    checkIds = @('B-001')
-                    csvSignals = @()
-                    requiredServicePlans = @('PLAN_B')
+        $multiMap = [PSCustomObject]@{
+            featureGroups = [PSCustomObject]@{
+                'feature-a' = [PSCustomObject]@{
+                    displayName     = 'Feature A'
+                    category        = 'Identity & Access'
+                    effortTier      = 'Quick Win'
+                    servicePlans    = @('PLAN_A')
+                    detectionChecks = @('A-001')
+                    prerequisites   = @()
+                    learnUrl        = 'https://learn.microsoft.com/a'
+                    csvSignals      = $null
                 }
-            )
-            categories = @(
-                @{ id = 'identity-access'; name = 'Identity & Access' },
-                @{ id = 'email-security'; name = 'Email Security' }
-            )
+                'feature-b' = [PSCustomObject]@{
+                    displayName     = 'Feature B'
+                    category        = 'Email Security'
+                    effortTier      = 'Medium'
+                    servicePlans    = @('PLAN_B')
+                    detectionChecks = @('B-001')
+                    prerequisites   = @()
+                    learnUrl        = 'https://learn.microsoft.com/b'
+                    csvSignals      = $null
+                }
+            }
         }
         $signals = @{
             'A-001.1' = @{ Status = 'Pass'; Setting = 'SA'; CurrentValue = 'VA'; Category = 'CA' }
@@ -139,20 +139,21 @@ Describe 'Get-FeatureAdoption' {
     }
 
     It 'Should not fail when CSV signal file does not exist' {
-        $csvMap = @{
-            features = @(
-                @{
-                    featureId = 'csv-feature'
-                    name = 'CSV Feature'
-                    category = 'identity-access'
-                    checkIds = @('CSV-001')
-                    csvSignals = @(
+        $csvMap = [PSCustomObject]@{
+            featureGroups = [PSCustomObject]@{
+                'csv-feature' = [PSCustomObject]@{
+                    displayName     = 'CSV Feature'
+                    category        = 'Identity & Access'
+                    effortTier      = 'Quick Win'
+                    servicePlans    = @('PLAN_A')
+                    detectionChecks = @('CSV-001')
+                    prerequisites   = @()
+                    learnUrl        = 'https://learn.microsoft.com/csv'
+                    csvSignals      = @(
                         @{ file = 'nonexistent.csv'; metric = 'count'; column = 'Status'; pattern = 'Pass'; label = 'Passes' }
                     )
-                    requiredServicePlans = @('PLAN_A')
                 }
-            )
-            categories = @(@{ id = 'identity-access'; name = 'Identity & Access' })
+            }
         }
         $signals = @{
             'CSV-001.1' = @{ Status = 'Pass'; Setting = 'S1'; CurrentValue = 'V1'; Category = 'C1' }

--- a/tests/ValueOpportunity/Get-FeatureReadiness.Tests.ps1
+++ b/tests/ValueOpportunity/Get-FeatureReadiness.Tests.ps1
@@ -4,28 +4,27 @@ BeforeAll {
 
 Describe 'Get-FeatureReadiness' {
     BeforeAll {
-        $script:mockFeatureMap = @{
-            features = @(
-                @{
-                    featureId = 'feature-a'
-                    name = 'Feature A'
-                    category = 'identity-access'
-                    effortTier = 'Quick Win'
-                    requiredServicePlans = @('PLAN_A')
-                    prerequisites = @()
-                    learnUrl = 'https://learn.microsoft.com/test-a'
+        $script:mockFeatureMap = [PSCustomObject]@{
+            featureGroups = [PSCustomObject]@{
+                'feature-a' = [PSCustomObject]@{
+                    displayName     = 'Feature A'
+                    category        = 'Identity & Access'
+                    effortTier      = 'Quick Win'
+                    servicePlans    = @('PLAN_A')
+                    prerequisites   = @()
+                    learnUrl        = 'https://learn.microsoft.com/test-a'
+                    detectionChecks = @()
                 }
-                @{
-                    featureId = 'feature-b'
-                    name = 'Feature B'
-                    category = 'identity-access'
-                    effortTier = 'Medium'
-                    requiredServicePlans = @('PLAN_B')
-                    prerequisites = @('feature-a')
-                    learnUrl = 'https://learn.microsoft.com/test-b'
+                'feature-b' = [PSCustomObject]@{
+                    displayName     = 'Feature B'
+                    category        = 'Identity & Access'
+                    effortTier      = 'Medium'
+                    servicePlans    = @('PLAN_B')
+                    prerequisites   = @('feature-a')
+                    learnUrl        = 'https://learn.microsoft.com/test-b'
+                    detectionChecks = @()
                 }
-            )
-            categories = @(@{ id = 'identity-access'; name = 'Identity & Access' })
+            }
         }
     }
 

--- a/tests/ValueOpportunity/Get-LicenseUtilization.Tests.ps1
+++ b/tests/ValueOpportunity/Get-LicenseUtilization.Tests.ps1
@@ -18,7 +18,7 @@ Describe 'Get-LicenseUtilization' {
         }
 
         $results = Get-LicenseUtilization -TenantLicenses $mockLicenses -FeatureMap $script:featureMap
-        $pim = $results | Where-Object { $_.FeatureId -eq 'pim' }
+        $pim = $results | Where-Object { $_.FeatureId -eq 'privileged-identity-management' }
         $pim.IsLicensed | Should -Be $true
     }
 
@@ -35,7 +35,7 @@ Describe 'Get-LicenseUtilization' {
         }
 
         $results = Get-LicenseUtilization -TenantLicenses $mockLicenses -FeatureMap $script:featureMap
-        $pim = $results | Where-Object { $_.FeatureId -eq 'pim' }
+        $pim = $results | Where-Object { $_.FeatureId -eq 'privileged-identity-management' }
         $pim.IsLicensed | Should -Be $false
     }
 
@@ -61,6 +61,6 @@ Describe 'Get-LicenseUtilization' {
         }
 
         $results = Get-LicenseUtilization -TenantLicenses $mockLicenses -FeatureMap $script:featureMap
-        $results.Count | Should -Be $script:featureMap.features.Count
+        $results.Count | Should -Be @($script:featureMap.featureGroups.PSObject.Properties).Count
     }
 }

--- a/tests/controls/sku-feature-map.Tests.ps1
+++ b/tests/controls/sku-feature-map.Tests.ps1
@@ -1,6 +1,7 @@
 BeforeAll {
     $mapPath = Join-Path $PSScriptRoot '../../src/M365-Assess/controls/sku-feature-map.json'
     $map = Get-Content $mapPath -Raw | ConvertFrom-Json
+    $groups = @($map.featureGroups.PSObject.Properties)
 }
 
 Describe 'SKU Feature Map Schema' {
@@ -8,64 +9,73 @@ Describe 'SKU Feature Map Schema' {
         $map.version | Should -Match '^\d+\.\d+\.\d+$'
     }
 
-    It 'Should have at least 6 categories' {
-        $map.categories.Count | Should -BeGreaterOrEqual 6
+    It 'Should have at least 20 featureGroups' {
+        $groups.Count | Should -BeGreaterOrEqual 20
     }
 
-    It 'Should have at least 30 features' {
-        $map.features.Count | Should -BeGreaterOrEqual 30
+    It 'Should have skuTiers with E3 and E5' {
+        $map.skuTiers.PSObject.Properties.Name | Should -Contain 'E3'
+        $map.skuTiers.PSObject.Properties.Name | Should -Contain 'E5'
     }
 
-    It 'Should have no duplicate featureIds' {
-        $ids = $map.features | ForEach-Object { $_.featureId }
-        $ids.Count | Should -Be ($ids | Sort-Object -Unique).Count
+    It 'Should have no duplicate featureGroup keys' {
+        $keys = @($groups | ForEach-Object { $_.Name })
+        $keys.Count | Should -Be ($keys | Sort-Object -Unique).Count
     }
 
-    It 'Should have valid effortTier values' {
+    It 'Should have valid effortTier values on every featureGroup' {
         $validTiers = @('Quick Win', 'Medium', 'Strategic')
-        foreach ($f in $map.features) {
-            $f.effortTier | Should -BeIn $validTiers -Because "$($f.featureId) has invalid effortTier"
+        foreach ($g in $groups) {
+            $g.Value.effortTier | Should -BeIn $validTiers -Because "$($g.Name) has invalid effortTier"
         }
     }
 
-    It 'Should reference valid category ids' {
-        $catIds = $map.categories | ForEach-Object { $_.id }
-        foreach ($f in $map.features) {
-            $f.category | Should -BeIn $catIds -Because "$($f.featureId) references unknown category"
+    It 'Should have servicePlans as non-empty array on every featureGroup' {
+        foreach ($g in $groups) {
+            $g.Value.servicePlans | Should -Not -BeNullOrEmpty -Because "$($g.Name) needs servicePlans"
         }
     }
 
-    It 'Should have requiredServicePlans as array on every feature' {
-        foreach ($f in $map.features) {
-            $f.requiredServicePlans | Should -Not -BeNullOrEmpty -Because "$($f.featureId) needs requiredServicePlans"
+    It 'Should have detectionChecks property on every featureGroup' {
+        foreach ($g in $groups) {
+            $g.Value.PSObject.Properties.Name | Should -Contain 'detectionChecks' -Because "$($g.Name) needs detectionChecks"
         }
     }
 
-    It 'Should have checkIds as array on every feature' {
-        foreach ($f in $map.features) {
-            $f.PSObject.Properties.Name | Should -Contain 'checkIds' -Because "$($f.featureId) needs checkIds"
+    It 'Should have learnUrl on every featureGroup' {
+        foreach ($g in $groups) {
+            $g.Value.learnUrl | Should -Match '^https://' -Because "$($g.Name) needs a Learn URL"
         }
     }
 
-    It 'Should have learnUrl on every feature' {
-        foreach ($f in $map.features) {
-            $f.learnUrl | Should -Match '^https://' -Because "$($f.featureId) needs a Learn URL"
+    It 'Should not use STANDARD sentinel in servicePlans' {
+        foreach ($g in $groups) {
+            $g.Value.servicePlans | Should -Not -Contain 'STANDARD' -Because "$($g.Name) should use a real service plan ID"
         }
     }
 
-    It 'Should not use STANDARD sentinel in requiredServicePlans' {
-        foreach ($f in $map.features) {
-            $f.requiredServicePlans | Should -Not -Contain 'STANDARD' -Because "$($f.featureId) should use a real service plan ID, not the STANDARD sentinel"
+    It 'Should have prerequisites as an array on every featureGroup' {
+        foreach ($g in $groups) {
+            $g.Value.PSObject.Properties.Name | Should -Contain 'prerequisites' -Because "$($g.Name) needs prerequisites array"
         }
     }
 
-    It 'Should reference CheckIds that exist in registry.json' {
+    It 'Should have prerequisite IDs that reference valid featureGroup keys' {
+        $keys = @($groups | ForEach-Object { $_.Name })
+        foreach ($g in $groups) {
+            foreach ($prereq in $g.Value.prerequisites) {
+                $keys | Should -Contain $prereq -Because "$($g.Name) references unknown prerequisite '$prereq'"
+            }
+        }
+    }
+
+    It 'Should reference detectionChecks that exist in registry.json' {
         $registryPath = Join-Path $PSScriptRoot '../../src/M365-Assess/controls/registry.json'
         $registry = Get-Content $registryPath -Raw | ConvertFrom-Json
         $registryIds = @($registry.checks | ForEach-Object { $_.checkId })
-        foreach ($f in $map.features) {
-            foreach ($checkId in $f.checkIds) {
-                $registryIds | Should -Contain $checkId -Because "$($f.featureId) references CheckId '$checkId' which must exist in registry.json"
+        foreach ($g in $groups) {
+            foreach ($checkId in $g.Value.detectionChecks) {
+                $registryIds | Should -Contain $checkId -Because "$($g.Name) references CheckId '$checkId' which must exist in registry.json"
             }
         }
     }


### PR DESCRIPTION
## Summary

Closes #483. Migrates the Value Opportunity pipeline to the breaking schema change introduced in CheckID v2.6.2.

- **`sku-feature-map.json`** — updated to v2.6.2 (28 `featureGroups` dict entries replace the `features[]` array; `skuTiers` dict added; each group now has `displayName`, `servicePlans`, `detectionChecks`, `prerequisites`, `effortTier`, `learnUrl`)
- **`Get-LicenseUtilization.ps1`** — iterates `featureGroups.PSObject.Properties`; `requiredServicePlans` → `servicePlans`; `name` → `displayName`
- **`Get-FeatureAdoption.ps1`** — `checkIds` → `detectionChecks`; category is now a direct display string (no `categories[]` lookup)
- **`Get-FeatureReadiness.ps1`** — same schema field renames; `featureNameLookup` uses `displayName`
- **`Measure-ValueOpportunity.ps1`** — `features` array loop replaced with `featureGroups.PSObject.Properties`; removed unused `$categoryNameLookup`; `requiredServicePlans` → `servicePlans`
- **All 4 test files updated** — mock objects rebuilt with new schema; `pim` → `privileged-identity-management` key; `@()` cast fixes `PSObject.Properties.Count` PowerShell member-enumeration bug

## Test plan

- [ ] `Invoke-Pester ./tests/ValueOpportunity` — 29/29 passing
- [ ] `Invoke-Pester ./tests/controls/sku-feature-map.Tests.ps1` — 12/12 passing
- [ ] Full CI Pester matrix passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)