### PR TITLE
fix(entra): skip 404 on licenseDetails for service principals in admin role separation

### DIFF
--- a/src/M365-Assess/Common/Build-SectionHtml.ps1
+++ b/src/M365-Assess/Common/Build-SectionHtml.ps1
@@ -1476,7 +1476,7 @@ foreach ($c in $summary) {
                 if ($fwData.profiles) { $fwHash[$fwDef.frameworkId].profiles = @($fwData.profiles) }
             }
         }
-        $cisData = $fwHash[$CisFrameworkId]
+        $cisData = $fwHash[$cisFrameworkId]
         $cisId = if ($cisData) { $cisData.controlId } else { '' }
 
         $allCisFindings.Add([PSCustomObject]@{
@@ -1535,17 +1535,15 @@ if ($allCisFindings.Count -gt 0) {
     }
 }
 
-if ($allCisFindings.Count -gt 0 -and $controlRegistry.Count -gt 0 -and -not $SkipComplianceOverview) {
+if ($allCisFindings.Count -gt 0 -and $controlRegistry.Count -gt 0 -and -not $CompactReport) {
     . (Join-Path -Path $PSScriptRoot -ChildPath 'Export-ComplianceOverview.ps1')
     $coParams = @{
         Findings         = @($allCisFindings)
         ControlRegistry  = $controlRegistry
         Frameworks       = $allFrameworks
-        FrameworkFilter  = $FrameworkFilter
         Sections         = @($summary | Select-Object -ExpandProperty Section -ErrorAction SilentlyContinue | Where-Object { $_ } | Sort-Object -Unique)
     }
     if ($WhiteLabel) { $coParams['WhiteLabel'] = $true }
-    if ($FrameworkFilters -and $FrameworkFilters.Count -gt 0) { $coParams['FrameworkFilters'] = $FrameworkFilters }
     $complianceHtml = Export-ComplianceOverview @coParams
 }
 
@@ -1555,37 +1553,10 @@ if ($allCisFindings.Count -gt 0 -and $controlRegistry.Count -gt 0 -and -not $Ski
 $catalogHtml = ''
 if ($allCisFindings.Count -gt 0 -and $controlRegistry.Count -gt 0) {
     . (Join-Path -Path $PSScriptRoot -ChildPath 'Export-FrameworkCatalog.ps1')
-    $catalogFrameworks = $allFrameworks
-    if ($FrameworkFilter -and $FrameworkFilter.Count -gt 0) {
-        $catalogFrameworks = @($allFrameworks | Where-Object { $_.filterFamily -in $FrameworkFilter })
-    }
-    foreach ($fw in $catalogFrameworks) {
+    foreach ($fw in $allFrameworks) {
         $fwCatalog = Export-FrameworkCatalog -Findings @($allCisFindings) -Framework $fw `
             -ControlRegistry $controlRegistry -Mode Inline
         if ($fwCatalog) { $catalogHtml += $fwCatalog }
-    }
-}
-
-# ------------------------------------------------------------------
-# Framework Catalog standalone exports (optional)
-# ------------------------------------------------------------------
-if ($FrameworkExport -and $allCisFindings.Count -gt 0 -and $controlRegistry.Count -gt 0) {
-    if (-not (Get-Command -Name Export-FrameworkCatalog -ErrorAction SilentlyContinue)) {
-        . (Join-Path -Path $PSScriptRoot -ChildPath 'Export-FrameworkCatalog.ps1')
-    }
-    $exportFrameworks = $allFrameworks
-    if ('All' -notin $FrameworkExport) {
-        $exportFrameworks = @($allFrameworks | Where-Object { $_.filterFamily -in $FrameworkExport })
-    }
-    $catalogTenantName = if ($reportDomainPrefix) { $reportDomainPrefix } elseif ($TenantName) { $TenantName } else { 'Unknown' }
-    $catalogSuffix = if ($reportDomainPrefix) { "_$reportDomainPrefix" } else { '' }
-    foreach ($fw in $exportFrameworks) {
-        $fwFileName = "_$($fw.label -replace '[^a-zA-Z0-9]','-')-Catalog${catalogSuffix}.html"
-        $fwPath = Join-Path -Path $AssessmentFolder -ChildPath $fwFileName
-        Export-FrameworkCatalog -Findings @($allCisFindings) -Framework $fw `
-            -ControlRegistry $controlRegistry -Mode Standalone `
-            -OutputPath $fwPath -TenantName $catalogTenantName
-        Write-Verbose "Framework catalog exported: $fwFileName"
     }
 }
 
@@ -1597,7 +1568,7 @@ try {
     if (Test-Path -Path $xlsxScript) {
         $xlsxParams = @{ AssessmentFolder = $AssessmentFolder; TenantName = $reportDomainPrefix }
         if ($WhiteLabel -and $CustomBranding) { $xlsxParams['CustomBranding'] = $CustomBranding }
-        if ($FrameworkFilters -and $FrameworkFilters.Count -gt 0) { $xlsxParams['FrameworkFilters'] = $FrameworkFilters }
+        if ($DriftReport -and $DriftReport.Count -gt 0) { $xlsxParams['DriftReport'] = $DriftReport }
         & $xlsxScript @xlsxParams
     }
 } catch {
@@ -1786,7 +1757,7 @@ if ($allCisFindings.Count -gt 0) {
 }
 
 # Append conditional entries to TOC now that compliance/issues counts are known
-if ($allCisFindings.Count -gt 0 -and $controlRegistry.Count -gt 0 -and -not $SkipComplianceOverview) {
+if ($allCisFindings.Count -gt 0 -and $controlRegistry.Count -gt 0 -and -not $CompactReport) {
     $null = $tocHtml.AppendLine("<li><a href='#compliance-overview'>Compliance Overview</a></li>")
 }
 if ($issues.Count -gt 0) {

--- a/src/M365-Assess/Common/Export-AssessmentReport.ps1
+++ b/src/M365-Assess/Common/Export-AssessmentReport.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 7.0
 <#
 .SYNOPSIS
-    Generates branded HTML and PDF assessment reports from M365 assessment output.
+    Generates branded HTML assessment reports from M365 assessment output.
 .DESCRIPTION
     Reads CSV data and metadata from an M365 assessment output folder and produces
     a self-contained HTML report with M365 Assess branding. The HTML
@@ -23,46 +23,18 @@
 .PARAMETER TenantName
     Tenant display name for the cover page. If not specified, attempts to read from
     the Tenant Information CSV.
-.PARAMETER NoBranding
-    Suppress the open-source project branding on the cover page. Useful for
-    white-labeling reports delivered to clients.
 .PARAMETER WhiteLabel
     Strip all M365-Assess and GitHub identity from the report. With CustomBranding
     keys produces Mode A (your brand). Without produces Mode C (neutral/clean).
-.PARAMETER Package
-    Generate HTML + PDF (headless browser) + XLSX delivery package.
 .PARAMETER FindingsNarrative
     Path to a .txt or .md file, or an inline string, with consultant-authored
     commentary. Rendered as a narrative card before the Executive Summary.
-.PARAMETER FrameworkFilters
-    Structured framework filter objects from ConvertTo-FrameworkFilter. Contains
-    sub-level profile/level arrays and display labels for the cover page and
-    compliance matrix heading. Passed from Invoke-M365Assessment.
-.PARAMETER SkipPdf
-    Skip PDF generation even if a headless browser is available on the system.
-.PARAMETER SkipComplianceOverview
-    Omit the Compliance Overview section from the report. Useful when running
-    a single section assessment where framework coverage cards are not relevant.
-.PARAMETER SkipCoverPage
-    Omit the branded cover page (logo, tenant name, date, version). The report
-    starts directly at the executive summary or section content.
-.PARAMETER SkipExecutiveSummary
-    Omit the executive summary hero panel (donut chart, metrics, TOC, alert
-    banners). Useful for data-only exports.
-.PARAMETER FrameworkFilter
-    Limit the compliance overview to specific framework families. Valid values:
-    CIS, NIST, ISO, STIG, PCI, CMMC, HIPAA, CISA, SOC2. Default: all frameworks.
+.PARAMETER CompactReport
+    Omit the cover page, executive summary, and compliance overview sections.
+    Produces a data-only report. Automatically enabled when -QuickScan is used.
 .PARAMETER CustomBranding
     Hashtable for white-label reports. Supported keys: CompanyName (string),
     LogoPath (file path to PNG/JPEG/SVG), AccentColor (hex color like '#1a56db').
-.PARAMETER FrameworkExport
-    Generate standalone per-framework HTML catalog exports alongside the main report.
-    Specify framework families (CIS, NIST, ISO, etc.) or 'All'. Output files are
-    named _<Framework>-Catalog_<tenant>.html in the assessment folder.
-.PARAMETER CisFrameworkId
-    The framework ID for the active CIS benchmark version used for the CisControl
-    property and reverse lookup. Defaults to 'cis-m365-v6'. Set to 'cis-m365-v7'
-    when CIS v7.0 framework data is available.
 .PARAMETER OpenReport
     Automatically open the generated HTML report in the default browser after
     generation. Works on Windows, macOS, and Linux.
@@ -94,36 +66,13 @@ param(
     [string]$TenantName,
 
     [Parameter()]
-    [switch]$NoBranding,
-
-    [Parameter()]
     [switch]$WhiteLabel,
-
-    [Parameter()]
-    [switch]$Package,
 
     [Parameter()]
     [string]$FindingsNarrative,
 
     [Parameter()]
-    [AllowEmptyCollection()]
-    [PSCustomObject[]]$FrameworkFilters = @(),
-
-    [Parameter()]
-    [switch]$SkipPdf,
-
-    [Parameter()]
-    [switch]$SkipComplianceOverview,
-
-    [Parameter()]
-    [switch]$SkipCoverPage,
-
-    [Parameter()]
-    [switch]$SkipExecutiveSummary,
-
-    [Parameter()]
-    [ValidateSet('CIS','NIST','ISO','STIG','PCI','CMMC','HIPAA','CISA','SOC2','FedRAMP','Essential8','MITRE','CISv8')]
-    [string[]]$FrameworkFilter,
+    [switch]$CompactReport,
 
     [Parameter()]
     [hashtable]$CustomBranding,
@@ -131,13 +80,6 @@ param(
     [Parameter()]
     [ValidateScript({ -not $_ -or (Test-Path -Path $_ -PathType Leaf) })]
     [string]$CustomerProfile,
-
-    [Parameter()]
-    [ValidateSet('CIS','NIST','ISO','STIG','PCI','CMMC','HIPAA','CISA','SOC2','FedRAMP','Essential8','MITRE','CISv8','All')]
-    [string[]]$FrameworkExport,
-
-    [Parameter()]
-    [string]$CisFrameworkId = 'cis-m365-v6',
 
     [Parameter()]
     [switch]$OpenReport,
@@ -164,7 +106,8 @@ $projectRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
 # ------------------------------------------------------------------
 . (Join-Path -Path $PSScriptRoot -ChildPath 'Import-ControlRegistry.ps1')
 $controlsPath = Join-Path -Path $projectRoot -ChildPath 'controls'
-$controlRegistry = Import-ControlRegistry -ControlsPath $controlsPath -CisFrameworkId $CisFrameworkId
+$cisFrameworkId = 'cis-m365-v6'
+$controlRegistry = Import-ControlRegistry -ControlsPath $controlsPath -CisFrameworkId $cisFrameworkId
 
 # ------------------------------------------------------------------
 # Framework definitions (auto-discovered from JSON)
@@ -297,20 +240,16 @@ $waveMime   = if ($waveAsset) { $waveAsset.Mime }   else { 'image/png' }
 # CustomerProfile: load .psd1 and merge into individual params
 # ------------------------------------------------------------------
 if ($CustomerProfile) {
-    if (-not (Get-Command -Name ConvertTo-FrameworkFilter -ErrorAction SilentlyContinue)) {
-        . (Join-Path -Path $PSScriptRoot -ChildPath 'ConvertTo-FrameworkFilter.ps1')
-    }
     $cpData = Import-PowerShellDataFile -Path $CustomerProfile
-    if ($cpData.CustomBranding -and -not $CustomBranding) {
+    if ($cpData.CustomBranding -and -not $PSBoundParameters.ContainsKey('CustomBranding')) {
         $CustomBranding = $cpData.CustomBranding
     }
-    if ($cpData.FindingsNarrative -and -not $FindingsNarrative) {
+    if ($cpData.FindingsNarrative -and -not $PSBoundParameters.ContainsKey('FindingsNarrative')) {
         $FindingsNarrative = $cpData.FindingsNarrative
     }
-    if ($cpData.Frameworks -and $FrameworkFilters.Count -eq 0) {
-        $FrameworkFilters = @(ConvertTo-FrameworkFilter -Frameworks @($cpData.Frameworks))
-        $FrameworkFilter  = @($FrameworkFilters | Select-Object -ExpandProperty FilterFamily -Unique)
-    }
+    $WhiteLabel = $true
+}
+if ($PSBoundParameters.ContainsKey('CustomBranding') -and -not $WhiteLabel) {
     $WhiteLabel = $true
 }
 
@@ -372,11 +311,7 @@ if ($FindingsNarrative) {
         $findingsNarrativeHtml = $safeText -replace "`r?`n", '<br>'
     }
 }
-# Framework display labels for cover page (from FrameworkFilters sub-level objects)
 $frameworkDisplayLabels = @()
-if ($FrameworkFilters -and $FrameworkFilters.Count -gt 0) {
-    $frameworkDisplayLabels = $FrameworkFilters | ForEach-Object { $_.DisplayLabel }
-}
 
 # ------------------------------------------------------------------
 # Compute summary statistics
@@ -483,43 +418,4 @@ Write-Output "HTML report generated: $OutputPath"
 
 if ($OpenReport) {
     Start-Process -FilePath $OutputPath
-}
-
-# ------------------------------------------------------------------
-# Generate PDF via headless browser (Edge preferred, Chrome fallback)
-# ------------------------------------------------------------------
-$pdfPath = [System.IO.Path]::ChangeExtension($OutputPath, '.pdf')
-$generatePdf = (-not $SkipPdf) -and ($Package -or -not $SkipPdf)
-
-if ($generatePdf) {
-    $browser = Get-Command -Name 'msedge' -ErrorAction SilentlyContinue
-    if (-not $browser) { $browser = Get-Command -Name 'chrome' -ErrorAction SilentlyContinue }
-
-    if ($browser) {
-        try {
-            $htmlUri = 'file:///' + ($OutputPath -replace '\\', '/')
-            $tmpScript = [System.IO.Path]::GetTempFileName() + '.ps1'
-            Set-Content -Path $tmpScript -Value @"
-& '$($browser.Source)' --headless --print-to-pdf='$pdfPath' --no-pdf-header-footer --disable-gpu '$htmlUri' 2>`$null
-"@
-            pwsh -NoProfile -File $tmpScript 2>$null
-            Remove-Item -Path $tmpScript -ErrorAction SilentlyContinue
-            if (Test-Path -Path $pdfPath) {
-                Write-Output "PDF report generated: $pdfPath"
-            }
-        }
-        catch {
-            Write-Warning "PDF generation failed: $_"
-        }
-    }
-    elseif (Get-Command -Name 'wkhtmltopdf' -ErrorAction SilentlyContinue) {
-        try {
-            & wkhtmltopdf --page-size Letter --margin-top 15 --margin-bottom 15 --margin-left 15 --margin-right 15 --enable-local-file-access $OutputPath $pdfPath 2>$null
-            if (Test-Path -Path $pdfPath) { Write-Output "PDF report generated: $pdfPath" }
-        }
-        catch { Write-Verbose "PDF generation failed: $_" }
-    }
-    else {
-        Write-Warning "No headless browser found (msedge/chrome) and wkhtmltopdf not available. Open the HTML report in a browser and print to PDF."
-    }
 }

--- a/src/M365-Assess/Common/Export-ComplianceMatrix.ps1
+++ b/src/M365-Assess/Common/Export-ComplianceMatrix.ps1
@@ -35,7 +35,7 @@ param(
 
     [Parameter()]
     [AllowEmptyCollection()]
-    [PSCustomObject[]]$FrameworkFilters = @()
+    [PSCustomObject[]]$DriftReport = @()
 )
 
 $ErrorActionPreference = 'Stop'
@@ -508,6 +508,34 @@ if ($verificationRows.Count -gt 0) {
 }
 
 # ------------------------------------------------------------------
+# Drift sheet (if a baseline comparison was run)
+# ------------------------------------------------------------------
+if ($DriftReport -and $DriftReport.Count -gt 0) {
+    $driftRows = $DriftReport | ForEach-Object {
+        [PSCustomObject]@{
+            CheckId       = $_.CheckId
+            Setting       = $_.Setting
+            Section       = $_.Section
+            Category      = $_.Category
+            ChangeType    = $_.ChangeType
+            PreviousStatus = $_.PreviousStatus
+            CurrentStatus  = $_.CurrentStatus
+            PreviousValue  = $_.PreviousValue
+            CurrentValue   = $_.CurrentValue
+        }
+    }
+    $driftParams = @{
+        Path          = $outputFile
+        WorksheetName = 'Drift'
+        AutoSize      = $true
+        FreezeTopRow  = $true
+        BoldTopRow    = $true
+        TableStyle    = 'Medium2'
+    }
+    $driftRows | Export-Excel @driftParams
+}
+
+# ------------------------------------------------------------------
 # Apply conditional formatting
 # ------------------------------------------------------------------
 $pkg = Open-ExcelPackage -Path $outputFile
@@ -544,6 +572,31 @@ for ($r = 2; $r -le $lastRow; $r++) {
         'High'     { $matrixSheet.Cells[$r, $impactSevCol].Style.Font.Color.SetColor([System.Drawing.Color]::FromArgb(154, 52, 18));  $matrixSheet.Cells[$r, $impactSevCol].Style.Fill.PatternType = 'Solid'; $matrixSheet.Cells[$r, $impactSevCol].Style.Fill.BackgroundColor.SetColor([System.Drawing.Color]::FromArgb(255, 237, 213)) }
         'Medium'   { $matrixSheet.Cells[$r, $impactSevCol].Style.Font.Color.SetColor([System.Drawing.Color]::FromArgb(146, 64, 14));  $matrixSheet.Cells[$r, $impactSevCol].Style.Fill.PatternType = 'Solid'; $matrixSheet.Cells[$r, $impactSevCol].Style.Fill.BackgroundColor.SetColor([System.Drawing.Color]::FromArgb(254, 243, 199)) }
         'Low'      { $matrixSheet.Cells[$r, $impactSevCol].Style.Font.Color.SetColor([System.Drawing.Color]::FromArgb(21, 128, 61));  $matrixSheet.Cells[$r, $impactSevCol].Style.Fill.PatternType = 'Solid'; $matrixSheet.Cells[$r, $impactSevCol].Style.Fill.BackgroundColor.SetColor([System.Drawing.Color]::FromArgb(220, 252, 231)) }
+    }
+}
+
+# Drift sheet - color-code ChangeType column
+$driftSheet = $pkg.Workbook.Worksheets['Drift']
+if ($driftSheet -and $driftSheet.Dimension) {
+    $changeTypeCol = 5  # Column E = ChangeType
+    $driftLastRow  = $driftSheet.Dimension.End.Row
+    for ($r = 2; $r -le $driftLastRow; $r++) {
+        $ct = $driftSheet.Cells[$r, $changeTypeCol].Value
+        $fg = $null; $bg = $null
+        switch ($ct) {
+            'Regressed'    { $fg = [System.Drawing.Color]::FromArgb(185, 28, 28);  $bg = [System.Drawing.Color]::FromArgb(254, 226, 226) }
+            'Improved'     { $fg = [System.Drawing.Color]::FromArgb(21, 128, 61);  $bg = [System.Drawing.Color]::FromArgb(220, 252, 231) }
+            'Modified'     { $fg = [System.Drawing.Color]::FromArgb(146, 64, 14);  $bg = [System.Drawing.Color]::FromArgb(254, 243, 199) }
+            'New'          { $fg = [System.Drawing.Color]::FromArgb(30, 64, 175);  $bg = [System.Drawing.Color]::FromArgb(219, 234, 254) }
+            'Removed'      { $fg = [System.Drawing.Color]::FromArgb(107, 114, 128);$bg = [System.Drawing.Color]::FromArgb(243, 244, 246) }
+            'SchemaNew'    { $fg = [System.Drawing.Color]::FromArgb(30, 64, 175);  $bg = [System.Drawing.Color]::FromArgb(219, 234, 254) }
+            'SchemaRemoved'{ $fg = [System.Drawing.Color]::FromArgb(107, 114, 128);$bg = [System.Drawing.Color]::FromArgb(243, 244, 246) }
+        }
+        if ($fg) {
+            $driftSheet.Cells[$r, $changeTypeCol].Style.Font.Color.SetColor($fg)
+            $driftSheet.Cells[$r, $changeTypeCol].Style.Fill.PatternType = 'Solid'
+            $driftSheet.Cells[$r, $changeTypeCol].Style.Fill.BackgroundColor.SetColor($bg)
+        }
     }
 }
 

--- a/src/M365-Assess/Common/Get-ReportTemplate.ps1
+++ b/src/M365-Assess/Common/Get-ReportTemplate.ps1
@@ -2291,6 +2291,18 @@ $html = @"
         .nav-theme-btn:hover { background: var(--m365a-hover-bg); }
         body:not(.dark-theme) .nav-theme-dark { display: none; }
         body.dark-theme .nav-theme-light { display: none; }
+        .nav-print-btn {
+            background: var(--m365a-card-bg);
+            border: 1px solid var(--m365a-border);
+            border-radius: 4px;
+            padding: 4px 8px;
+            cursor: pointer;
+            font-size: 14px;
+            line-height: 1;
+            color: var(--m365a-text);
+            transition: background 0.15s;
+        }
+        .nav-print-btn:hover { background: var(--m365a-hover-bg); }
         .nav-list { list-style: none; padding: 8px 0; margin: 0; }
         .nav-item a {
             display: flex;
@@ -2626,6 +2638,7 @@ $html = @"
             .section-filter { display: none; }
             .col-picker-bar { display: none; }
             .csv-export-btn { display: none; }
+            .nav-print-btn { display: none; }
             .table-expand-btn { display: none; }
             .matrix-controls { display: none; }
             .callout-row { display: block; }
@@ -2765,6 +2778,7 @@ $accentCss
                     <span class="nav-theme-light">&#9788;</span>
                     <span class="nav-theme-dark">&#9790;</span>
                 </button>
+                <button class="nav-print-btn" onclick="window.print()" aria-label="Print or save as PDF" title="Print / Save as PDF">&#128438;</button>
             </div>
             <ul class="nav-list" id="navList">
 "@
@@ -2907,7 +2921,7 @@ $html += @"
 "@
 
 # Persistent branded banner -- visible on every page in paginated mode
-if (-not $SkipCoverPage) {
+if (-not $CompactReport) {
     $html += @"
 
         <!-- Persistent branded banner (screen, all pages) -->
@@ -2936,7 +2950,7 @@ $html += @"
         <div class="report-page page-active" data-page="overview" id="overview">
 "@
 
-if (-not $SkipCoverPage) {
+if (-not $CompactReport) {
     if ($WhiteLabel) {
         # White-label cover page: client logo hero + "Prepared by" pill + engagement fields
         $prepByPill = if ($companyLogoImgTag -or ($brandName -ne 'M365 Assess')) {
@@ -2982,16 +2996,12 @@ if (-not $SkipCoverPage) {
             <div class="cover-tenant">$(ConvertTo-HtmlSafe -Text $TenantName)</div>
             <div class="cover-subtitle">$assessmentDate</div>
             <div class="cover-date">v$assessmentVersion</div>
-$(if (-not $NoBranding) {
-@'
             <div class="cover-branding">
                 <a href="https://github.com/Galvnyz/M365-Assess" target="_blank" rel="noopener" class="cover-branding-link">
                     <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor" class="cover-branding-icon"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
                     <span>Open-source &mdash; M365-Assess on GitHub</span>
                 </a>
             </div>
-'@
-})
         </header>
 "@
     }
@@ -3003,7 +3013,7 @@ if ($tenantHtml.Length -gt 0) {
 }
 
 # Findings alert — between org profile and exec summary
-if ($allCisFindings.Count -gt 0 -and -not $SkipComplianceOverview) {
+if ($allCisFindings.Count -gt 0 -and -not $CompactReport) {
     $nonPassingCount = @($allCisFindings | Where-Object { $_.Status -ne 'Pass' }).Count
     if ($nonPassingCount -gt 0) {
         $html += @"
@@ -3014,7 +3024,7 @@ if ($allCisFindings.Count -gt 0 -and -not $SkipComplianceOverview) {
     }
 }
 
-if (-not $SkipExecutiveSummary) {
+if (-not $CompactReport) {
     $completePct = if ($totalCollectors -gt 0) { [math]::Round(($completeCount / $totalCollectors) * 100, 0) } else { 0 }
     $donutClass = if ($completePct -ge 90) { 'success' } elseif ($completePct -ge 70) { 'warning' } else { 'danger' }
     $donutSvg = Get-SvgDonut -Percentage $completePct -CssClass $donutClass -Label "$completeCount/$totalCollectors" -Size 120 -StrokeWidth 10

--- a/src/M365-Assess/Entra/Get-EntraAdminRoleSeparationConfig.ps1
+++ b/src/M365-Assess/Entra/Get-EntraAdminRoleSeparationConfig.ps1
@@ -138,7 +138,17 @@ try {
             Uri         = "/v1.0/users/$userId/licenseDetails"
             ErrorAction = 'Stop'
         }
-        $licDetails = Invoke-MgGraphRequest @licParams
+        try {
+            $licDetails = Invoke-MgGraphRequest @licParams
+        }
+        catch {
+            # 404 = service principal or deleted user assigned to the role — skip
+            if ("$_" -match '404|ResourceNotFound|Not Found') {
+                Write-Verbose "Principal $userId not a user object or no longer exists — skipping license check."
+                continue
+            }
+            throw
+        }
         if (-not $licDetails -or -not $licDetails['value']) { continue }
 
         foreach ($sku in @($licDetails['value'])) {

--- a/src/M365-Assess/Entra/Get-EntraAdminRoleSeparationConfig.ps1
+++ b/src/M365-Assess/Entra/Get-EntraAdminRoleSeparationConfig.ps1
@@ -87,16 +87,26 @@ try {
 
     foreach ($roleId in $privilegedRoleIds) {
         Write-Verbose "Checking assignments for role $roleId..."
-        $assignParams = @{
-            Method      = 'GET'
-            Uri         = "/v1.0/roleManagement/directory/roleAssignments?`$filter=roleDefinitionId eq '$roleId'&`$top=999"
-            ErrorAction = 'Stop'
+        try {
+            $assignParams = @{
+                Method      = 'GET'
+                Uri         = "/v1.0/roleManagement/directory/roleAssignments?`$filter=roleDefinitionId eq '$roleId'&`$top=999"
+                ErrorAction = 'Stop'
+            }
+            $assignments = Invoke-MgGraphRequest @assignParams
+            if ($assignments -and $assignments['value']) {
+                foreach ($a in @($assignments['value'])) {
+                    $principalId = $a['principalId']
+                    if ($principalId) { [void]$adminUserIds.Add($principalId) }
+                }
+            }
         }
-        $assignments = Invoke-MgGraphRequest @assignParams
-        if ($assignments -and $assignments['value']) {
-            foreach ($a in @($assignments['value'])) {
-                $principalId = $a['principalId']
-                if ($principalId) { [void]$adminUserIds.Add($principalId) }
+        catch {
+            if ($_.Exception.Message -match '404|ResourceNotFound') {
+                Write-Verbose "Role $roleId not present in this tenant — skipping."
+            }
+            else {
+                throw
             }
         }
     }
@@ -182,9 +192,6 @@ catch {
         Write-Host '      Add a permission > Microsoft Graph > Application permissions' -ForegroundColor DarkGray
         Write-Host "    Then click 'Grant admin consent for [tenant]' and re-run." -ForegroundColor DarkGray
         Write-Host ''
-    }
-    elseif ($_.Exception.Message -match '404|ResourceNotFound') {
-        Write-Verbose "Role assignment query returned 404 — no qualifying assignments found."
     }
     else {
         Write-Warning "Could not check admin role separation: $_"

--- a/src/M365-Assess/Entra/Get-EntraAdminRoleSeparationConfig.ps1
+++ b/src/M365-Assess/Entra/Get-EntraAdminRoleSeparationConfig.ps1
@@ -102,7 +102,7 @@ try {
             }
         }
         catch {
-            if ($_.Exception.Message -match '404|ResourceNotFound') {
+            if ("$_" -match '404|ResourceNotFound|Not Found') {
                 Write-Verbose "Role $roleId not present in this tenant — skipping."
             }
             else {
@@ -173,7 +173,7 @@ try {
     Add-Setting @settingParams
 }
 catch {
-    if ($_.Exception.Message -match '403|Forbidden|Authorization|Ensure the required|service is connected|Access_Denied|Authorization_RequestDenied') {
+    if ("$_" -match '403|Forbidden|Authorization|Ensure the required|service is connected|Access_Denied|Authorization_RequestDenied') {
         $settingParams = @{
             Category         = 'Admin Role Separation'
             Setting          = 'Privileged Account vs Daily-Use Account Separation'

--- a/src/M365-Assess/Exchange-Online/Get-ExoSecurityConfig.ps1
+++ b/src/M365-Assess/Exchange-Online/Get-ExoSecurityConfig.ps1
@@ -252,7 +252,7 @@ catch {
 # ------------------------------------------------------------------
 try {
     Write-Verbose "Checking OWA mailbox policies..."
-    $owaPolicies = Get-OwaMailboxPolicy -ErrorAction Stop
+    $owaPolicies = Get-OwaMailboxPolicy -ErrorAction Stop -WarningAction SilentlyContinue
     foreach ($policy in $owaPolicies) {
         $additionalStorage = $policy.AdditionalStorageProvidersAvailable
         $settingParams = @{
@@ -305,7 +305,7 @@ catch {
 # ------------------------------------------------------------------
 try {
     Write-Verbose "Checking mailbox audit bypass..."
-    $bypassedMailboxes = Get-MailboxAuditBypassAssociation -ResultSize Unlimited -ErrorAction Stop |
+    $bypassedMailboxes = Get-MailboxAuditBypassAssociation -ResultSize Unlimited -ErrorAction Stop -WarningAction SilentlyContinue |
         Where-Object { $_.AuditBypassEnabled -eq $true }
     $bypassCount = @($bypassedMailboxes).Count
 
@@ -645,7 +645,7 @@ catch {
 # ------------------------------------------------------------------
 try {
     Write-Verbose "Checking for hidden user mailboxes..."
-    $hiddenMailboxes = @(Get-EXOMailbox -RecipientTypeDetails UserMailbox -ResultSize Unlimited -Filter 'HiddenFromAddressListsEnabled -eq $True' -Properties DisplayName, PrimarySmtpAddress -ErrorAction Stop)
+    $hiddenMailboxes = @(Get-EXOMailbox -RecipientTypeDetails UserMailbox -ResultSize Unlimited -Filter 'HiddenFromAddressListsEnabled -eq $True' -Properties DisplayName, PrimarySmtpAddress -ErrorAction Stop -WarningAction SilentlyContinue)
 
     if ($hiddenMailboxes.Count -eq 0) {
         $settingParams = @{

--- a/src/M365-Assess/Invoke-M365Assessment.ps1
+++ b/src/M365-Assess/Invoke-M365Assessment.ps1
@@ -14,8 +14,9 @@
 .PARAMETER Section
     One or more assessment sections to run. Valid values: Tenant, Identity,
     Licensing, Email, Intune, Security, Collaboration, Hybrid, PowerBI,
-    Inventory, ActiveDirectory, SOC2, ValueOpportunity. Defaults to all standard
-    sections. Inventory, ActiveDirectory, SOC2, and ValueOpportunity are opt-in only.
+    Inventory, ActiveDirectory, SOC2, ValueOpportunity, All. Defaults to all
+    standard sections. Use 'All' to include opt-in sections (Inventory,
+    ActiveDirectory, SOC2, ValueOpportunity) in a single value.
 .PARAMETER TenantId
     Tenant ID or domain (e.g., 'contoso.onmicrosoft.com').
 .PARAMETER OutputFolder
@@ -49,55 +50,56 @@
     Target cloud environment for all service connections. Commercial and GCC
     use standard endpoints. GCCHigh and DoD use sovereign cloud endpoints.
     Auto-detected from tenant metadata when not explicitly specified.
-.PARAMETER SkipDLP
-    Skips the DLP Policies collector and its Purview (Security & Compliance)
-    connection. Purview connection adds ~46 seconds of latency, so use this
-    switch when DLP policy assessment is not needed.
-.PARAMETER SkipComplianceOverview
-    Omit the Compliance Overview section from the HTML report. Useful when
-    running a single section assessment where framework coverage cards are
-    not relevant.
-.PARAMETER SkipCoverPage
-    Omit the branded cover page from the HTML report.
-.PARAMETER SkipExecutiveSummary
-    Omit the executive summary hero panel from the HTML report.
-.PARAMETER SkipPdf
-    Skip PDF generation even when wkhtmltopdf is available.
-.PARAMETER FrameworkFilter
-    Limit the compliance overview to specific framework families.
+.PARAMETER SkipPurview
+    Skips all Purview-connected collectors (DLP Policies, Compliance Security
+    Config, Purview Retention Config) and their Security and Compliance
+    connection. Saves ~46 seconds of latency when Purview data is not needed.
+.PARAMETER OpenReport
+    Automatically open the generated HTML report in the default browser after
+    generation. Works on Windows, macOS, and Linux.
 .PARAMETER CustomBranding
     Hashtable for white-label reports. Keys: CompanyName, LogoPath, AccentColor,
     ClientLogoPath, ClientName, ReportNote, Disclaimer, SidebarSubtitle, FooterText,
-    FooterUrl, PrimaryColor, ReportTitle.
+    FooterUrl, PrimaryColor, ReportTitle. Automatically enables -WhiteLabel.
 .PARAMETER WhiteLabel
-    Strips all M365-Assess and GitHub identity from the report. Combined with
-    CustomBranding keys produces a fully branded consultant deliverable (Mode A).
-    Without CustomBranding produces a neutral, tool-agnostic report (Mode C).
-.PARAMETER Package
-    Generates a full delivery package: white-labeled HTML, auto-generated PDF
-    (via headless Edge or Chrome), and XLSX compliance matrix in one folder.
+    Strips all M365-Assess and GitHub identity from the report. With -CustomBranding
+    produces a fully branded consultant deliverable (Mode A). Without -CustomBranding
+    produces a neutral, tool-agnostic report (Mode C).
 .PARAMETER CustomerProfile
-    Path to a .psd1 configuration file with CustomBranding, FindingsNarrative,
-    and Frameworks keys. Merged into the equivalent parameters — direct params
-    win on conflict. Enables reusable per-customer configuration.
+    Path to a .psd1 configuration file with CustomBranding and FindingsNarrative
+    keys. Merged into the equivalent parameters — direct params win on conflict.
+    Enables reusable per-customer configuration. Automatically enables -WhiteLabel.
 .PARAMETER FindingsNarrative
     Path to a .txt or .md file (or an inline string) containing consultant-authored
     findings commentary. Rendered as a narrative card before the Executive Summary,
     alongside auto-populated severity chip counts.
-.PARAMETER FrameworkExport
-    Generate standalone per-framework HTML catalog exports. Specify framework
-    families or 'All'. Output files are named _<Framework>-Catalog_<tenant>.html.
-.PARAMETER CisBenchmarkVersion
-    CIS benchmark version to use for framework rendering. Defaults to 'v6'
-    (CIS Microsoft 365 v6.0.1). Set to 'v7' when CIS v7.0 data is available.
+.PARAMETER CompactReport
+    Omit cover page, executive summary, and compliance overview from the HTML
+    report. Produces a lean, findings-focused report. Automatically set by
+    -QuickScan unless overridden with -CompactReport:$false.
 .PARAMETER QuickScan
     Run only Critical and High severity checks. Useful for CI/CD pipelines
     and daily monitoring. Collectors with no qualifying checks are skipped
     entirely. The report shows a "Quick Scan Mode" banner and automatically
-    omits the cover page, executive summary, and compliance overview to
-    produce a compact, action-focused triage report. Override any of these
-    individually with -SkipCoverPage:$false, -SkipExecutiveSummary:$false,
-    or -SkipComplianceOverview:$false.
+    sets -CompactReport. Override with -CompactReport:$false to keep the
+    full report structure.
+.PARAMETER SaveBaseline
+    Label for a new baseline snapshot. Saves the current assessment results
+    to a Baselines subfolder under the output folder. Use with -CompareBaseline
+    on a later run to detect policy drift.
+.PARAMETER CompareBaseline
+    Label of a previously saved baseline to compare against. Generates a drift
+    report highlighting settings that changed since the baseline was captured.
+    Version-aware: when the registry version differs from the baseline, only
+    shared CheckIDs are compared and schema changes are reported separately.
+.PARAMETER AutoBaseline
+    Automatically saves a dated snapshot after every run and compares against
+    the most recent previous auto-snapshot for this tenant. No label management
+    required. Ideal for scheduled assessments and continuous drift tracking.
+.PARAMETER ListBaselines
+    Lists all saved baselines for the tenant (label, date, registry version,
+    check count) and exits without running an assessment. Use -TenantId to
+    scope results; omit to list baselines for all tenants.
 .PARAMETER DryRun
     Show a dry-run preview of what the assessment would do (sections,
     services, Graph scopes, check counts) without connecting or collecting
@@ -116,47 +118,61 @@
     environments. Also triggered automatically when the session is not
     user-interactive ([Environment]::UserInteractive is false).
 .EXAMPLE
-    PS> .\Invoke-M365Assessment.ps1 -TenantId 'contoso.onmicrosoft.com'
+    PS> Invoke-M365Assessment -TenantId 'contoso.onmicrosoft.com'
 
-    Runs a full assessment with interactive authentication and exports CSVs.
+    Full assessment with interactive browser auth.
 .EXAMPLE
-    PS> .\Invoke-M365Assessment.ps1 -Section Identity,Email -TenantId 'contoso.onmicrosoft.com'
+    PS> Invoke-M365Assessment -TenantId 'contoso.onmicrosoft.com' -Section All
 
-    Runs only the Identity and Email sections.
+    Full assessment including all opt-in sections (Inventory, ActiveDirectory,
+    SOC2, ValueOpportunity).
 .EXAMPLE
-    PS> .\Invoke-M365Assessment.ps1 -SkipConnection
+    PS> Invoke-M365Assessment -TenantId 'contoso.onmicrosoft.com' -ClientId '00000000-0000-0000-0000-000000000000' -CertificateThumbprint 'ABC123'
 
-    Runs all sections using pre-existing service connections.
+    App-only authentication using a certificate. Recommended for automation.
 .EXAMPLE
-    PS> .\Invoke-M365Assessment.ps1 -TenantId 'contoso.onmicrosoft.com' -ClientId '00000000-0000-0000-0000-000000000000' -CertificateThumbprint 'ABC123'
+    PS> Invoke-M365Assessment -ManagedIdentity -Section Tenant,Identity,Security
 
-    Runs a full assessment using certificate-based app-only auth.
+    Runs selected sections using Azure managed identity (no credentials needed).
 .EXAMPLE
-    PS> .\Invoke-M365Assessment.ps1 -TenantId 'contoso.onmicrosoft.com' -UserPrincipalName 'admin@contoso.onmicrosoft.com'
+    PS> Invoke-M365Assessment -TenantId 'contoso.onmicrosoft.us' -UseDeviceCode
 
-    Runs a full assessment using UPN-based auth for EXO/Purview (avoids WAM broker errors).
+    Device code auth — choose which browser profile to sign in with.
 .EXAMPLE
-    PS> .\Invoke-M365Assessment.ps1 -TenantId 'contoso.onmicrosoft.us' -UseDeviceCode
+    PS> Invoke-M365Assessment -TenantId 'contoso.onmicrosoft.com' -QuickScan
 
-    Runs a full assessment using device code auth. You choose which browser profile
-    to authenticate in (useful for multi-profile machines).
+    Critical and High checks only. Produces a compact triage report.
+.EXAMPLE
+    PS> Invoke-M365Assessment -TenantId 'contoso.onmicrosoft.com' -AutoBaseline
+
+    Runs assessment and auto-saves a dated snapshot. On subsequent runs,
+    generates a drift report showing what changed since the last snapshot.
+.EXAMPLE
+    PS> Invoke-M365Assessment -TenantId 'contoso.onmicrosoft.com' -ListBaselines
+
+    Lists all saved baseline snapshots for the tenant without running an assessment.
 .EXAMPLE
     PS> Invoke-M365Assessment -TenantId 'contoso.onmicrosoft.com' -Section Identity,Email -DryRun
 
-    Shows a dry-run preview: sections, services, Graph scopes, and check counts
-    without connecting or collecting any data.
+    Dry-run preview: sections, services, Graph scopes, and check counts —
+    no connections made, no data collected.
 #>
 #Requires -Version 7.0
 
 function Invoke-M365Assessment {
-[CmdletBinding()]
+[CmdletBinding(DefaultParameterSetName = 'Interactive')]
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'connectedServices',
     Justification = 'Used by Connect-RequiredService in Orchestrator/ via parent scope')]
 param(
     [Parameter()]
-    [ValidateSet('Tenant', 'Identity', 'Licensing', 'Email', 'Intune', 'Security', 'Collaboration', 'PowerBI', 'Hybrid', 'Inventory', 'ActiveDirectory', 'SOC2', 'ValueOpportunity')]
+    [ValidateSet('Tenant', 'Identity', 'Licensing', 'Email', 'Intune', 'Security', 'Collaboration',
+                 'PowerBI', 'Hybrid', 'Inventory', 'ActiveDirectory', 'SOC2', 'ValueOpportunity', 'All')]
     [string[]]$Section = @('Tenant', 'Identity', 'Licensing', 'Email', 'Intune', 'Security', 'Collaboration', 'PowerBI', 'Hybrid'),
 
+    # TenantId: optional in Interactive/DeviceCode/ManagedIdentity/SkipConnection sets;
+    # mandatory in app-only sets where the tenant cannot be inferred interactively.
+    [Parameter(ParameterSetName = 'AppOnlyCert',   Mandatory)]
+    [Parameter(ParameterSetName = 'AppOnlySecret', Mandatory)]
     [Parameter()]
     [string]$TenantId,
 
@@ -164,25 +180,26 @@ param(
     [ValidateNotNullOrEmpty()]
     [string]$OutputFolder = '.\M365-Assessment',
 
-    [Parameter()]
+    [Parameter(ParameterSetName = 'SkipConnection', Mandatory)]
     [switch]$SkipConnection,
 
-    [Parameter()]
+    [Parameter(ParameterSetName = 'AppOnlyCert',   Mandatory)]
+    [Parameter(ParameterSetName = 'AppOnlySecret', Mandatory)]
     [string]$ClientId,
 
-    [Parameter()]
+    [Parameter(ParameterSetName = 'AppOnlyCert', Mandatory)]
     [string]$CertificateThumbprint,
 
-    [Parameter()]
+    [Parameter(ParameterSetName = 'AppOnlySecret', Mandatory)]
     [SecureString]$ClientSecret,
 
     [Parameter()]
     [string]$UserPrincipalName,
 
-    [Parameter()]
+    [Parameter(ParameterSetName = 'ManagedIdentity', Mandatory)]
     [switch]$ManagedIdentity,
 
-    [Parameter()]
+    [Parameter(ParameterSetName = 'DeviceCode', Mandatory)]
     [switch]$UseDeviceCode,
 
     [Parameter()]
@@ -190,45 +207,16 @@ param(
     [string]$M365Environment = 'commercial',
 
     [Parameter()]
-    [switch]$NoBranding,
-
-    [Parameter()]
-    [switch]$SkipDLP,
-
-    [Parameter()]
-    [switch]$SkipComplianceOverview,
-
-    [Parameter()]
-    [switch]$SkipCoverPage,
-
-    [Parameter()]
-    [switch]$SkipExecutiveSummary,
-
-    [Parameter()]
-    [switch]$SkipPdf,
+    [switch]$SkipPurview,
 
     [Parameter()]
     [switch]$OpenReport,
-
-    [Parameter()]
-    [ValidateScript({
-        $validFamilies = @('CIS','NIST','ISO','STIG','PCI','CMMC','HIPAA','CISA','SOC2','FedRAMP','Essential8','MITRE','CISv8')
-        foreach ($fw in $_) {
-            $family = ($fw -split ':')[0].ToUpper()
-            if ($family -notin $validFamilies) { throw "Invalid framework family '$family' in '$fw'. Valid: $($validFamilies -join ', ')" }
-        }
-        $true
-    })]
-    [string[]]$FrameworkFilter,
 
     [Parameter()]
     [hashtable]$CustomBranding,
 
     [Parameter()]
     [switch]$WhiteLabel,
-
-    [Parameter()]
-    [switch]$Package,
 
     [Parameter()]
     [ValidateScript({ -not $_ -or (Test-Path -Path $_ -PathType Leaf) })]
@@ -238,12 +226,7 @@ param(
     [string]$FindingsNarrative,
 
     [Parameter()]
-    [ValidateSet('CIS','NIST','ISO','STIG','PCI','CMMC','HIPAA','CISA','SOC2','FedRAMP','Essential8','MITRE','All')]
-    [string[]]$FrameworkExport,
-
-    [Parameter()]
-    [ValidatePattern('^v\d+$')]
-    [string]$CisBenchmarkVersion = 'v6',
+    [switch]$CompactReport,
 
     [Parameter()]
     [switch]$NonInteractive,
@@ -255,12 +238,18 @@ param(
     [switch]$DryRun,
 
     [Parameter()]
-    [string]$SaveBaseline = '',
+    [string]$SaveBaseline,
 
     [Parameter()]
-    [string]$CompareBaseline = '',
+    [string]$CompareBaseline,
 
     [Parameter()]
+    [switch]$AutoBaseline,
+
+    [Parameter()]
+    [switch]$ListBaselines,
+
+    [Parameter(ParameterSetName = 'ConnectionProfile', Mandatory)]
     [ArgumentCompleter({
         param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
         $root = Split-Path -Parent $PSCommandPath
@@ -293,14 +282,9 @@ if (-not (Get-Command -Name Show-InteractiveWizard -ErrorAction SilentlyContinue
     Get-ChildItem -Path (Join-Path $projectRoot 'Orchestrator') -Filter '*.ps1' |
         ForEach-Object { . $_.FullName }
 }
-if (-not (Get-Command -Name ConvertTo-FrameworkFilter -ErrorAction SilentlyContinue)) {
-    . (Join-Path $projectRoot 'Common\ConvertTo-FrameworkFilter.ps1')
-}
-
 # ------------------------------------------------------------------
 # CustomerProfile — merge .psd1 into params (direct params win)
 # ------------------------------------------------------------------
-$script:frameworkFilters = $null
 if ($CustomerProfile) {
     $cpData = Import-PowerShellDataFile -Path $CustomerProfile
     if ($cpData.ContainsKey('CustomBranding')) {
@@ -315,18 +299,12 @@ if ($CustomerProfile) {
     if ($cpData.ContainsKey('FindingsNarrative') -and -not $PSBoundParameters.ContainsKey('FindingsNarrative')) {
         $FindingsNarrative = $cpData['FindingsNarrative']
     }
-    if ($cpData.ContainsKey('Frameworks') -and -not $PSBoundParameters.ContainsKey('FrameworkFilter')) {
-        $script:frameworkFilters = ConvertTo-FrameworkFilter -Frameworks $cpData['Frameworks']
-        $FrameworkFilter = $script:frameworkFilters | ForEach-Object { $_.FilterFamily } | Select-Object -Unique
-    }
+    $WhiteLabel = $true
 }
-# Parse any sub-level notation passed directly via -FrameworkFilter
-if ($FrameworkFilter -and -not $script:frameworkFilters) {
-    $hasSubLevel = $FrameworkFilter | Where-Object { $_ -match ':' }
-    if ($hasSubLevel) {
-        $script:frameworkFilters = ConvertTo-FrameworkFilter -Frameworks $FrameworkFilter
-        $FrameworkFilter = $script:frameworkFilters | ForEach-Object { $_.FilterFamily } | Select-Object -Unique
-    }
+
+# CustomBranding implicitly enables WhiteLabel
+if ($PSBoundParameters.ContainsKey('CustomBranding') -and -not $WhiteLabel) {
+    $WhiteLabel = $true
 }
 
 # Show-InteractiveWizard -- extracted to Orchestrator/Show-InteractiveWizard.ps1
@@ -395,20 +373,8 @@ if ($launchWizard -and [Environment]::UserInteractive) {
     }
 
     # Report options from wizard
-    if ($wizardParams.ContainsKey('SkipComplianceOverview')) {
-        $SkipComplianceOverview = [switch]$true
-    }
-    if ($wizardParams.ContainsKey('SkipCoverPage')) {
-        $SkipCoverPage = [switch]$true
-    }
-    if ($wizardParams.ContainsKey('SkipExecutiveSummary')) {
-        $SkipExecutiveSummary = [switch]$true
-    }
-    if ($wizardParams.ContainsKey('NoBranding')) {
-        $NoBranding = [switch]$true
-    }
-    if ($wizardParams.ContainsKey('FrameworkFilter') -and -not $PSBoundParameters.ContainsKey('FrameworkFilter')) {
-        $FrameworkFilter = $wizardParams['FrameworkFilter']
+    if ($wizardParams.ContainsKey('CompactReport')) {
+        $CompactReport = [switch]$true
     }
     if ($wizardParams.ContainsKey('ConnectionProfile') -and -not $PSBoundParameters.ContainsKey('ConnectionProfile')) {
         $ConnectionProfile = $wizardParams['ConnectionProfile']
@@ -532,6 +498,45 @@ $collectorMap      = $maps.CollectorMap
 $dnsCollector      = $maps.DnsCollector
 
 # ------------------------------------------------------------------
+# Section 'All' — expand shorthand to full section list
+# ------------------------------------------------------------------
+if ($Section -contains 'All') {
+    $Section = @('Tenant','Identity','Licensing','Email','Intune','Security',
+                 'Collaboration','PowerBI','Hybrid','Inventory',
+                 'ActiveDirectory','SOC2','ValueOpportunity')
+}
+
+# ------------------------------------------------------------------
+# ListBaselines — display saved snapshots and exit (no assessment)
+# ------------------------------------------------------------------
+if ($ListBaselines) {
+    $baselineRoot = Join-Path -Path $OutputFolder -ChildPath 'Baselines'
+    if (-not (Test-Path -Path $baselineRoot)) {
+        Write-Host "No baselines found at '$baselineRoot'." -ForegroundColor Yellow
+        return
+    }
+    $manifests = Get-ChildItem -Path $baselineRoot -Recurse -Filter 'manifest.json' |
+        Where-Object { -not $TenantId -or $_.FullName -match [regex]::Escape($TenantId) }
+    if ($manifests.Count -eq 0) {
+        Write-Host "No baselines found$(if ($TenantId) { " for tenant '$TenantId'" })." -ForegroundColor Yellow
+        return
+    }
+    $rows = foreach ($m in $manifests | Sort-Object LastWriteTime -Descending) {
+        try { $data = Get-Content -Path $m.FullName -Raw | ConvertFrom-Json } catch { continue }
+        [PSCustomObject]@{
+            Label             = $data.Label
+            SavedAt           = $data.SavedAt
+            RegistryVersion   = $data.RegistryVersion
+            AssessmentVersion = $data.AssessmentVersion
+            CheckCount        = $data.CheckCount
+            TenantId          = $data.TenantId
+        }
+    }
+    $rows | Format-Table -AutoSize
+    return
+}
+
+# ------------------------------------------------------------------
 # Auto-detect cloud environment (when not explicitly specified)
 # ------------------------------------------------------------------
 if ($TenantId -and -not $PSBoundParameters.ContainsKey('M365Environment')) {
@@ -622,7 +627,7 @@ $failedServices = [System.Collections.Generic.HashSet[string]]::new()
 
 # Module compatibility check -- extracted to Orchestrator/Test-ModuleCompatibility.ps1
 if (-not $SkipConnection) {
-    $modResult = Test-ModuleCompatibility -Section $Section -SectionServiceMap $sectionServiceMap -NonInteractive:$NonInteractive -SkipDLP:$SkipDLP
+    $modResult = Test-ModuleCompatibility -Section $Section -SectionServiceMap $sectionServiceMap -NonInteractive:$NonInteractive -SkipDLP:$SkipPurview
     if (-not $modResult.Passed) { return }
     $Section = $modResult.Section
 
@@ -775,13 +780,13 @@ foreach ($sectionName in $Section) {
 
     $collectors = $collectorMap[$sectionName]
 
-    # Skip DLP collector (and its Purview connection overhead) when -SkipDLP is set
-    if ($SkipDLP) {
-        $dlpCollectors = @($collectors | Where-Object { $_.ContainsKey('RequiredServices') -and $_.RequiredServices -contains 'Purview' })
-        if ($dlpCollectors.Count -gt 0) {
+    # Skip Purview collectors (and their Security and Compliance connection overhead) when -SkipPurview is set
+    if ($SkipPurview) {
+        $purviewCollectors = @($collectors | Where-Object { $_.ContainsKey('RequiredServices') -and $_.RequiredServices -contains 'Purview' })
+        if ($purviewCollectors.Count -gt 0) {
             $collectors = @($collectors | Where-Object { -not ($_.ContainsKey('RequiredServices') -and $_.RequiredServices -contains 'Purview') })
-            foreach ($skipped in $dlpCollectors) {
-                Write-AssessmentLog -Level INFO -Message "Skipped: $($skipped.Label) (-SkipDLP)" -Section $sectionName -Collector $skipped.Label
+            foreach ($skipped in $purviewCollectors) {
+                Write-AssessmentLog -Level INFO -Message "Skipped: $($skipped.Label) (-SkipPurview)" -Section $sectionName -Collector $skipped.Label
             }
         }
     }
@@ -1223,7 +1228,8 @@ if ($SaveBaseline) {
         -Label $SaveBaseline `
         -TenantId $TenantId `
         -Sections @($sections | ForEach-Object { $_ }) `
-        -Version $script:AssessmentVersion
+        -Version $script:AssessmentVersion `
+        -RegistryVersion (Get-RegistryVersion -ProjectRoot $projectRoot)
     Write-AssessmentLog -Level INFO -Message "Baseline saved: $savedBaselineDir"
 }
 
@@ -1235,15 +1241,16 @@ if ($CompareBaseline) {
         Write-AssessmentLog -Level INFO -Message "Comparing against baseline '$CompareBaseline'..."
         $driftReport = Compare-AssessmentBaseline `
             -AssessmentFolder $assessmentFolder `
-            -BaselineFolder $baselineFolder
+            -BaselineFolder $baselineFolder `
+            -RegistryVersion (Get-RegistryVersion -ProjectRoot $projectRoot)
         $driftBaselineLabel = $CompareBaseline
-        $metaPath = Join-Path -Path $baselineFolder -ChildPath '_baseline-metadata.json'
+        $metaPath = Join-Path -Path $baselineFolder -ChildPath 'manifest.json'
         if (Test-Path -Path $metaPath) {
             try {
                 $meta = Get-Content -Path $metaPath -Raw | ConvertFrom-Json
-                $driftBaselineTimestamp = $meta.timestamp
+                $driftBaselineTimestamp = $meta.SavedAt
             }
-            catch { Write-Verbose "Drift: could not read baseline metadata: $_" }
+            catch { Write-Verbose "Drift: could not read baseline manifest: $_" }
         }
         Write-AssessmentLog -Level INFO -Message "Drift analysis: $($driftReport.Count) changes detected vs baseline '$CompareBaseline'"
     }
@@ -1253,16 +1260,52 @@ if ($CompareBaseline) {
 }
 
 # ------------------------------------------------------------------
+# AutoBaseline — save dated snapshot and compare to previous auto-*
+# ------------------------------------------------------------------
+if ($AutoBaseline) {
+    $autoLabel   = "auto_$(Get-Date -Format 'yyyy-MM-ddTHH-mm-ss')"
+    $safeTenant  = $TenantId -replace '[^\w\.\-]', '_'
+    $sections    = @($Section | ForEach-Object { $_ })
+    Export-AssessmentBaseline `
+        -AssessmentFolder $assessmentFolder `
+        -OutputFolder $OutputFolder `
+        -TenantId $TenantId `
+        -Label $autoLabel `
+        -Sections $sections `
+        -Version $script:AssessmentVersion `
+        -RegistryVersion (Get-RegistryVersion -ProjectRoot $projectRoot)
+    Write-AssessmentLog -Level INFO -Message "AutoBaseline saved: $autoLabel"
+
+    # Compare to most recent previous auto-snapshot for this tenant
+    $prevAuto = Get-ChildItem -Path (Join-Path $OutputFolder 'Baselines') -Directory -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -match "^auto_.*_${safeTenant}$" } |
+        Sort-Object LastWriteTime -Descending |
+        Select-Object -Skip 1 -First 1
+    if ($prevAuto) {
+        Write-AssessmentLog -Level INFO -Message "AutoBaseline: comparing to $($prevAuto.Name)..."
+        $driftReport = Compare-AssessmentBaseline `
+            -AssessmentFolder $assessmentFolder `
+            -BaselineFolder $prevAuto.FullName `
+            -RegistryVersion (Get-RegistryVersion -ProjectRoot $projectRoot)
+        $driftBaselineLabel = $prevAuto.Name -replace "_${safeTenant}$", ''
+        try {
+            $meta = Get-Content -Path (Join-Path $prevAuto.FullName 'manifest.json') -Raw | ConvertFrom-Json
+            $driftBaselineTimestamp = $meta.SavedAt
+        }
+        catch { Write-Verbose "AutoBaseline: could not read previous manifest: $_" }
+        Write-AssessmentLog -Level INFO -Message "AutoBaseline drift: $($driftReport.Count) changes vs $($prevAuto.Name)"
+    }
+}
+
+# ------------------------------------------------------------------
 # Generate HTML report
 # ------------------------------------------------------------------
 $reportScriptPath = Join-Path -Path $projectRoot -ChildPath 'Common\Export-AssessmentReport.ps1'
 if (Test-Path -Path $reportScriptPath) {
     try {
-        # QuickScan: default to compact triage report unless the user explicitly overrode each flag
-        if ($QuickScan) {
-            if (-not $PSBoundParameters.ContainsKey('SkipCoverPage'))          { $SkipCoverPage = $true }
-            if (-not $PSBoundParameters.ContainsKey('SkipExecutiveSummary'))   { $SkipExecutiveSummary = $true }
-            if (-not $PSBoundParameters.ContainsKey('SkipComplianceOverview')) { $SkipComplianceOverview = $true }
+        # QuickScan: default to compact report unless the user explicitly overrode it
+        if ($QuickScan -and -not $PSBoundParameters.ContainsKey('CompactReport')) {
+            $CompactReport = $true
         }
 
         $reportParams = @{
@@ -1270,26 +1313,17 @@ if (Test-Path -Path $reportScriptPath) {
         }
         if ($script:domainPrefix) { $reportParams['TenantName'] = $script:domainPrefix }
         elseif ($TenantId)        { $reportParams['TenantName'] = $TenantId }
-        if ($NoBranding) { $reportParams['NoBranding'] = $true }
-        if ($WhiteLabel) { $reportParams['WhiteLabel'] = $true }
-        if ($Package) { $reportParams['Package'] = $true }
+        if ($WhiteLabel)        { $reportParams['WhiteLabel']        = $true }
         if ($FindingsNarrative) { $reportParams['FindingsNarrative'] = $FindingsNarrative }
-        if ($script:frameworkFilters) { $reportParams['FrameworkFilters'] = $script:frameworkFilters }
-        if ($SkipComplianceOverview) { $reportParams['SkipComplianceOverview'] = $true }
-        if ($SkipCoverPage) { $reportParams['SkipCoverPage'] = $true }
-        if ($SkipExecutiveSummary) { $reportParams['SkipExecutiveSummary'] = $true }
-        if ($SkipPdf) { $reportParams['SkipPdf'] = $true }
-        if ($OpenReport) { $reportParams['OpenReport'] = $true }
-        if ($FrameworkFilter) { $reportParams['FrameworkFilter'] = $FrameworkFilter }
-        if ($CustomBranding) { $reportParams['CustomBranding'] = $CustomBranding }
-        if ($FrameworkExport) { $reportParams['FrameworkExport'] = $FrameworkExport }
-        if ($QuickScan) { $reportParams['QuickScan'] = $true }
+        if ($CompactReport)     { $reportParams['CompactReport']     = $true }
+        if ($OpenReport)        { $reportParams['OpenReport']        = $true }
+        if ($CustomBranding)    { $reportParams['CustomBranding']    = $CustomBranding }
+        if ($QuickScan)         { $reportParams['QuickScan']         = $true }
         if ($driftReport.Count -gt 0 -or $driftBaselineLabel) {
             $reportParams['DriftReport']            = $driftReport
             $reportParams['DriftBaselineLabel']     = $driftBaselineLabel
             $reportParams['DriftBaselineTimestamp'] = $driftBaselineTimestamp
         }
-        $reportParams['CisFrameworkId'] = "cis-m365-$CisBenchmarkVersion"
 
         $reportOutput = & $reportScriptPath @reportParams
         foreach ($line in $reportOutput) {

--- a/src/M365-Assess/M365-Assess.psd1
+++ b/src/M365-Assess/M365-Assess.psd1
@@ -50,6 +50,7 @@
         'Set-M365ConnectionProfile'
         'Remove-M365ConnectionProfile'
         'Get-M365ConnectionProfile'
+        'Compare-M365Baseline'
     )
     CmdletsToExport   = @()
     VariablesToExport = @()
@@ -73,6 +74,7 @@
         'Orchestrator\Invoke-DnsAuthentication.ps1'
         'Orchestrator\Export-AssessmentBaseline.ps1'
         'Orchestrator\Compare-AssessmentBaseline.ps1'
+        'Orchestrator\Compare-M365Baseline.ps1'
         'Common\SecurityConfigHelper.ps1'
         'Common\Connect-Service.ps1'
         'Common\Resolve-DnsRecord.ps1'

--- a/src/M365-Assess/M365-Assess.psm1
+++ b/src/M365-Assess/M365-Assess.psm1
@@ -6,7 +6,7 @@ Get-ChildItem -Path "$PSScriptRoot\Orchestrator\*.ps1" | ForEach-Object { . $_.F
 # Dot-source shared helpers needed by public cmdlets
 . "$PSScriptRoot\Common\SecurityConfigHelper.ps1"
 . "$PSScriptRoot\Common\Resolve-DnsRecord.ps1"
-. "$PSScriptRoot\Common\ConvertTo-FrameworkFilter.ps1"
+. "$PSScriptRoot\Orchestrator\Compare-M365Baseline.ps1"
 
 # Dot-source the main orchestrator to import Invoke-M365Assessment function
 . $PSScriptRoot\Invoke-M365Assessment.ps1
@@ -210,6 +210,7 @@ Export-ModuleMember -Function @(
     'Get-M365FormsSecurityConfig'
     'Get-M365PowerBISecurityConfig'
     'Get-M365PurviewRetentionConfig'
+    'Compare-M365Baseline'
     'Grant-M365AssessConsent'
     'New-M365ConnectionProfile'
     'Set-M365ConnectionProfile'

--- a/src/M365-Assess/Orchestrator/AssessmentHelpers.ps1
+++ b/src/M365-Assess/Orchestrator/AssessmentHelpers.ps1
@@ -350,3 +350,25 @@ function Show-AssessmentSummary {
     Write-Host '  ░▒▓████████████████████████████████████████████████▓▒░' -ForegroundColor Cyan
     Write-Host ''
 }
+
+# ------------------------------------------------------------------
+# Helper: Get-RegistryVersion — read version from registry.json
+# ------------------------------------------------------------------
+function Get-RegistryVersion {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ProjectRoot
+    )
+
+    $registryPath = Join-Path -Path $ProjectRoot -ChildPath 'controls/registry.json'
+    if (-not (Test-Path -Path $registryPath)) { return '' }
+    try {
+        $reg = Get-Content -Path $registryPath -Raw -ErrorAction Stop | ConvertFrom-Json
+        return if ($reg.dataVersion) { $reg.dataVersion }
+               elseif ($reg.schemaVersion) { $reg.schemaVersion }
+               else { '' }
+    }
+    catch { return '' }
+}

--- a/src/M365-Assess/Orchestrator/Compare-AssessmentBaseline.ps1
+++ b/src/M365-Assess/Orchestrator/Compare-AssessmentBaseline.ps1
@@ -18,6 +18,10 @@ function Compare-AssessmentBaseline {
         Path to the current assessment output folder (with live CSVs).
     .PARAMETER BaselineFolder
         Path to the named baseline folder created by Export-AssessmentBaseline.
+    .PARAMETER RegistryVersion
+        Registry data version of the current run (from controls/registry.json).
+        Compared against the baseline manifest's RegistryVersion to decide
+        whether to do a full or intersect-only comparison.
     .OUTPUTS
         [PSCustomObject[]] One entry per changed check with fields:
           CheckId, Setting, Category, Section, ChangeType,
@@ -36,7 +40,10 @@ function Compare-AssessmentBaseline {
 
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [string]$BaselineFolder
+        [string]$BaselineFolder,
+
+        [Parameter()]
+        [string]$RegistryVersion = ''
     )
 
     if (-not (Test-Path -Path $BaselineFolder -PathType Container)) {
@@ -44,10 +51,23 @@ function Compare-AssessmentBaseline {
         return @()
     }
 
+    # Read baseline manifest for version metadata
+    $baselineRegistryVersion = ''
+    $manifestPath = Join-Path -Path $BaselineFolder -ChildPath 'manifest.json'
+    if (Test-Path -Path $manifestPath) {
+        try {
+            $manifestData = Get-Content -Path $manifestPath -Raw -ErrorAction Stop | ConvertFrom-Json
+            $baselineRegistryVersion = $manifestData.RegistryVersion
+        }
+        catch { Write-Verbose "Drift: could not read manifest: $_" }
+    }
+
+    $crossVersionCompare = $RegistryVersion -and $baselineRegistryVersion -and ($RegistryVersion -ne $baselineRegistryVersion)
+
     # Build a lookup of all baseline checks: CheckId -> row object
     $baselineMap = @{}
     $baselineJsonFiles = Get-ChildItem -Path $BaselineFolder -Filter '*.json' -ErrorAction SilentlyContinue |
-        Where-Object { $_.Name -ne '_baseline-metadata.json' }
+        Where-Object { $_.Name -ne 'manifest.json' }
 
     foreach ($jsonFile in $baselineJsonFiles) {
         try {
@@ -91,17 +111,26 @@ function Compare-AssessmentBaseline {
         }
     }
 
+    # In cross-version mode: only compare CheckIDs present in both snapshots.
+    # New/removed CheckIDs are schema changes, not policy drift.
+    $sharedIds = if ($crossVersionCompare) {
+        $currentMap.Keys | Where-Object { $baselineMap.ContainsKey($_) }
+    } else {
+        $currentMap.Keys
+    }
+
     $passStatuses = @('Pass')
     $failStatuses = @('Fail', 'Warning')
 
     $driftResults = [System.Collections.Generic.List[PSCustomObject]]::new()
 
-    # Check all current items against baseline
-    foreach ($checkId in $currentMap.Keys) {
+    # Check shared (or all) current items against baseline
+    foreach ($checkId in $sharedIds) {
         $current  = $currentMap[$checkId]
         $baseline = $baselineMap[$checkId]
 
         if (-not $baseline) {
+            # New check — only reported in same-version mode
             $driftResults.Add([PSCustomObject]@{
                 CheckId        = $checkId
                 Setting        = $current.Setting
@@ -129,10 +158,8 @@ function Compare-AssessmentBaseline {
             'Improved'
         } elseif ($prevStatus -in $passStatuses -and $currStatus -in $failStatuses) {
             'Regressed'
-        } elseif ($prevStatus -ne $currStatus) {
-            'Modified'
         } else {
-            'Modified'  # Same status, different value
+            'Modified'
         }
 
         $driftResults.Add([PSCustomObject]@{
@@ -148,21 +175,59 @@ function Compare-AssessmentBaseline {
         })
     }
 
-    # Check for removed items (in baseline but not in current)
-    foreach ($checkId in $baselineMap.Keys) {
-        if (-not $currentMap.ContainsKey($checkId)) {
-            $baseline = $baselineMap[$checkId]
-            $driftResults.Add([PSCustomObject]@{
-                CheckId        = $checkId
-                Setting        = $baseline.Setting
-                Category       = $baseline.Category
-                Section        = ''
-                ChangeType     = 'Removed'
-                PreviousStatus = $baseline.Status
-                CurrentStatus  = ''
-                PreviousValue  = $baseline.CurrentValue
-                CurrentValue   = ''
-            })
+    if ($crossVersionCompare) {
+        # Schema additions: in current but not in baseline registry
+        foreach ($checkId in $currentMap.Keys) {
+            if (-not $baselineMap.ContainsKey($checkId)) {
+                $current = $currentMap[$checkId]
+                $driftResults.Add([PSCustomObject]@{
+                    CheckId        = $checkId
+                    Setting        = $current.Setting
+                    Category       = $current.Category
+                    Section        = $current._Section
+                    ChangeType     = 'SchemaNew'
+                    PreviousStatus = ''
+                    CurrentStatus  = $current.Status
+                    PreviousValue  = ''
+                    CurrentValue   = $current.CurrentValue
+                })
+            }
+        }
+        # Schema removals: in baseline but not in current registry
+        foreach ($checkId in $baselineMap.Keys) {
+            if (-not $currentMap.ContainsKey($checkId)) {
+                $baseline = $baselineMap[$checkId]
+                $driftResults.Add([PSCustomObject]@{
+                    CheckId        = $checkId
+                    Setting        = $baseline.Setting
+                    Category       = $baseline.Category
+                    Section        = ''
+                    ChangeType     = 'SchemaRemoved'
+                    PreviousStatus = $baseline.Status
+                    CurrentStatus  = ''
+                    PreviousValue  = $baseline.CurrentValue
+                    CurrentValue   = ''
+                })
+            }
+        }
+    }
+    else {
+        # Same-version mode: removed checks are policy drift
+        foreach ($checkId in $baselineMap.Keys) {
+            if (-not $currentMap.ContainsKey($checkId)) {
+                $baseline = $baselineMap[$checkId]
+                $driftResults.Add([PSCustomObject]@{
+                    CheckId        = $checkId
+                    Setting        = $baseline.Setting
+                    Category       = $baseline.Category
+                    Section        = ''
+                    ChangeType     = 'Removed'
+                    PreviousStatus = $baseline.Status
+                    CurrentStatus  = ''
+                    PreviousValue  = $baseline.CurrentValue
+                    CurrentValue   = ''
+                })
+            }
         }
     }
 

--- a/src/M365-Assess/Orchestrator/Compare-M365Baseline.ps1
+++ b/src/M365-Assess/Orchestrator/Compare-M365Baseline.ps1
@@ -1,0 +1,274 @@
+function Compare-M365Baseline {
+    <#
+    .SYNOPSIS
+        Compares two saved baseline snapshots to produce a drift report without re-running an assessment.
+    .DESCRIPTION
+        Reads the security-config JSON files from two saved baseline folders and produces
+        a drift HTML report showing Improved, Regressed, Modified, New, and Removed checks
+        between the two points in time.
+
+        When -BaselineB is omitted the most recent saved baseline for the tenant is used as
+        the "current" reference, allowing you to compare any historical baseline against the
+        closest subsequent one.
+    .PARAMETER BaselineA
+        Label of the earlier (reference) baseline to compare from.
+    .PARAMETER BaselineB
+        Label of the later baseline to compare to. Defaults to the most recent saved baseline
+        for the tenant.
+    .PARAMETER TenantId
+        Tenant identifier used to locate the baseline folders under
+        <OutputFolder>/Baselines/<Label>_<TenantId>/.
+    .PARAMETER OutputFolder
+        Root output folder (parent of Baselines/). Defaults to the current directory.
+    .PARAMETER OutputPath
+        Path for the generated HTML report. Defaults to _Drift-<BaselineA>-vs-<BaselineB>.html
+        in the OutputFolder.
+    .EXAMPLE
+        PS> Compare-M365Baseline -BaselineA 'Q1-2026' -BaselineB 'Q2-2026' -TenantId 'contoso.com'
+
+        Generates a drift report between two quarterly baselines.
+    .EXAMPLE
+        PS> Compare-M365Baseline -BaselineA 'Q1-2026' -TenantId 'contoso.com'
+
+        Compares Q1-2026 against the most recent other saved baseline for the tenant.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$BaselineA,
+
+        [Parameter()]
+        [string]$BaselineB,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$TenantId,
+
+        [Parameter()]
+        [string]$OutputFolder = '.',
+
+        [Parameter()]
+        [string]$OutputPath
+    )
+
+    $safeTenant = $TenantId -replace '[^\w\.\-]', '_'
+    $safeA = $BaselineA -replace '[^\w\-]', '_'
+    $baselinesRoot = Join-Path -Path $OutputFolder -ChildPath 'Baselines'
+
+    $folderA = Join-Path -Path $baselinesRoot -ChildPath "${safeA}_${safeTenant}"
+    if (-not (Test-Path -Path $folderA -PathType Container)) {
+        Write-Error "Baseline '$BaselineA' not found at '$folderA'"
+        return
+    }
+
+    # Resolve BaselineB: explicit label, or most recent other baseline for tenant
+    if ($BaselineB) {
+        $safeB = $BaselineB -replace '[^\w\-]', '_'
+        $folderB = Join-Path -Path $baselinesRoot -ChildPath "${safeB}_${safeTenant}"
+        if (-not (Test-Path -Path $folderB -PathType Container)) {
+            Write-Error "Baseline '$BaselineB' not found at '$folderB'"
+            return
+        }
+        $labelB = $BaselineB
+    }
+    else {
+        $otherFolders = Get-ChildItem -Path $baselinesRoot -Directory -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -like "*_${safeTenant}" -and $_.Name -ne "${safeA}_${safeTenant}" } |
+            Sort-Object LastWriteTime -Descending
+        if (-not $otherFolders) {
+            Write-Error "No other baselines found for tenant '$TenantId' to compare against."
+            return
+        }
+        $folderB = $otherFolders[0].FullName
+        $labelB  = $otherFolders[0].Name -replace "_${safeTenant}$", ''
+    }
+
+    # Read manifest version info for cross-version detection
+    $regVersionA = ''
+    $regVersionB = ''
+    $timestampA  = ''
+    $timestampB  = ''
+    foreach ($info in @(
+        @{ Folder = $folderA; VersionRef = [ref]$regVersionA; TsRef = [ref]$timestampA }
+        @{ Folder = $folderB; VersionRef = [ref]$regVersionB; TsRef = [ref]$timestampB }
+    )) {
+        $mPath = Join-Path -Path $info.Folder -ChildPath 'manifest.json'
+        if (Test-Path -Path $mPath) {
+            try {
+                $m = Get-Content -Path $mPath -Raw | ConvertFrom-Json
+                $info.VersionRef.Value = $m.RegistryVersion
+                $info.TsRef.Value     = $m.SavedAt
+            }
+            catch { Write-Verbose "Compare-M365Baseline: could not read manifest at '$mPath': $_" }
+        }
+    }
+
+    $crossVersion = $regVersionA -and $regVersionB -and ($regVersionA -ne $regVersionB)
+
+    # Build check maps from baseline JSON files
+    $mapA = @{}
+    $mapB = @{}
+    foreach ($pair in @(
+        @{ Folder = $folderA; Map = [ref]$mapA }
+        @{ Folder = $folderB; Map = [ref]$mapB }
+    )) {
+        Get-ChildItem -Path $pair.Folder -Filter '*.json' -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -ne 'manifest.json' } |
+            ForEach-Object {
+                try {
+                    $rows = Get-Content -Path $_.FullName -Raw -ErrorAction Stop | ConvertFrom-Json
+                    foreach ($row in $rows) {
+                        if ($row.CheckId) { $pair.Map.Value[$row.CheckId] = $row }
+                    }
+                }
+                catch { Write-Warning "Could not load '$($_.Name)': $_" }
+            }
+    }
+
+    $sharedIds = if ($crossVersion) {
+        $mapB.Keys | Where-Object { $mapA.ContainsKey($_) }
+    } else {
+        $mapB.Keys
+    }
+
+    $passStatuses = @('Pass')
+    $failStatuses = @('Fail', 'Warning')
+    $driftResults = [System.Collections.Generic.List[PSCustomObject]]::new()
+
+    foreach ($checkId in $sharedIds) {
+        $current  = $mapB[$checkId]
+        $baseline = $mapA[$checkId]
+
+        if (-not $baseline) {
+            $driftResults.Add([PSCustomObject]@{
+                CheckId        = $checkId
+                Setting        = $current.Setting
+                Category       = $current.Category
+                Section        = ''
+                ChangeType     = 'New'
+                PreviousStatus = ''
+                CurrentStatus  = $current.Status
+                PreviousValue  = ''
+                CurrentValue   = $current.CurrentValue
+            })
+            continue
+        }
+
+        if ($baseline.Status -eq $current.Status -and $baseline.CurrentValue -eq $current.CurrentValue) {
+            continue
+        }
+
+        $changeType = if ($baseline.Status -in $failStatuses -and $current.Status -in $passStatuses) {
+            'Improved'
+        } elseif ($baseline.Status -in $passStatuses -and $current.Status -in $failStatuses) {
+            'Regressed'
+        } else {
+            'Modified'
+        }
+
+        $driftResults.Add([PSCustomObject]@{
+            CheckId        = $checkId
+            Setting        = $current.Setting
+            Category       = $current.Category
+            Section        = ''
+            ChangeType     = $changeType
+            PreviousStatus = $baseline.Status
+            CurrentStatus  = $current.Status
+            PreviousValue  = $baseline.CurrentValue
+            CurrentValue   = $current.CurrentValue
+        })
+    }
+
+    if ($crossVersion) {
+        foreach ($checkId in $mapB.Keys) {
+            if (-not $mapA.ContainsKey($checkId)) {
+                $row = $mapB[$checkId]
+                $driftResults.Add([PSCustomObject]@{
+                    CheckId        = $checkId
+                    Setting        = $row.Setting
+                    Category       = $row.Category
+                    Section        = ''
+                    ChangeType     = 'SchemaNew'
+                    PreviousStatus = ''
+                    CurrentStatus  = $row.Status
+                    PreviousValue  = ''
+                    CurrentValue   = $row.CurrentValue
+                })
+            }
+        }
+        foreach ($checkId in $mapA.Keys) {
+            if (-not $mapB.ContainsKey($checkId)) {
+                $row = $mapA[$checkId]
+                $driftResults.Add([PSCustomObject]@{
+                    CheckId        = $checkId
+                    Setting        = $row.Setting
+                    Category       = $row.Category
+                    Section        = ''
+                    ChangeType     = 'SchemaRemoved'
+                    PreviousStatus = $row.Status
+                    CurrentStatus  = ''
+                    PreviousValue  = $row.CurrentValue
+                    CurrentValue   = ''
+                })
+            }
+        }
+    }
+    else {
+        foreach ($checkId in $mapA.Keys) {
+            if (-not $mapB.ContainsKey($checkId)) {
+                $row = $mapA[$checkId]
+                $driftResults.Add([PSCustomObject]@{
+                    CheckId        = $checkId
+                    Setting        = $row.Setting
+                    Category       = $row.Category
+                    Section        = ''
+                    ChangeType     = 'Removed'
+                    PreviousStatus = $row.Status
+                    CurrentStatus  = ''
+                    PreviousValue  = $row.CurrentValue
+                    CurrentValue   = ''
+                })
+            }
+        }
+    }
+
+    # Build and write drift HTML
+    $commonDir = Join-Path -Path $PSScriptRoot -ChildPath '..\Common'
+    if (-not (Get-Command -Name Build-DriftHtml -ErrorAction SilentlyContinue)) {
+        . (Join-Path -Path $commonDir -ChildPath 'Build-DriftHtml.ps1')
+    }
+
+    $driftHtmlFragment = Build-DriftHtml `
+        -DriftReport @($driftResults) `
+        -BaselineLabel $BaselineA `
+        -BaselineTimestamp $timestampA
+
+    if (-not $OutputPath) {
+        $safeLabelB = $labelB -replace '[^\w\-]', '_'
+        $OutputPath = Join-Path -Path $OutputFolder -ChildPath "_Drift-${safeA}-vs-${safeLabelB}.html"
+    }
+
+    # Wrap in a minimal standalone HTML page
+    $html = @"
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Drift: $BaselineA vs $labelB</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; margin: 0; padding: 20px; background: #f8fafc; color: #1e293b; }
+  h1 { font-size: 1.4em; margin-bottom: 4px; }
+  .meta { font-size: 0.85em; color: #64748b; margin-bottom: 20px; }
+</style>
+</head>
+<body>
+<h1>Policy Drift: $BaselineA &rarr; $labelB</h1>
+<div class="meta">Tenant: $TenantId &nbsp;|&nbsp; $($driftResults.Count) changes detected</div>
+$driftHtmlFragment
+</body>
+</html>
+"@
+
+    Set-Content -Path $OutputPath -Value $html -Encoding UTF8
+    Write-Output "Drift report generated: $OutputPath ($($driftResults.Count) changes)"
+}

--- a/src/M365-Assess/Orchestrator/Export-AssessmentBaseline.ps1
+++ b/src/M365-Assess/Orchestrator/Export-AssessmentBaseline.ps1
@@ -21,7 +21,10 @@ function Export-AssessmentBaseline {
     .PARAMETER Sections
         Array of section names that were assessed (recorded in metadata).
     .PARAMETER Version
-        Assessment version string recorded in metadata for schema compatibility.
+        Assessment module version string (e.g. '1.15.0') recorded in metadata.
+    .PARAMETER RegistryVersion
+        Registry data version string (from controls/registry.json dataVersion)
+        recorded in metadata to enable version-aware drift comparison.
     .EXAMPLE
         Export-AssessmentBaseline -AssessmentFolder $assessmentFolder `
             -OutputFolder '.\M365-Assessment' -Label 'Q1-2026' -TenantId 'contoso.com'
@@ -49,7 +52,10 @@ function Export-AssessmentBaseline {
         [string[]]$Sections = @(),
 
         [Parameter()]
-        [string]$Version = ''
+        [string]$Version = '',
+
+        [Parameter()]
+        [string]$RegistryVersion = ''
     )
 
     # Sanitise label for use as a folder name
@@ -61,22 +67,12 @@ function Export-AssessmentBaseline {
         $null = New-Item -Path $baselineDir -ItemType Directory -Force
     }
 
-    # Write metadata
-    $metadata = [PSCustomObject]@{
-        label     = $Label
-        tenant    = $TenantId
-        timestamp = (Get-Date -Format 'o')
-        version   = $Version
-        sections  = $Sections
-    }
-    $metaPath = Join-Path -Path $baselineDir -ChildPath '_baseline-metadata.json'
-    $metadata | ConvertTo-Json -Depth 5 | Set-Content -Path $metaPath -Encoding UTF8
-
     # Copy each security-config CSV as JSON (identified by having CheckId + Status columns)
     $csvFiles = Get-ChildItem -Path $AssessmentFolder -Filter '*.csv' -ErrorAction SilentlyContinue |
         Where-Object { $_.Name -notlike '_*' }
 
     $saved = 0
+    $checkCount = 0
     foreach ($csvFile in $csvFiles) {
         try {
             $rows = Import-Csv -Path $csvFile.FullName -ErrorAction Stop
@@ -89,6 +85,7 @@ function Export-AssessmentBaseline {
             $jsonName = [System.IO.Path]::GetFileNameWithoutExtension($csvFile.Name) + '.json'
             $jsonPath = Join-Path -Path $baselineDir -ChildPath $jsonName
             $rows | ConvertTo-Json -Depth 5 | Set-Content -Path $jsonPath -Encoding UTF8
+            $checkCount += @($rows).Count
             $saved++
         }
         catch {
@@ -96,6 +93,19 @@ function Export-AssessmentBaseline {
         }
     }
 
-    Write-Verbose "Baseline '$Label' saved to '$baselineDir' ($saved collector files)"
+    # Write manifest after CSV scan (includes accurate CheckCount)
+    $manifest = [PSCustomObject]@{
+        Label             = $Label
+        SavedAt           = (Get-Date -Format 'o')
+        TenantId          = $TenantId
+        AssessmentVersion = $Version
+        RegistryVersion   = $RegistryVersion
+        CheckCount        = $checkCount
+        Sections          = $Sections
+    }
+    $manifestPath = Join-Path -Path $baselineDir -ChildPath 'manifest.json'
+    $manifest | ConvertTo-Json -Depth 5 | Set-Content -Path $manifestPath -Encoding UTF8
+
+    Write-Verbose "Baseline '$Label' saved to '$baselineDir' ($saved collector files, $checkCount checks)"
     return $baselineDir
 }

--- a/src/M365-Assess/Orchestrator/Show-InteractiveWizard.ps1
+++ b/src/M365-Assess/Orchestrator/Show-InteractiveWizard.ps1
@@ -311,32 +311,9 @@ function Show-InteractiveWizard {
     # ================================================================
     $currentStep++
     $reportOptions = [ordered]@{
-        '1' = @{ Name = 'ComplianceOverview'; Label = 'Compliance Overview';  Selected = $true }
-        '2' = @{ Name = 'CoverPage';          Label = 'Cover Page';           Selected = $true }
-        '3' = @{ Name = 'ExecutiveSummary';    Label = 'Executive Summary';    Selected = $true }
-        '4' = @{ Name = 'NoBranding';          Label = 'Remove Branding';      Selected = $false }
-        '5' = @{ Name = 'LimitFrameworks';     Label = 'Limit Frameworks';     Selected = $false }
-        '6' = @{ Name = 'QuickScan';           Label = 'Quick Scan (Critical + High only)'; Selected = $false }
+        '1' = @{ Name = 'CompactReport'; Label = 'Compact Report (no cover page, executive summary, or compliance overview)'; Selected = $false }
+        '2' = @{ Name = 'QuickScan';     Label = 'Quick Scan (Critical + High findings only)'; Selected = $false }
     }
-    $wizFrameworkFilter = @()
-
-    # Framework family definitions for the sub-selector
-    $fwFamilies = [ordered]@{
-        '1'  = @{ Family = 'CIS';       Label = 'CIS Benchmarks';                    Selected = $true }
-        '2'  = @{ Family = 'NIST';      Label = 'NIST 800-53 / CSF';                 Selected = $true }
-        '3'  = @{ Family = 'ISO';       Label = 'ISO 27001:2022';                    Selected = $true }
-        '4'  = @{ Family = 'STIG';      Label = 'DISA STIG';                         Selected = $true }
-        '5'  = @{ Family = 'PCI';       Label = 'PCI DSS v4';                        Selected = $true }
-        '6'  = @{ Family = 'CMMC';      Label = 'CMMC 2.0';                          Selected = $true }
-        '7'  = @{ Family = 'HIPAA';     Label = 'HIPAA Security Rule';               Selected = $true }
-        '8'  = @{ Family = 'CISA';      Label = 'CISA SCuBA';                        Selected = $true }
-        '9'  = @{ Family = 'SOC2';      Label = 'SOC 2 TSC';                         Selected = $true }
-        '10' = @{ Family = 'FedRAMP';   Label = 'FedRAMP';                           Selected = $true }
-        '11' = @{ Family = 'Essential8'; Label = 'Essential Eight';                   Selected = $true }
-        '12' = @{ Family = 'MITRE';     Label = 'MITRE ATT&CK';                      Selected = $true }
-        '13' = @{ Family = 'CISv8';     Label = 'CIS Controls v8';                   Selected = $true }
-    }
-    $fwTotalCount = $fwFamilies.Count
 
     $reportStepDone = $false
     while (-not $reportStepDone) {
@@ -350,17 +327,7 @@ function Show-InteractiveWizard {
             $opt = $reportOptions[$key]
             $marker = if ($opt.Selected) { [char]0x25CF } else { [char]0x25CB }
             $color = if ($opt.Selected) { $cNormal } else { $cMuted }
-            $extra = ''
-            if ($opt.Name -eq 'LimitFrameworks') {
-                if ($opt.Selected) {
-                    $selectedCount = @($fwFamilies.Values | Where-Object { $_.Selected }).Count
-                    $extra = "  ($selectedCount of $fwTotalCount selected)"
-                }
-                else {
-                    $extra = "  (showing all $fwTotalCount)"
-                }
-            }
-            Write-Host "  [$key] $marker $($opt.Label)$extra" -ForegroundColor $color
+            Write-Host "  [$key] $marker $($opt.Label)" -ForegroundColor $color
         }
 
         Write-Host ''
@@ -375,68 +342,6 @@ function Show-InteractiveWizard {
                     $num = 0
                     if ($token -ne '' -and [int]::TryParse($token, [ref]$num) -and $reportOptions.Contains("$num")) {
                         $reportOptions["$num"].Selected = -not $reportOptions["$num"].Selected
-                        # When Limit Frameworks is toggled on, enter the framework sub-selector
-                        if ($num -eq 5 -and $reportOptions['5'].Selected) {
-                            $fwSubDone = $false
-                            while (-not $fwSubDone) {
-                                Show-Header
-                                Show-StepHeader -Step $currentStep -Total $totalSteps -Title 'Report Options > Frameworks'
-                                Write-Host '  Toggle frameworks by number. Press ENTER when done.' -ForegroundColor $cNormal
-                                Write-Host ''
-
-                                foreach ($fwKey in $fwFamilies.Keys) {
-                                    $fw = $fwFamilies[$fwKey]
-                                    $fwMarker = if ($fw.Selected) { [char]0x25CF } else { [char]0x25CB }
-                                    $fwColor = if ($fw.Selected) { $cNormal } else { $cMuted }
-                                    $pad = if ([int]$fwKey -lt 10) { ' ' } else { '' }
-                                    Write-Host "  $pad[$fwKey] $fwMarker $($fw.Label)" -ForegroundColor $fwColor
-                                }
-
-                                Write-Host ''
-                                Write-Host '  [A] Select all    [N] Select none' -ForegroundColor $cPrompt
-                                Write-Host ''
-                                Write-Host '  > ' -ForegroundColor $cPrompt -NoNewline
-                                $fwChoice = (Read-Host) ?? ''
-
-                                switch ($fwChoice.Trim().ToUpper()) {
-                                    '' { $fwSubDone = $true }
-                                    'A' {
-                                        foreach ($k in @($fwFamilies.Keys)) { $fwFamilies[$k].Selected = $true }
-                                    }
-                                    'N' {
-                                        foreach ($k in @($fwFamilies.Keys)) { $fwFamilies[$k].Selected = $false }
-                                    }
-                                    default {
-                                        $fwTokens = $fwChoice.Trim() -split '[,\s]+'
-                                        foreach ($fwToken in $fwTokens) {
-                                            $fwNum = 0
-                                            if ($fwToken -ne '' -and [int]::TryParse($fwToken, [ref]$fwNum) -and $fwFamilies.Contains("$fwNum")) {
-                                                $fwFamilies["$fwNum"].Selected = -not $fwFamilies["$fwNum"].Selected
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-
-                            # Build the filter list from selected families
-                            $wizFrameworkFilter = @($fwFamilies.Values | Where-Object { $_.Selected } | ForEach-Object { $_.Family })
-                            # If all are selected, clear the filter (no filtering needed)
-                            if ($wizFrameworkFilter.Count -eq $fwTotalCount) {
-                                $reportOptions['5'].Selected = $false
-                                $wizFrameworkFilter = @()
-                            }
-                            elseif ($wizFrameworkFilter.Count -eq 0) {
-                                Write-Host ''
-                                Write-Host '  At least one framework must be selected. Filter disabled.' -ForegroundColor $cError
-                                $reportOptions['5'].Selected = $false
-                                Start-Sleep -Seconds $errorDisplayDelay
-                            }
-                        }
-                        # When toggled off, reset all families to selected
-                        elseif ($num -eq 5 -and -not $reportOptions['5'].Selected) {
-                            $wizFrameworkFilter = @()
-                            foreach ($k in @($fwFamilies.Keys)) { $fwFamilies[$k].Selected = $true }
-                        }
                     }
                 }
             }
@@ -473,23 +378,11 @@ function Show-InteractiveWizard {
     Write-Host "    Output:    $wizOutputFolder\" -ForegroundColor $cNormal
 
     # Report options summary
-    $reportIncludes = @()
-    if ($reportOptions['1'].Selected) { $reportIncludes += 'Compliance Overview' }
-    if ($reportOptions['2'].Selected) { $reportIncludes += 'Cover Page' }
-    if ($reportOptions['3'].Selected) { $reportIncludes += 'Executive Summary' }
-    $reportExcludes = @()
-    if (-not $reportOptions['1'].Selected) { $reportExcludes += 'Compliance Overview' }
-    if (-not $reportOptions['2'].Selected) { $reportExcludes += 'Cover Page' }
-    if (-not $reportOptions['3'].Selected) { $reportExcludes += 'Executive Summary' }
-    if ($reportOptions['4'].Selected) { $reportExcludes += 'Branding' }
-    $reportDisplay = if ($reportIncludes.Count -eq 3 -and $reportExcludes.Count -eq 0) { 'All sections, branded' } else { $reportIncludes -join ', ' }
+    $reportModes = @()
+    if ($reportOptions['1'].Selected) { $reportModes += 'Compact' }
+    if ($reportOptions['2'].Selected) { $reportModes += 'Quick Scan' }
+    $reportDisplay = if ($reportModes.Count -gt 0) { $reportModes -join ', ' } else { 'Full report' }
     Write-Host "    Report:    $reportDisplay" -ForegroundColor $cNormal
-    if ($reportExcludes.Count -gt 0) {
-        Write-Host "    Skipping:  $($reportExcludes -join ', ')" -ForegroundColor $cMuted
-    }
-    if ($wizFrameworkFilter.Count -gt 0) {
-        Write-Host "    Frameworks: $($wizFrameworkFilter -join ', ') ($($wizFrameworkFilter.Count) of $fwTotalCount)" -ForegroundColor $cNormal
-    }
     Write-Host ''
     Write-Host '  Press ENTER to begin, or Q to quit.' -ForegroundColor $cPrompt
     Write-Host '  > ' -ForegroundColor $cPrompt -NoNewline
@@ -508,12 +401,8 @@ function Show-InteractiveWizard {
     }
 
     # Report options
-    if (-not $reportOptions['1'].Selected) { $wizardResult['SkipComplianceOverview'] = $true }
-    if (-not $reportOptions['2'].Selected) { $wizardResult['SkipCoverPage'] = $true }
-    if (-not $reportOptions['3'].Selected) { $wizardResult['SkipExecutiveSummary'] = $true }
-    if ($reportOptions['4'].Selected) { $wizardResult['NoBranding'] = $true }
-    if ($wizFrameworkFilter.Count -gt 0) { $wizardResult['FrameworkFilter'] = $wizFrameworkFilter }
-    if ($reportOptions['6'].Selected) { $wizardResult['QuickScan'] = $true }
+    if ($reportOptions['1'].Selected) { $wizardResult['CompactReport'] = $true }
+    if ($reportOptions['2'].Selected) { $wizardResult['QuickScan'] = $true }
 
     if ($wizConnectionProfile) {
         $wizardResult['ConnectionProfile'] = $wizConnectionProfile

--- a/tests/Common/Build-RemediationPlanHtml.Tests.ps1
+++ b/tests/Common/Build-RemediationPlanHtml.Tests.ps1
@@ -13,7 +13,7 @@ Describe 'Build-RemediationPlanHtml' {
         # Build-SectionHtml.ps1 sets variables AND defines Build-RemediationPlanHtml.
         # Stub the variables the script-body references so it does not fail.
         $allCisFindings         = @()
-        $SkipComplianceOverview = $false
+        $CompactReport          = $false
         $controlRegistry        = @{}
         $issues                 = @()
         $sections               = @()

--- a/tests/Common/Export-AssessmentReport.Tests.ps1
+++ b/tests/Common/Export-AssessmentReport.Tests.ps1
@@ -401,25 +401,17 @@ Describe 'QuickScan triage report auto-apply' {
         $templateSrc = Get-Content -Path "$PSScriptRoot/../../src/M365-Assess/Common/Get-ReportTemplate.ps1" -Raw
     }
 
-    Context 'Orchestrator auto-applies skip flags for QuickScan' {
-        It 'Should contain the QuickScan auto-apply block' {
-            $orchestratorSrc | Should -Match 'if \(\$QuickScan\)[\s\S]*?SkipCoverPage'
+    Context 'Orchestrator auto-applies CompactReport for QuickScan' {
+        It 'Should contain the QuickScan CompactReport auto-apply block' {
+            $orchestratorSrc | Should -Match 'if \(\$QuickScan\)[\s\S]*?CompactReport'
         }
 
-        It 'Should guard SkipCoverPage with PSBoundParameters check' {
-            $orchestratorSrc | Should -Match "PSBoundParameters\.ContainsKey\('SkipCoverPage'\)"
+        It 'Should guard CompactReport with PSBoundParameters check' {
+            $orchestratorSrc | Should -Match "PSBoundParameters\.ContainsKey\('CompactReport'\)"
         }
 
-        It 'Should guard SkipExecutiveSummary with PSBoundParameters check' {
-            $orchestratorSrc | Should -Match "PSBoundParameters\.ContainsKey\('SkipExecutiveSummary'\)"
-        }
-
-        It 'Should guard SkipComplianceOverview with PSBoundParameters check' {
-            $orchestratorSrc | Should -Match "PSBoundParameters\.ContainsKey\('SkipComplianceOverview'\)"
-        }
-
-        It 'Should document triage report behaviour in QuickScan parameter help' {
-            $orchestratorSrc | Should -Match 'compact.*triage|triage.*report|omits.*cover|cover page.*omit'
+        It 'Should document CompactReport behaviour in QuickScan parameter help' {
+            $orchestratorSrc | Should -Match 'compact.*report|CompactReport|omits.*cover|data.only'
         }
     }
 

--- a/tests/Entra/Get-EntraAdminRoleSeparationConfig.Tests.ps1
+++ b/tests/Entra/Get-EntraAdminRoleSeparationConfig.Tests.ps1
@@ -131,6 +131,42 @@ Describe 'Get-EntraAdminRoleSeparationConfig - No Role Assignments' {
     }
 }
 
+Describe 'Get-EntraAdminRoleSeparationConfig - One Role Returns 404' {
+    BeforeAll {
+        function global:Update-CheckProgress { param($CheckId, $Setting, $Status) }
+
+        # First role throws 404; remaining roles return a valid assignment
+        $script:callCount = 0
+        Mock Invoke-MgGraphRequest {
+            param($Method, $Uri, $ErrorAction)
+            if ($Uri -match 'roleAssignments') {
+                $script:callCount++
+                if ($script:callCount -eq 1) { throw '404 ResourceNotFound - role not present' }
+                return @{ value = @(@{ principalId = 'admin-ok' }) }
+            }
+            # licenseDetails — no Exchange plans
+            return @{ value = @(@{ servicePlans = @(@{ servicePlanId = 'other-plan' }) }) }
+        }
+
+        . "$PSScriptRoot/../../src/M365-Assess/Orchestrator/AssessmentHelpers.ps1"
+        . "$PSScriptRoot/../../src/M365-Assess/Entra/Get-EntraAdminRoleSeparationConfig.ps1"
+    }
+
+    It 'should still produce a result despite the 404 on one role' {
+        $check = $settings | Where-Object { $_.CheckId -like 'ENTRA-ADMINROLE-SEPARATION-001*' }
+        $check | Should -Not -BeNullOrEmpty
+    }
+
+    It 'should return Pass when the remaining admins have no Exchange plans' {
+        $check = $settings | Where-Object { $_.CheckId -like 'ENTRA-ADMINROLE-SEPARATION-001*' }
+        $check.Status | Should -Be 'Pass'
+    }
+
+    AfterAll {
+        Remove-Item Function:\Update-CheckProgress -ErrorAction SilentlyContinue
+    }
+}
+
 Describe 'Get-EntraAdminRoleSeparationConfig - Forbidden' {
     BeforeAll {
         function global:Update-CheckProgress { param($CheckId, $Setting, $Status) }

--- a/tests/Entra/Get-EntraAdminRoleSeparationConfig.Tests.ps1
+++ b/tests/Entra/Get-EntraAdminRoleSeparationConfig.Tests.ps1
@@ -141,7 +141,7 @@ Describe 'Get-EntraAdminRoleSeparationConfig - One Role Returns 404' {
             param($Method, $Uri, $ErrorAction)
             if ($Uri -match 'roleAssignments') {
                 $script:callCount++
-                if ($script:callCount -eq 1) { throw '404 ResourceNotFound - role not present' }
+                if ($script:callCount -eq 1) { throw 'Response status code does not indicate success: 404 (Not Found).' }
                 return @{ value = @(@{ principalId = 'admin-ok' }) }
             }
             # licenseDetails — no Exchange plans

--- a/tests/Orchestrator/Compare-AssessmentBaseline.Tests.ps1
+++ b/tests/Orchestrator/Compare-AssessmentBaseline.Tests.ps1
@@ -16,7 +16,7 @@ Describe 'Compare-AssessmentBaseline' {
 
         # Write baseline metadata (required; excluded from JSON comparison by name filter)
         @{ label = 'Q1-2026'; tenant = 'test'; timestamp = '2026-01-01T00:00:00Z' } |
-            ConvertTo-Json | Set-Content -Path (Join-Path -Path $script:baselineFolder -ChildPath '_baseline-metadata.json') -Encoding UTF8
+            ConvertTo-Json | Set-Content -Path (Join-Path -Path $script:baselineFolder -ChildPath 'manifest.json') -Encoding UTF8
     }
 
     Context 'when baseline folder does not exist' {
@@ -61,7 +61,7 @@ Describe 'Compare-AssessmentBaseline' {
             $null = New-Item -Path $currentDir  -ItemType Directory -Force
 
             @{ label = 'test' } | ConvertTo-Json |
-                Set-Content -Path (Join-Path -Path $baselineDir -ChildPath '_baseline-metadata.json') -Encoding UTF8
+                Set-Content -Path (Join-Path -Path $baselineDir -ChildPath 'manifest.json') -Encoding UTF8
 
             @(
                 [PSCustomObject]@{ CheckId = 'ENTRA-CA-001'; Setting = 'CA policy'; Status = 'Fail'; CurrentValue = 'Disabled'; Category = 'Access' }
@@ -91,7 +91,7 @@ Describe 'Compare-AssessmentBaseline' {
             $null = New-Item -Path $currentDir  -ItemType Directory -Force
 
             @{ label = 'test' } | ConvertTo-Json |
-                Set-Content -Path (Join-Path -Path $baselineDir -ChildPath '_baseline-metadata.json') -Encoding UTF8
+                Set-Content -Path (Join-Path -Path $baselineDir -ChildPath 'manifest.json') -Encoding UTF8
 
             # Baseline has no matching check
             @(
@@ -123,7 +123,7 @@ Describe 'Compare-AssessmentBaseline' {
             $null = New-Item -Path $currentDir  -ItemType Directory -Force
 
             @{ label = 'test' } | ConvertTo-Json |
-                Set-Content -Path (Join-Path -Path $baselineDir -ChildPath '_baseline-metadata.json') -Encoding UTF8
+                Set-Content -Path (Join-Path -Path $baselineDir -ChildPath 'manifest.json') -Encoding UTF8
 
             @(
                 [PSCustomObject]@{ CheckId = 'ENTRA-GONE-001'; Setting = 'Removed check'; Status = 'Pass'; CurrentValue = 'Yes'; Category = 'Identity' }
@@ -153,7 +153,7 @@ Describe 'Compare-AssessmentBaseline' {
             $null = New-Item -Path $currentDir  -ItemType Directory -Force
 
             @{ label = 'test' } | ConvertTo-Json |
-                Set-Content -Path (Join-Path -Path $baselineDir -ChildPath '_baseline-metadata.json') -Encoding UTF8
+                Set-Content -Path (Join-Path -Path $baselineDir -ChildPath 'manifest.json') -Encoding UTF8
 
             @(
                 [PSCustomObject]@{ CheckId = 'EXO-SPF-001'; Setting = 'SPF record'; Status = 'Pass'; CurrentValue = 'v=spf1 include:old.com ~all'; Category = 'Email' }
@@ -183,7 +183,7 @@ Describe 'Compare-AssessmentBaseline' {
             $null = New-Item -Path $currentDir  -ItemType Directory -Force
 
             @{ label = 'test' } | ConvertTo-Json |
-                Set-Content -Path (Join-Path -Path $baselineDir -ChildPath '_baseline-metadata.json') -Encoding UTF8
+                Set-Content -Path (Join-Path -Path $baselineDir -ChildPath 'manifest.json') -Encoding UTF8
 
             @(
                 [PSCustomObject]@{ CheckId = 'ENTRA-PIM-001'; Setting = 'PIM'; Status = 'Pass'; CurrentValue = 'Enabled'; Category = 'Identity' }
@@ -209,7 +209,7 @@ Describe 'Compare-AssessmentBaseline' {
             $null = New-Item -Path $currentDir  -ItemType Directory -Force
 
             @{ label = 'test' } | ConvertTo-Json |
-                Set-Content -Path (Join-Path -Path $baselineDir -ChildPath '_baseline-metadata.json') -Encoding UTF8
+                Set-Content -Path (Join-Path -Path $baselineDir -ChildPath 'manifest.json') -Encoding UTF8
 
             @(
                 [PSCustomObject]@{ CheckId = 'EXO-DKIM-001'; Setting = 'DKIM'; Status = 'Pass'; CurrentValue = 'Enabled'; Category = 'Email' }

--- a/tests/Orchestrator/Export-AssessmentBaseline.Tests.ps1
+++ b/tests/Orchestrator/Export-AssessmentBaseline.Tests.ps1
@@ -47,19 +47,20 @@ Describe 'Export-AssessmentBaseline' {
             Test-Path -Path $script:result -PathType Container | Should -Be $true
         }
 
-        It 'should write a metadata file' {
-            $metaPath = Join-Path -Path $script:result -ChildPath '_baseline-metadata.json'
+        It 'should write a manifest file' {
+            $metaPath = Join-Path -Path $script:result -ChildPath 'manifest.json'
             Test-Path -Path $metaPath | Should -Be $true
         }
 
-        It 'should write correct metadata fields' {
-            $metaPath = Join-Path -Path $script:result -ChildPath '_baseline-metadata.json'
+        It 'should write correct manifest fields' {
+            $metaPath = Join-Path -Path $script:result -ChildPath 'manifest.json'
             $meta = Get-Content -Path $metaPath -Raw | ConvertFrom-Json
-            $meta.label   | Should -Be 'Q1-2026'
-            $meta.tenant  | Should -Be 'contoso.com'
-            $meta.version | Should -Be '1.11.0'
-            $meta.sections | Should -Contain 'Entra'
-            $meta.timestamp | Should -Not -BeNullOrEmpty
+            $meta.Label             | Should -Be 'Q1-2026'
+            $meta.TenantId          | Should -Be 'contoso.com'
+            $meta.AssessmentVersion | Should -Be '1.11.0'
+            $meta.Sections          | Should -Contain 'Entra'
+            $meta.SavedAt           | Should -Not -BeNullOrEmpty
+            $meta.CheckCount        | Should -BeGreaterOrEqual 0
         }
 
         It 'should serialize the security-config CSV to JSON' {

--- a/tests/Orchestrator/Show-InteractiveWizard.Tests.ps1
+++ b/tests/Orchestrator/Show-InteractiveWizard.Tests.ps1
@@ -187,7 +187,7 @@ Describe 'Show-InteractiveWizard - non-interactive paths' {
         }
     }
 
-    Context 'when report options are toggled to exclude ComplianceOverview' {
+    Context 'when CompactReport is toggled on' {
         BeforeAll {
             $script:readHostCallCount = 0
             Mock Read-Host {
@@ -195,7 +195,7 @@ Describe 'Show-InteractiveWizard - non-interactive paths' {
                 switch ($script:readHostCallCount) {
                     1 { return 'contoso.onmicrosoft.com' }  # Tenant
                     2 { return '4' }                        # Auth: Skip
-                    3 { return '1' }                        # Toggle option 1 (ComplianceOverview off)
+                    3 { return '1' }                        # Toggle option 1 (CompactReport on)
                     4 { return '' }                         # Accept report options
                     5 { return '' }                         # Confirm
                     default { return '' }
@@ -209,9 +209,9 @@ Describe 'Show-InteractiveWizard - non-interactive paths' {
                 -PreSelectedOutputFolder '.\Out'
         }
 
-        It 'should set SkipComplianceOverview when toggled off' {
-            $result.ContainsKey('SkipComplianceOverview') | Should -Be $true
-            $result.SkipComplianceOverview | Should -Be $true
+        It 'should set CompactReport when toggled on' {
+            $result.ContainsKey('CompactReport') | Should -Be $true
+            $result.CompactReport | Should -Be $true
         }
     }
 }


### PR DESCRIPTION
## Summary

- Role assignments can reference service principals or deleted user objects — `/v1.0/users/{id}/licenseDetails` returns 404 for these, aborting the entire collector with "Could not check admin role separation"
- Wraps each per-principal license lookup in a try/catch; 404 is silently skipped with `Write-Verbose`
- Follows same pattern as the per-role 404 fix from #526

## Test Plan
- [ ] All existing tests pass (11/11)
- [ ] Re-run against tenant — "Admin Role Separation" warning gone from issues log

🤖 Generated with [Claude Code](https://claude.com/claude-code)