### PR TITLE
fix(ci): fix PSGallery publish encoding failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,8 +109,13 @@ jobs:
           python3 -c "
           import json, glob
           for p in glob.glob('src/M365-Assess/controls/**/*.json', recursive=True):
-              with open(p) as f: data = json.load(f)
-              with open(p, 'w') as f: json.dump(data, f, separators=(',',':'))
+              with open(p, 'rb') as f: raw = f.read()
+              try:
+                  content = raw.decode('utf-8-sig')
+              except UnicodeDecodeError:
+                  content = raw.decode('latin-1')
+              data = json.loads(content)
+              with open(p, 'w', encoding='utf-8') as f: json.dump(data, f, separators=(',',':'))
           print('JSON files minified')
           "
 

--- a/.github/workflows/sync-checkid.yml
+++ b/.github/workflows/sync-checkid.yml
@@ -38,10 +38,11 @@ jobs:
       - name: Normalize encoding in downloaded files
         run: |
           python3 - <<'EOF'
-          import os, glob
+          import glob
 
-          # Some CheckID releases ship framework JSONs with Windows-1252 bytes.
-          # Replace known offenders with their UTF-8 equivalents before committing.
+          # Only apply CP1252 byte fixes to files that are NOT already valid UTF-8.
+          # Applying byte substitutions to valid UTF-8 files double-encodes characters
+          # (e.g. c2 a7 for § becomes c2 c2 a7 when the bare a7 replacement fires).
           cp1252_fixes = {
               bytes([0x97]): '\u2014'.encode('utf-8'),  # em dash
               bytes([0x96]): '\u2013'.encode('utf-8'),  # en dash
@@ -54,6 +55,11 @@ jobs:
           files.append('src/M365-Assess/controls/registry.json')
           for path in files:
               raw = open(path, 'rb').read()
+              try:
+                  raw.decode('utf-8')
+                  continue  # already valid UTF-8, skip
+              except UnicodeDecodeError:
+                  pass
               fixed = raw
               for bad, good in cp1252_fixes.items():
                   fixed = fixed.replace(bad, good)

--- a/src/M365-Assess/controls/frameworks/hipaa.json
+++ b/src/M365-Assess/controls/frameworks/hipaa.json
@@ -10,23 +10,23 @@
   "scoring": {
     "method": "criteria-coverage",
     "criteria": {
-      "�§164.308": {
+      "§164.308": {
         "label": "Administrative Safeguards",
         "description": "Security management, access management, training, and contingency planning"
       },
-      "�§164.310": {
+      "§164.310": {
         "label": "Physical Safeguards",
         "description": "Facility access controls, workstation use, and device/media controls"
       },
-      "�§164.312": {
+      "§164.312": {
         "label": "Technical Safeguards",
         "description": "Access control, audit controls, integrity, transmission security"
       },
-      "�§164.314": {
+      "§164.314": {
         "label": "Organizational Requirements",
         "description": "Business associate contracts and group health plan requirements"
       },
-      "�§164.316": {
+      "§164.316": {
         "label": "Policies and Procedures",
         "description": "Documentation requirements and record retention"
       }


### PR DESCRIPTION
## Summary
- **hipaa.json**: Binary-replaces `\xc2\xc2\xa7` → `\xc2\xa7` — the double-encoded section sign introduced when the sync normalization replaced bare `\xa7` bytes inside an already-valid UTF-8 `\xc2\xa7` sequence
- **sync-checkid.yml**: Normalization step now skips files that already decode as valid UTF-8; previously it blindly replaced byte patterns even in valid UTF-8, double-encoding multibyte characters on every sync
- **release.yml**: JSON minify step now reads files as binary, tries UTF-8 (with BOM support), falls back to Latin-1, always writes as UTF-8 — prevents encoding errors from aborting PSGallery publish

## Root cause
CheckID v2.8.0 `hipaa.json` contained `\xc2\xa7` (valid UTF-8 for §). The normalization step replaced all bare `\xa7` bytes with `\xc2\xa7`, turning the already-valid `\xc2\xa7` into `\xc2\xc2\xa7` (invalid UTF-8). The Python minify script in `release.yml` then crashed when trying to `open(..., encoding='utf-8')`.

## Test plan
- [ ] CI passes (Quality Gates + Pester)
- [ ] After merge, re-tag v1.15.0 or confirm release workflow completes
- [ ] hipaa.json decodes as valid UTF-8 after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)