### PR TITLE
fix: compliance matrix grouped-by-profile zeros and gap row contamination

### DIFF
--- a/src/M365-Assess/Common/Export-ComplianceMatrix.ps1
+++ b/src/M365-Assess/Common/Export-ComplianceMatrix.ps1
@@ -250,7 +250,10 @@ if ($cisFw -and $findings.Count -gt 0) {
                 $baseId = $_.CheckId -replace '\.\d+$', ''
                 if ($controlRegistry.ContainsKey($baseId) -and $controlRegistry[$baseId].frameworks) {
                     $fwObj = $controlRegistry[$baseId].frameworks
-                    if ($fwObj.PSObject.Properties.Name -contains $fwDef.frameworkId) {
+                    if ($fwObj -is [hashtable] -and $fwObj.ContainsKey($fwDef.frameworkId)) {
+                        $fwHash[$fwDef.frameworkId] = $fwObj[$fwDef.frameworkId]
+                    }
+                    elseif ($fwObj -and $fwObj.PSObject.Properties.Name -contains $fwDef.frameworkId) {
                         $fwHash[$fwDef.frameworkId] = $fwObj.($fwDef.frameworkId)
                     }
                 }
@@ -269,6 +272,7 @@ if ($cisFw -and $findings.Count -gt 0) {
         if ($groupedResult -and $groupedResult.Groups) {
             $groupedRows = [System.Collections.Generic.List[PSCustomObject]]::new()
             foreach ($group in $groupedResult.Groups) {
+                if ($group.IsGap) { continue }
                 $grpPassRate = if ($group.Mapped -gt 0) { [math]::Round(($group.Passed / $group.Mapped) * 100, 1) } else { 0 }
                 $groupedRows.Add([PSCustomObject][ordered]@{
                     Profile      = $group.Key


### PR DESCRIPTION
## Summary
Two bugs in the *Grouped by Profile* XLSX sheet:

**Bug 1 — All zeros:** `Import-ControlRegistry` stores `frameworks` as a hashtable (`@{}`), but `Export-ComplianceMatrix` checked membership via `PSObject.Properties.Name` (which only works on PSCustomObjects). The hashtable check always returned false, leaving every finding's `Frameworks` property empty → all profile counts were 0. Fixed by using `ContainsKey()` for hashtables with a PSObject fallback.

**Bug 2 — Gap rows in profile sheet:** `$groupedResult.Groups` includes both profile summary rows (E3-L1, E3-L2...) and individual control gap rows (1.1.1, 1.1.2...). The loop now skips `IsGap` rows so only actual profile groups appear.

## Test plan
- [ ] CI passes
- [ ] Re-run `Export-ComplianceMatrix` against an assessment folder — *Grouped by Profile* sheet should show non-zero counts for E3-L1/L2, E5-L1/L2 and no individual control rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)