### PR TITLE
chore: bump version to v1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to M365 Assess are documented here. This project uses [Conve
 
 ## [Unreleased]
 
+## [1.14.0] - 2026-04-18
+
+### Added
+- CMMC L2 collector: `Get-IntuneRemovableMediaConfig` (MP.L2-3.8.7) — enumerates all `storageBlockRemovableStorage` device restriction profiles, one row per profile with assignment status (#467)
+- CMMC L2 collector: `Get-EntraAdminRoleSeparationConfig` (SC.L2-3.13.3) — detects privileged roles used for day-to-day access (permanent Global Admin, dual admin+user accounts) (#468)
+- 4 new Intune CMMC L2 collectors wired into assessment: `Get-IntuneVpnSplitTunnelConfig`, `Get-IntuneWifiEapConfig`, `Get-IntuneCaRemoteDeviceConfig`, `Get-IntuneAlwaysOnVpnConfig` (#449)
+- Framework Catalog full control list with gap rows (controls not yet in assessment), column picker, and per-catalog CSV export (#454, #455)
+- CMMC L2 level sub-filter (L1 / L2 pill buttons) in Compliance Overview, mirroring the existing CIS profile sub-filter (#501)
+
+### Changed
+- 6 Intune collectors rewritten to emit one row per profile instead of a single aggregate row: `Get-IntuneMobileEncryptConfig`, `Get-IntunePortStorageConfig`, `Get-IntuneAppControlConfig`, `Get-IntuneFipsConfig`, `Get-IntuneAutoDiscConfig`, `Get-IntuneRemovableMediaConfig` — each collector now emits a Fail/Warning sentinel row when no qualifying profiles exist (#503)
+- Registry remediation fallback: `Export-AssessmentReport` now falls back to collector-supplied remediation text when `registry.json` has no entry, eliminating blank remediation cells in the Appendix (#491)
+- Dark mode contrast fixed for active filter buttons (`--m365a-dark` replaced with `--m365a-primary` for `.fw-checkbox.active` and `.co-profile-btn.active`) (#501)
+
+### Fixed
+- `Get-EntraAdminRoleSeparationConfig` returned 404 when querying role assignments with `$expand=principal` — orphaned (deleted) principals cause Graph to reject the expand; removed expand and use `principalId` directly (#502)
+
 ## [1.13.0] - 2026-04-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [![Coverage](https://img.shields.io/badge/coverage-check%20CI-informational)](https://github.com/Galvnyz/M365-Assess/actions/workflows/ci.yml)
 [![PowerShell 7.x](https://img.shields.io/badge/PowerShell-7.x-blue?logo=powershell&logoColor=white)](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows)
 [![Read-Only](https://img.shields.io/badge/Operations-Read--Only-brightgreen)](.)
-[![Version](https://img.shields.io/badge/version-1.13.0-blue)](.)
+[![Version](https://img.shields.io/badge/version-1.14.0-blue)](.)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 </div>

--- a/src/M365-Assess/M365-Assess.psd1
+++ b/src/M365-Assess/M365-Assess.psd1
@@ -3,7 +3,7 @@
     # Generated: 2026-03-08
 
     RootModule        = 'M365-Assess.psm1'
-    ModuleVersion     = '1.13.0'
+    ModuleVersion     = '1.14.0'
     GUID              = 'f7e3b2a1-4c5d-6e8f-9a0b-1c2d3e4f5a6b'
     Author            = 'Galvnyz'
     CompanyName       = 'Community'
@@ -219,7 +219,7 @@
             IconUri      = 'https://raw.githubusercontent.com/Galvnyz/M365-Assess/main/src/M365-Assess/assets/m365-assess-logo.png'
             LicenseUri   = 'https://github.com/Galvnyz/M365-Assess/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/Galvnyz/M365-Assess'
-            ReleaseNotes = 'v1.13.0 - Compliance Overview filter revamp (severity chips, collapsible panel, localStorage), CIS profile sub-filters, Appendix enrichment (column picker, filters, CSV), Framework Catalog label/tooltip fixes, CheckID v2.6.1 sync'
+            ReleaseNotes = 'v1.14.0 - CMMC L2 collectors (removable media, admin role separation), 4 new Intune collectors (VPN split tunnel, Wi-Fi EAP, CA remote device, always-on VPN), per-profile breakdowns for 6 Intune collectors, admin role separation 404 fix'
         }
     }
 }


### PR DESCRIPTION
## Summary
- Bumps `ModuleVersion` to `1.14.0` in `M365-Assess.psd1`
- Updates `ReleaseNotes` in `M365-Assess.psd1`
- Updates version badge in `README.md`
- Adds `[1.14.0]` section to `CHANGELOG.md`

## What's in v1.14.0
- CMMC L2 collectors: removable media (MP.L2-3.8.7) + admin role separation (SC.L2-3.13.3)
- 4 new Intune CMMC L2 collectors wired in (VPN split tunnel, Wi-Fi EAP, CA remote device, always-on VPN)
- Per-profile breakdowns for 6 Intune collectors (one row per policy, sentinel on missing)
- Admin role separation 404 fix (removed `$expand=principal`)
- Framework Catalog full control list + gap rows + column picker + CSV export
- Compliance Overview dark mode contrast fix + CMMC L2 level sub-filter

## Test plan
- [ ] CI passes (doc-only path — quality-gates/pester skipped)
- [ ] Version badge renders correctly on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)