### PR TITLE
feat(branding): New-M365BrandingConfig helper + suppress Teams 412 noise

### DIFF
--- a/src/M365-Assess/Collaboration/Get-TeamsAccessReport.ps1
+++ b/src/M365-Assess/Collaboration/Get-TeamsAccessReport.ps1
@@ -53,7 +53,12 @@ try {
     $isUserPersonalScopeResourceSpecificConsentEnabled = $teamsAppSettings.isUserPersonalScopeResourceSpecificConsentEnabled
 }
 catch {
-    Write-Warning "Teams app settings (beta) endpoint unavailable. Some settings will be reported as N/A. Error: $_"
+    if ("$_" -match '412|PreconditionFailed|not supported in application-only') {
+        Write-Verbose "Teams app settings beta endpoint unavailable in app-only auth — some settings will be N/A."
+    }
+    else {
+        Write-Warning "Teams app settings (beta) endpoint unavailable. Some settings will be reported as N/A. Error: $_"
+    }
 }
 
 # Retrieve group settings for guest access configuration

--- a/src/M365-Assess/Common/New-M365BrandingConfig.ps1
+++ b/src/M365-Assess/Common/New-M365BrandingConfig.ps1
@@ -1,0 +1,95 @@
+function New-M365BrandingConfig {
+    <#
+    .SYNOPSIS
+        Creates a validated branding hashtable for use with -CustomBranding.
+    .DESCRIPTION
+        Returns a hashtable with tab-completable, validated parameters that can
+        be passed directly to Invoke-M365Assessment -CustomBranding or
+        Export-AssessmentReport -CustomBranding. Logo paths are validated at
+        call time; hex colors are validated for correct format.
+    .PARAMETER CompanyName
+        Your company name, shown in the report header and footer.
+    .PARAMETER LogoPath
+        Path to your company logo (PNG, JPEG, or SVG). Embedded as base64.
+    .PARAMETER ClientLogoPath
+        Path to the client's logo for white-label cover pages.
+    .PARAMETER ClientName
+        Client organisation name shown on the cover page "Prepared For" field.
+    .PARAMETER AccentColor
+        Hex color for the report accent/highlight color (e.g. '#0078D4').
+    .PARAMETER PrimaryColor
+        Hex color for the primary sidebar/header color.
+    .PARAMETER ReportTitle
+        Custom report title shown in the browser tab and report header.
+    .PARAMETER SidebarSubtitle
+        Subtitle shown beneath your company name in the report sidebar.
+    .PARAMETER ReportNote
+        Short note appended to the executive summary section.
+    .PARAMETER Disclaimer
+        Confidentiality disclaimer shown in the report footer.
+    .PARAMETER FooterText
+        Footer text (defaults to "Assessment by <CompanyName>" when WhiteLabel is set).
+    .PARAMETER FooterUrl
+        URL the footer text links to.
+    .EXAMPLE
+        PS> $branding = New-M365BrandingConfig -CompanyName 'Contoso Consulting' -LogoPath './logo.png' -AccentColor '#0078D4'
+        PS> Invoke-M365Assessment -TenantId 'fabrikam.com' -CustomBranding $branding
+
+        Creates a branding config and passes it to an assessment run.
+    .EXAMPLE
+        PS> $branding = New-M365BrandingConfig -CompanyName 'Contoso' -ClientName 'Fabrikam' -ClientLogoPath './client.png'
+        PS> Export-AssessmentReport -AssessmentFolder '.\Assessment_20260418' -CustomBranding $branding
+
+        Re-renders an existing assessment with client-specific branding.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]$CompanyName,
+
+        [Parameter()]
+        [ValidateScript({ -not $_ -or (Test-Path -Path $_ -PathType Leaf) })]
+        [string]$LogoPath,
+
+        [Parameter()]
+        [ValidateScript({ -not $_ -or (Test-Path -Path $_ -PathType Leaf) })]
+        [string]$ClientLogoPath,
+
+        [Parameter()]
+        [string]$ClientName,
+
+        [Parameter()]
+        [ValidatePattern('^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$')]
+        [string]$AccentColor,
+
+        [Parameter()]
+        [ValidatePattern('^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$')]
+        [string]$PrimaryColor,
+
+        [Parameter()]
+        [string]$ReportTitle,
+
+        [Parameter()]
+        [string]$SidebarSubtitle,
+
+        [Parameter()]
+        [string]$ReportNote,
+
+        [Parameter()]
+        [string]$Disclaimer,
+
+        [Parameter()]
+        [string]$FooterText,
+
+        [Parameter()]
+        [string]$FooterUrl
+    )
+
+    $config = @{}
+    foreach ($key in $PSBoundParameters.Keys) {
+        $config[$key] = $PSBoundParameters[$key]
+    }
+    $config
+}

--- a/src/M365-Assess/M365-Assess.psd1
+++ b/src/M365-Assess/M365-Assess.psd1
@@ -51,6 +51,7 @@
         'Remove-M365ConnectionProfile'
         'Get-M365ConnectionProfile'
         'Compare-M365Baseline'
+        'New-M365BrandingConfig'
     )
     CmdletsToExport   = @()
     VariablesToExport = @()
@@ -80,6 +81,7 @@
         'Common\Resolve-DnsRecord.ps1'
         'Common\Resolve-TenantLicenses.ps1'
         'Common\Export-AssessmentReport.ps1'
+        'Common\New-M365BrandingConfig.ps1'
         'Common\ReportHelpers.ps1'
         'Common\Build-SectionHtml.ps1'
         'Common\Get-ReportTemplate.ps1'

--- a/src/M365-Assess/M365-Assess.psm1
+++ b/src/M365-Assess/M365-Assess.psm1
@@ -7,6 +7,7 @@ Get-ChildItem -Path "$PSScriptRoot\Orchestrator\*.ps1" | ForEach-Object { . $_.F
 . "$PSScriptRoot\Common\SecurityConfigHelper.ps1"
 . "$PSScriptRoot\Common\Resolve-DnsRecord.ps1"
 . "$PSScriptRoot\Orchestrator\Compare-M365Baseline.ps1"
+. "$PSScriptRoot\Common\New-M365BrandingConfig.ps1"
 
 # Dot-source the main orchestrator to import Invoke-M365Assessment function
 . $PSScriptRoot\Invoke-M365Assessment.ps1
@@ -211,6 +212,7 @@ Export-ModuleMember -Function @(
     'Get-M365PowerBISecurityConfig'
     'Get-M365PurviewRetentionConfig'
     'Compare-M365Baseline'
+    'New-M365BrandingConfig'
     'Grant-M365AssessConsent'
     'New-M365ConnectionProfile'
     'Set-M365ConnectionProfile'

--- a/tests/Common/New-M365BrandingConfig.Tests.ps1
+++ b/tests/Common/New-M365BrandingConfig.Tests.ps1
@@ -1,0 +1,126 @@
+Describe 'New-M365BrandingConfig' {
+    BeforeAll {
+        . "$PSScriptRoot/../../src/M365-Assess/Common/New-M365BrandingConfig.ps1"
+    }
+
+    Context 'when called with no parameters' {
+        It 'should return an empty hashtable' {
+            $result = New-M365BrandingConfig
+            $result | Should -BeOfType [hashtable]
+            $result.Count | Should -Be 0
+        }
+    }
+
+    Context 'when called with CompanyName only' {
+        It 'should return a hashtable with only CompanyName' {
+            $result = New-M365BrandingConfig -CompanyName 'Contoso Consulting'
+            $result['CompanyName'] | Should -Be 'Contoso Consulting'
+            $result.Count | Should -Be 1
+        }
+    }
+
+    Context 'when called with all string parameters' {
+        It 'should return a hashtable with all supplied keys' {
+            $result = New-M365BrandingConfig `
+                -CompanyName 'Contoso' `
+                -ClientName 'Fabrikam' `
+                -ReportTitle 'Security Assessment' `
+                -SidebarSubtitle 'Prepared by Contoso' `
+                -ReportNote 'Confidential' `
+                -Disclaimer 'This report is confidential.' `
+                -FooterText 'Assessment by Contoso' `
+                -FooterUrl 'https://contoso.com'
+
+            $result['CompanyName']     | Should -Be 'Contoso'
+            $result['ClientName']      | Should -Be 'Fabrikam'
+            $result['ReportTitle']     | Should -Be 'Security Assessment'
+            $result['SidebarSubtitle'] | Should -Be 'Prepared by Contoso'
+            $result['ReportNote']      | Should -Be 'Confidential'
+            $result['Disclaimer']      | Should -Be 'This report is confidential.'
+            $result['FooterText']      | Should -Be 'Assessment by Contoso'
+            $result['FooterUrl']       | Should -Be 'https://contoso.com'
+            $result.Count              | Should -Be 8
+        }
+    }
+
+    Context 'when AccentColor is a valid 6-digit hex' {
+        It 'should accept the color and include it in the result' {
+            $result = New-M365BrandingConfig -AccentColor '#0078D4'
+            $result['AccentColor'] | Should -Be '#0078D4'
+        }
+    }
+
+    Context 'when AccentColor is a valid 3-digit hex' {
+        It 'should accept the shorthand hex color' {
+            $result = New-M365BrandingConfig -AccentColor '#F0F'
+            $result['AccentColor'] | Should -Be '#F0F'
+        }
+    }
+
+    Context 'when AccentColor is an invalid hex string' {
+        It 'should throw a validation error' {
+            { New-M365BrandingConfig -AccentColor 'blue' } | Should -Throw
+        }
+
+        It 'should throw when hash prefix is missing' {
+            { New-M365BrandingConfig -AccentColor '0078D4' } | Should -Throw
+        }
+    }
+
+    Context 'when PrimaryColor is a valid hex' {
+        It 'should include PrimaryColor in the result' {
+            $result = New-M365BrandingConfig -PrimaryColor '#1E3A5F'
+            $result['PrimaryColor'] | Should -Be '#1E3A5F'
+        }
+    }
+
+    Context 'when LogoPath is provided' {
+        It 'should throw when the file does not exist' {
+            { New-M365BrandingConfig -LogoPath 'C:\nonexistent\logo.png' } | Should -Throw
+        }
+
+        It 'should accept a path that resolves to an existing file' {
+            $tempFile = [System.IO.Path]::GetTempFileName()
+            try {
+                $result = New-M365BrandingConfig -LogoPath $tempFile
+                $result['LogoPath'] | Should -Be $tempFile
+            }
+            finally {
+                Remove-Item -Path $tempFile -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    Context 'when ClientLogoPath is provided' {
+        It 'should throw when the file does not exist' {
+            { New-M365BrandingConfig -ClientLogoPath 'C:\nonexistent\client.png' } | Should -Throw
+        }
+
+        It 'should accept a path that resolves to an existing file' {
+            $tempFile = [System.IO.Path]::GetTempFileName()
+            try {
+                $result = New-M365BrandingConfig -ClientLogoPath $tempFile
+                $result['ClientLogoPath'] | Should -Be $tempFile
+            }
+            finally {
+                Remove-Item -Path $tempFile -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    Context 'sparse population' {
+        It 'should not include keys that were not passed' {
+            $result = New-M365BrandingConfig -CompanyName 'Test'
+            $result.ContainsKey('AccentColor')  | Should -Be $false
+            $result.ContainsKey('LogoPath')     | Should -Be $false
+            $result.ContainsKey('ClientName')   | Should -Be $false
+        }
+    }
+
+    Context 'output type' {
+        It 'should return a hashtable regardless of parameter count' {
+            $result = New-M365BrandingConfig -CompanyName 'X' -AccentColor '#ABC'
+            $result | Should -BeOfType [hashtable]
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Closes #515** — adds `New-M365BrandingConfig` public cmdlet as a validated factory for the `-CustomBranding` hashtable
- **Suppresses Teams 412 noise** — demotes `412 PreconditionFailed` from `Write-Warning` to `Write-Verbose` in `Get-TeamsAccessReport.ps1`

## New-M365BrandingConfig details

`New-M365BrandingConfig` returns a sparse hashtable (only keys the caller explicitly passed) with tab-completable, validated parameters:

| Parameter | Validation |
|---|---|
| `CompanyName` | `ValidateNotNullOrEmpty` |
| `LogoPath` / `ClientLogoPath` | `ValidateScript` — file must exist |
| `AccentColor` / `PrimaryColor` | `ValidatePattern` — hex `#RGB` or `#RRGGBB` |
| All others | Plain string |

```powershell
$branding = New-M365BrandingConfig -CompanyName 'Contoso Consulting' -AccentColor '#0078D4' -LogoPath './logo.png'
Invoke-M365Assessment -TenantId 'fabrikam.com' -CustomBranding $branding
```

## Teams 412 fix

`/beta/teamwork/teamsAppSettings` returns 412 PreconditionFailed when using app-only (certificate) auth — this is a known Microsoft limitation, not an assessment finding. Previously surfaced in the issues report as a warning; now only visible with `-Verbose`.

## Test plan

- [x] 14 new Pester tests cover: empty call, single key, all string params, valid/invalid hex, path validation, sparse population, return type
- [x] All 14 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)