### PR TITLE
fix: Framework Catalog gap rows, appendix chip init, group table columns, admin role sep

### DIFF
--- a/src/M365-Assess/Common/Export-FrameworkCatalog.ps1
+++ b/src/M365-Assess/Common/Export-FrameworkCatalog.ps1
@@ -313,7 +313,7 @@ function ConvertTo-CatalogInlineHtml {
     $null = $html.AppendLine("<button class='catalog-csv-btn csv-export-btn'>Export CSV</button>")
     $null = $html.AppendLine("</div>")
     $null = $html.AppendLine("<table id='$catalogTableId' class='catalog-groups' data-catalog-table='$fwId'><thead><tr>")
-    $null = $html.AppendLine("<th>Group</th><th>Label</th><th>Coverage %</th><th>Automated Checks</th><th>Passed</th><th>Failed</th><th>Warning</th><th>Review</th><th>Pass Rate</th>")
+    $null = $html.AppendLine("<th>Group</th><th>Label</th><th title='Total controls defined in this framework group'>Total Controls</th><th title='Controls with no automated check in this assessment'>Not Automated</th><th>Coverage %</th><th>Automated Checks</th><th>Passed</th><th>Failed</th><th>Warning</th><th>Review</th><th>Pass Rate</th>")
     $null = $html.AppendLine("</tr></thead><tbody>")
 
     foreach ($group in $groups) {
@@ -321,16 +321,20 @@ function ConvertTo-CatalogInlineHtml {
         if ($group.IsGap) {
             $idEncoded    = [System.Web.HttpUtility]::HtmlEncode([string]$group.ControlId)
             $labelEncoded = [System.Web.HttpUtility]::HtmlEncode([string]$group.Label)
-            $null = $html.AppendLine("<tr class='fw-catalog-gap-row'><td><span class='fw-tag $fwCss'>$idEncoded</span></td><td>$labelEncoded</td><td colspan='7'><span class='fw-catalog-gap-badge'>No automated check</span></td></tr>")
+            $null = $html.AppendLine("<tr class='fw-catalog-gap-row'><td><span class='fw-tag $fwCss'>$idEncoded</span></td><td>$labelEncoded</td><td colspan='9'><span class='fw-catalog-gap-badge'>No automated check</span></td></tr>")
             continue
         }
 
         $grpPassRate = if ($group.Mapped -gt 0) { [math]::Round(($group.Passed / $group.Mapped) * 100, 1) } else { 0 }
         $grpClass = if ($group.Mapped -eq 0) { '' } elseif ($grpPassRate -ge 80) { 'success' } elseif ($grpPassRate -ge 60) { 'warning' } else { 'danger' }
 
+        $grpGapCount = if ($group.Total -gt 0) { $group.Total - $group.Covered } else { 0 }
         $null = $html.AppendLine("<tr>")
         $null = $html.AppendLine("<td><span class='fw-tag $fwCss'>$([System.Web.HttpUtility]::HtmlEncode([string]$group.Key))</span></td>")
         $null = $html.AppendLine("<td>$([System.Web.HttpUtility]::HtmlEncode([string]$group.Label))</td>")
+        $null = $html.AppendLine("<td>$($group.Total)</td>")
+        $notAutoDisplay = if ($grpGapCount -gt 0) { "<span class='fw-catalog-gap-badge' title='$grpGapCount control(s) with no automated check'>$grpGapCount</span>" } else { '0' }
+        $null = $html.AppendLine("<td>$notAutoDisplay</td>")
         $coveragePctVal = if ($group.Total -gt 0) { [math]::Round(($group.Covered / $group.Total) * 100, 0) } else { 0 }
         $coverageDisplay = if ($group.Total -gt 0) { "<span title='$($group.Covered) of $($group.Total) controls'>$coveragePctVal%</span>" } else { "$($group.Covered)" }
         $null = $html.AppendLine("<td>$coverageDisplay</td>")

--- a/src/M365-Assess/Common/Get-ReportTemplate.ps1
+++ b/src/M365-Assess/Common/Get-ReportTemplate.ps1
@@ -2629,7 +2629,7 @@ $html = @"
         .csv-export-btn { padding: 4px 10px; border: 1px solid var(--m365a-accent); border-radius: 4px; background: var(--m365a-card-bg); color: var(--m365a-accent); cursor: pointer; font-size: 0.82em; font-weight: 500; white-space: nowrap; }
         .csv-export-btn:hover { background: var(--m365a-accent); color: #fff; }
         /* Framework Catalog — gap rows for uncovered controls */
-        .fw-catalog-gap-row { opacity: 0.55; font-style: italic; }
+        .fw-catalog-gap-row { display: none; opacity: 0.55; font-style: italic; }
         .fw-catalog-gap-badge { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 0.78em; background: var(--m365a-hover-bg); color: var(--m365a-medium-gray); border: 1px solid var(--m365a-border); white-space: nowrap; }
         /* Intune Overview — category coverage grid */
         .intune-category-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 12px; padding: 12px 0 4px; }
@@ -4232,6 +4232,19 @@ $html += @"
         filterAppendixTable();
     }
 
+    // Show/hide catalog gap rows when Detailed Checks <details> is toggled
+    document.querySelectorAll('.catalog-findings-detail').forEach(function(det) {
+        det.addEventListener('toggle', function() {
+            var sec = det.closest('.catalog-section');
+            if (!sec) { return; }
+            sec.querySelectorAll('.fw-catalog-gap-row').forEach(function(row) {
+                row.style.display = det.open ? '' : 'none';
+            });
+        });
+    });
+
+    // Activate all appendix chips on page load
+    appendixFilterAll(true);
 
     </script>
 </body>

--- a/src/M365-Assess/Entra/Get-EntraAdminRoleSeparationConfig.ps1
+++ b/src/M365-Assess/Entra/Get-EntraAdminRoleSeparationConfig.ps1
@@ -163,7 +163,7 @@ try {
     Add-Setting @settingParams
 }
 catch {
-    if ($_.Exception.Message -match '403|Forbidden|Authorization') {
+    if ($_.Exception.Message -match '403|Forbidden|Authorization|Ensure the required|service is connected|Access_Denied|Authorization_RequestDenied') {
         $settingParams = @{
             Category         = 'Admin Role Separation'
             Setting          = 'Privileged Account vs Daily-Use Account Separation'
@@ -171,7 +171,7 @@ catch {
             RecommendedValue = 'Admin accounts must not have Exchange mailbox service plans'
             Status           = 'Review'
             CheckId          = 'ENTRA-ADMINROLE-SEPARATION-001'
-            Remediation      = 'Requires RoleManagement.Read.Directory and Directory.Read.All permissions.'
+            Remediation      = 'Requires RoleManagement.Read.Directory and Directory.Read.All permissions. Grant via Entra admin center or reconnect with additional scopes.'
         }
         Add-Setting @settingParams
     }


### PR DESCRIPTION
## Summary
- **Framework Catalog gap rows**: Hidden by default (`display:none`); revealed when the *Detailed Checks* `<details>` section is expanded via a `toggle` event listener
- **Appendix chips not highlighted on load**: `appendixFilterAll(true)` was defined but never called — now called at page load so all chips show active state correctly
- **Framework Catalog group table**: Added *Total Controls* and *Not Automated* columns (gap count per group) with tooltip badges
- **Admin role separation error**: Broadened catch pattern to treat Graph SDK "Ensure the required PowerShell module is installed" auth errors as `Review` instead of a console warning

## Test plan
- [ ] CI passes
- [ ] Generate a report and verify Framework Catalog gap rows are hidden until Detailed Checks is expanded
- [ ] Verify appendix chips are all highlighted on initial page load
- [ ] Verify catalog group table shows Total Controls and Not Automated columns
- [ ] Run assessment against a tenant with limited permissions — admin role sep should emit Review row instead of Warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)