### PR TITLE
feat: registry remediation fallback + sku-feature-map v2.1.0 verification (#491, #483)

### DIFF
--- a/src/M365-Assess/Common/Import-ControlRegistry.ps1
+++ b/src/M365-Assess/Common/Import-ControlRegistry.ps1
@@ -84,6 +84,7 @@ function Import-ControlRegistry {
             frameworks        = @{}
             scf               = $check.scf           # PSCustomObject from CheckID v2.0.0; $null for local extensions
             impactRating      = $check.impactRating   # PSCustomObject from CheckID v2.0.0; $null for local extensions
+            remediation       = if ($check.remediation) { [string]$check.remediation } else { '' }
         }
 
         # Convert framework PSCustomObject properties to hashtable

--- a/src/M365-Assess/Common/Import-ControlRegistry.ps1
+++ b/src/M365-Assess/Common/Import-ControlRegistry.ps1
@@ -84,7 +84,7 @@ function Import-ControlRegistry {
             frameworks        = @{}
             scf               = $check.scf           # PSCustomObject from CheckID v2.0.0; $null for local extensions
             impactRating      = $check.impactRating   # PSCustomObject from CheckID v2.0.0; $null for local extensions
-            remediation       = if ($check.remediation) { [string]$check.remediation } else { '' }
+            remediation       = if ($check.remediation) { [string]$check.remediation } else { '' }  # empty string not $null
         }
 
         # Convert framework PSCustomObject properties to hashtable

--- a/src/M365-Assess/Common/SecurityConfigHelper.ps1
+++ b/src/M365-Assess/Common/SecurityConfigHelper.ps1
@@ -106,6 +106,16 @@ function Add-SecuritySetting {
         $subCheckId = "$CheckId.$($CheckIdCounter[$CheckId])"
     }
 
+    # Fall back to registry.remediation when the caller omits the Remediation parameter.
+    # Hardcoded strings always win — this only fires when Remediation is empty/whitespace.
+    if ([string]::IsNullOrWhiteSpace($Remediation) -and $CheckId) {
+        $reg = Get-Variable -Name 'M365AssessRegistry' -Scope Global -ErrorAction SilentlyContinue
+        if ($reg -and $reg.Value -and $reg.Value.ContainsKey($CheckId)) {
+            $entry = $reg.Value[$CheckId]
+            if ($entry -and $entry.remediation) { $Remediation = $entry.remediation }
+        }
+    }
+
     $Settings.Add([PSCustomObject]@{
         Category         = $Category
         Setting          = $Setting

--- a/src/M365-Assess/Common/SecurityConfigHelper.ps1
+++ b/src/M365-Assess/Common/SecurityConfigHelper.ps1
@@ -106,8 +106,7 @@ function Add-SecuritySetting {
         $subCheckId = "$CheckId.$($CheckIdCounter[$CheckId])"
     }
 
-    # Fall back to registry.remediation when the caller omits the Remediation parameter.
-    # Hardcoded strings always win — this only fires when Remediation is empty/whitespace.
+    # Registry remediation used as fallback so new collectors can omit the param
     if ([string]::IsNullOrWhiteSpace($Remediation) -and $CheckId) {
         $reg = Get-Variable -Name 'M365AssessRegistry' -Scope Global -ErrorAction SilentlyContinue
         if ($reg -and $reg.Value -and $reg.Value.ContainsKey($CheckId)) {

--- a/src/M365-Assess/Invoke-M365Assessment.ps1
+++ b/src/M365-Assess/Invoke-M365Assessment.ps1
@@ -594,8 +594,7 @@ if (Test-Path -Path $progressHelper) {
         . $registryHelper
         $controlsDir = Join-Path -Path $projectRoot -ChildPath 'controls'
         $progressRegistry = Import-ControlRegistry -ControlsPath $controlsDir
-        # Expose registry globally so Add-SecuritySetting can fall back to registry.remediation
-        # when a collector omits the Remediation parameter.
+        # Exposed globally so dot-sourced collectors can resolve registry.remediation as fallback
         $global:M365AssessRegistry = $progressRegistry
         if ($progressRegistry.Count -gt 1) {
             # When connections are active, initialize progress silently --

--- a/src/M365-Assess/Invoke-M365Assessment.ps1
+++ b/src/M365-Assess/Invoke-M365Assessment.ps1
@@ -594,6 +594,9 @@ if (Test-Path -Path $progressHelper) {
         . $registryHelper
         $controlsDir = Join-Path -Path $projectRoot -ChildPath 'controls'
         $progressRegistry = Import-ControlRegistry -ControlsPath $controlsDir
+        # Expose registry globally so Add-SecuritySetting can fall back to registry.remediation
+        # when a collector omits the Remediation parameter.
+        $global:M365AssessRegistry = $progressRegistry
         if ($progressRegistry.Count -gt 1) {
             # When connections are active, initialize progress silently --
             # the console summary is deferred until Connect-RequiredService

--- a/tests/Common/SecurityConfigHelper.Tests.ps1
+++ b/tests/Common/SecurityConfigHelper.Tests.ps1
@@ -1,0 +1,39 @@
+BeforeAll {
+    . "$PSScriptRoot/../../src/M365-Assess/Common/SecurityConfigHelper.ps1"
+}
+
+Describe 'Add-SecuritySetting - remediation fallback' {
+    BeforeEach {
+        $ctx = Initialize-SecurityConfig
+        $global:M365AssessRegistry = @{
+            'ENTRA-MFA-001' = [PSCustomObject]@{ remediation = 'Registry remediation text' }
+        }
+    }
+    AfterEach {
+        Remove-Variable -Name M365AssessRegistry -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    It 'Uses hardcoded Remediation when provided' {
+        Add-SecuritySetting -Settings $ctx.Settings -CheckIdCounter $ctx.CheckIdCounter `
+            -Category 'MFA' -Setting 'MFA Policy' -CurrentValue 'Enabled' `
+            -RecommendedValue 'Enabled' -Status 'Pass' `
+            -CheckId 'ENTRA-MFA-001' -Remediation 'Hardcoded text'
+        $ctx.Settings[0].Remediation | Should -Be 'Hardcoded text'
+    }
+
+    It 'Falls back to registry remediation when Remediation param is empty' {
+        Add-SecuritySetting -Settings $ctx.Settings -CheckIdCounter $ctx.CheckIdCounter `
+            -Category 'MFA' -Setting 'MFA Policy' -CurrentValue 'Enabled' `
+            -RecommendedValue 'Enabled' -Status 'Pass' `
+            -CheckId 'ENTRA-MFA-001' -Remediation ''
+        $ctx.Settings[0].Remediation | Should -Be 'Registry remediation text'
+    }
+
+    It 'Leaves Remediation empty when param is empty and CheckId has no registry entry' {
+        Add-SecuritySetting -Settings $ctx.Settings -CheckIdCounter $ctx.CheckIdCounter `
+            -Category 'MFA' -Setting 'Unknown Check' -CurrentValue 'x' `
+            -RecommendedValue 'x' -Status 'Info' `
+            -CheckId 'UNKNOWN-001' -Remediation ''
+        $ctx.Settings[0].Remediation | Should -Be ''
+    }
+}

--- a/tests/ValueOpportunity/SkuFeatureMap.Tests.ps1
+++ b/tests/ValueOpportunity/SkuFeatureMap.Tests.ps1
@@ -1,0 +1,25 @@
+Describe 'sku-feature-map v2.1.0 schema' {
+    BeforeAll {
+        $mapPath = "$PSScriptRoot/../../src/M365-Assess/controls/sku-feature-map.json"
+        $map = Get-Content $mapPath -Raw | ConvertFrom-Json
+    }
+
+    It 'Has featureGroups key at top level' {
+        $map.PSObject.Properties.Name | Should -Contain 'featureGroups'
+    }
+
+    It 'First featureGroup entry has effortTier' {
+        $first = $map.featureGroups.PSObject.Properties | Select-Object -First 1
+        $first.Value.effortTier | Should -Not -BeNullOrEmpty
+    }
+
+    It 'First featureGroup entry has learnUrl' {
+        $first = $map.featureGroups.PSObject.Properties | Select-Object -First 1
+        $first.Value.learnUrl | Should -Not -BeNullOrEmpty
+    }
+
+    It 'First featureGroup entry has prerequisites field' {
+        $first = $map.featureGroups.PSObject.Properties | Select-Object -First 1
+        $first.Value.PSObject.Properties.Name | Should -Contain 'prerequisites'
+    }
+}


### PR DESCRIPTION
## Summary
- `Add-SecuritySetting` now falls back to `registry.remediation` when the `Remediation` param is empty -- hardcoded strings continue to win (no breaking change)
- New collectors written after this PR can omit `Remediation =` entirely and inherit it from the registry automatically
- `Import-ControlRegistry` now includes the `remediation` field in each entry hashtable
- `Invoke-M365Assessment` exposes `$global:M365AssessRegistry` after registry load so `Add-SecuritySetting` can resolve it from any scope
- Regression test confirms sku-feature-map v2.1.0 fields (`effortTier`, `learnUrl`, `prerequisites`) are accessible after CheckID v2.7.0 sync

## Test plan
- [ ] SecurityConfigHelper.Tests.ps1 -- 3 tests pass (hardcoded wins, fallback fires, missing-entry safe)
- [ ] SkuFeatureMap.Tests.ps1 -- 4 tests pass
- [ ] Import-ControlRegistry.Tests.ps1 -- 16 tests pass (remediation field additive, no regressions)
- [ ] SecurityConfigContract.Tests.ps1 -- 92 tests pass
- [ ] Full Pester suite passes with coverage >= 65%

Closes #491, closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)