### PR TITLE
feat(v2): Build-ReportData.ps1 — PowerShell data bridge for React report

### DIFF
--- a/src/M365-Assess/Common/Build-ReportData.ps1
+++ b/src/M365-Assess/Common/Build-ReportData.ps1
@@ -12,11 +12,11 @@ function Get-CheckDomain {
         'DNS-*'          { return 'Exchange Online' }
         'INTUNE-*'       { return 'Intune' }
         'DEFENDER-*'     { return 'Defender' }
-        'SPO-*'          { return 'SharePoint' }
+        'SPO-*'          { return 'SharePoint & OneDrive' }
         'TEAMS-*'        { return 'Teams' }
-        'PURVIEW-*'      { return 'Purview' }
-        'DLP-*'          { return 'Purview' }
-        'COMPLIANCE-*'   { return 'Purview' }
+        'PURVIEW-*'      { return 'Purview / Compliance' }
+        'DLP-*'          { return 'Purview / Compliance' }
+        'COMPLIANCE-*'   { return 'Purview / Compliance' }
         'POWERBI-*'      { return 'Power BI' }
         'PBI-*'          { return 'Power BI' }
         'FORMS-*'        { return 'Forms' }
@@ -50,12 +50,18 @@ function Build-ReportDataJson {
         riskSeverity and frameworks fallback when AllFindings rows lack those fields.
     .PARAMETER WhiteLabel
         When set, REPORT_DATA.whiteLabel is true — the React app hides Galvnyz attribution.
+    .PARAMETER FrameworkDefs
+        Array of framework definition hashtables from Import-FrameworkDefinitions.
+        Produces REPORT_DATA.frameworks as [{id, full}] for the React FrameworkQuilt
+        component. When omitted, frameworks is an empty array and the React app falls
+        back to its own hardcoded list.
     .PARAMETER XlsxFileName
         Relative filename of the companion XLSX (e.g., "MyClient_Assessment-Report.xlsx").
         Embedded as REPORT_DATA.xlsxFileName for the download anchor in the report.
     .EXAMPLE
         $json = Build-ReportDataJson -AllFindings $allCisFindings -SectionData $sectionData `
-            -RegistryData $controlRegistry -XlsxFileName 'Contoso_Assessment-Report.xlsx'
+            -RegistryData $controlRegistry -FrameworkDefs $allFrameworks `
+            -XlsxFileName 'Contoso_Assessment-Report.xlsx'
         Get-ReportTemplate -ReportDataJson $json -ReportTitle 'M365 Assessment'
     #>
     [CmdletBinding()]
@@ -73,6 +79,10 @@ function Build-ReportDataJson {
 
         [Parameter()]
         [switch]$WhiteLabel,
+
+        [Parameter()]
+        [AllowEmptyCollection()]
+        [hashtable[]]$FrameworkDefs = @(),
 
         [Parameter()]
         [string]$XlsxFileName = ''
@@ -175,6 +185,8 @@ function Build-ReportDataJson {
     $caRows        = & $get 'ca'
     $adminRoleRows = & $get 'admin-roles'
 
+    $frameworkList = @($FrameworkDefs | ForEach-Object { @{ id = $_['frameworkId']; full = $_['label'] } })
+
     $reportData = [ordered]@{
         tenant         = @($tenantRows | Select-Object OrgDisplayName, TenantId, DefaultDomain, CreatedDateTime)
         users          = @($usersRows  | Select-Object TotalUsers, Licensed, GuestUsers, SyncedFromOnPrem)
@@ -182,6 +194,7 @@ function Build-ReportDataJson {
         mfaStats       = $mfaStats
         findings       = @($findings)
         domainStats    = $domainStats
+        frameworks     = $frameworkList
         licenses       = @($licenseRows  | Select-Object License, Assigned, Total)
         dns            = @($dnsRows      | Select-Object Domain, SPF, DMARC, DMARCPolicy, DKIM, DKIMStatus)
         ca             = @($caRows       | Select-Object DisplayName, State)

--- a/src/M365-Assess/Common/Build-ReportData.ps1
+++ b/src/M365-Assess/Common/Build-ReportData.ps1
@@ -1,0 +1,200 @@
+function Get-CheckDomain {
+    <#
+    .SYNOPSIS
+        Maps a base CheckId prefix to the React report domain label.
+    #>
+    param([string]$CheckId)
+    switch -Wildcard ($CheckId) {
+        'CA-*'           { return 'Conditional Access' }
+        'ENTRA-ENTAPP-*' { return 'Enterprise Apps' }
+        'ENTRA-*'        { return 'Entra ID' }
+        'EXO-*'          { return 'Exchange Online' }
+        'DNS-*'          { return 'Exchange Online' }
+        'INTUNE-*'       { return 'Intune' }
+        'DEFENDER-*'     { return 'Defender' }
+        'SPO-*'          { return 'SharePoint' }
+        'TEAMS-*'        { return 'Teams' }
+        'PURVIEW-*'      { return 'Purview' }
+        'DLP-*'          { return 'Purview' }
+        'COMPLIANCE-*'   { return 'Purview' }
+        'POWERBI-*'      { return 'Power BI' }
+        'PBI-*'          { return 'Power BI' }
+        'FORMS-*'        { return 'Forms' }
+        'AD-*'           { return 'Active Directory' }
+        'SOC2-*'         { return 'SOC 2' }
+        'VO-*'           { return 'Value Opportunity' }
+        default          { return 'Other' }
+    }
+}
+
+function Build-ReportDataJson {
+    <#
+    .SYNOPSIS
+        Transforms M365-Assess collector output into the window.REPORT_DATA JSON for the React report.
+    .DESCRIPTION
+        Accepts pre-loaded assessment data and produces a JavaScript assignment statement
+        (window.REPORT_DATA = {...};) safe for inline embedding in an HTML <script> block.
+        All </script> substrings in JSON string values are escaped as <\/script>.
+    .PARAMETER AllFindings
+        Array of enriched security-config check rows (output of Build-SectionHtml.ps1's
+        $allCisFindings). Each row must have: CheckId, Category, Setting, CurrentValue,
+        RecommendedValue (or Recommended), Status, Remediation, Section.
+        Rows with RiskSeverity and Frameworks fields are used directly; missing fields
+        fall back to $RegistryData lookup.
+    .PARAMETER SectionData
+        Hashtable of pre-loaded section data keyed by: 'tenant', 'users', 'score', 'mfa',
+        'admin-roles', 'licenses', 'dns', 'ca'. Values are arrays of PSCustomObjects or
+        Import-Csv rows. Missing keys produce empty arrays in the output.
+    .PARAMETER RegistryData
+        Control registry hashtable (output of Import-ControlRegistry). Used for
+        riskSeverity and frameworks fallback when AllFindings rows lack those fields.
+    .PARAMETER WhiteLabel
+        When set, REPORT_DATA.whiteLabel is true — the React app hides Galvnyz attribution.
+    .PARAMETER XlsxFileName
+        Relative filename of the companion XLSX (e.g., "MyClient_Assessment-Report.xlsx").
+        Embedded as REPORT_DATA.xlsxFileName for the download anchor in the report.
+    .EXAMPLE
+        $json = Build-ReportDataJson -AllFindings $allCisFindings -SectionData $sectionData `
+            -RegistryData $controlRegistry -XlsxFileName 'Contoso_Assessment-Report.xlsx'
+        Get-ReportTemplate -ReportDataJson $json -ReportTitle 'M365 Assessment'
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter()]
+        [AllowEmptyCollection()]
+        [PSCustomObject[]]$AllFindings = @(),
+
+        [Parameter()]
+        [hashtable]$SectionData = @{},
+
+        [Parameter()]
+        [hashtable]$RegistryData = @{},
+
+        [Parameter()]
+        [switch]$WhiteLabel,
+
+        [Parameter()]
+        [string]$XlsxFileName = ''
+    )
+
+    # ------------------------------------------------------------------
+    # 1. Map findings → REPORT_DATA.findings shape
+    # ------------------------------------------------------------------
+    $findings = [System.Collections.Generic.List[PSCustomObject]]::new()
+
+    foreach ($f in $AllFindings) {
+        $baseCheckId = $f.CheckId -replace '\.\d+$', ''
+        $regEntry    = if ($RegistryData.ContainsKey($baseCheckId)) { $RegistryData[$baseCheckId] } else { $null }
+
+        $severity = if ($f.PSObject.Properties['RiskSeverity'] -and $f.RiskSeverity) {
+            $f.RiskSeverity.ToLower()
+        } elseif ($regEntry -and $regEntry.riskSeverity) {
+            $regEntry.riskSeverity.ToLower()
+        } else {
+            'medium'
+        }
+
+        $frameworks = if ($f.PSObject.Properties['Frameworks'] -and $f.Frameworks) {
+            $f.Frameworks
+        } elseif ($regEntry -and $regEntry.frameworks) {
+            $regEntry.frameworks
+        } else {
+            @{}
+        }
+
+        $recommended = if ($f.PSObject.Properties['RecommendedValue']) { $f.RecommendedValue }
+                       elseif ($f.PSObject.Properties['Recommended'])   { $f.Recommended }
+                       else                                              { '' }
+
+        $findings.Add([PSCustomObject]@{
+            checkId     = $f.CheckId
+            status      = $f.Status
+            severity    = $severity
+            domain      = Get-CheckDomain -CheckId $baseCheckId
+            section     = $f.Section
+            category    = $f.Category
+            setting     = $f.Setting
+            current     = $f.CurrentValue
+            recommended = $recommended
+            remediation = $f.Remediation
+            effort      = $null
+            frameworks  = $frameworks
+        })
+    }
+
+    # ------------------------------------------------------------------
+    # 2. Compute domainStats
+    # ------------------------------------------------------------------
+    $domainStats = [ordered]@{}
+    foreach ($finding in $findings) {
+        $d = $finding.domain
+        if (-not $domainStats.Contains($d)) {
+            $domainStats[$d] = [ordered]@{ pass=0; warn=0; fail=0; review=0; info=0; total=0 }
+        }
+        $domainStats[$d].total++
+        switch ($finding.status) {
+            'Pass'    { $domainStats[$d].pass++   }
+            'Warning' { $domainStats[$d].warn++   }
+            'Fail'    { $domainStats[$d].fail++   }
+            'Review'  { $domainStats[$d].review++ }
+            'Info'    { $domainStats[$d].info++   }
+        }
+    }
+
+    # ------------------------------------------------------------------
+    # 3. Compute mfaStats
+    # ------------------------------------------------------------------
+    $mfaRows = if ($SectionData.ContainsKey('mfa')) { @($SectionData['mfa']) } else { @() }
+    $isAdminTrue = { param($r) $r.IsAdmin -eq 'True' -or $r.IsAdmin -eq $true }
+    $isNoMfa     = { param($r) $r.MfaStrength -eq 'None' -or -not $r.MfaStrength }
+
+    $mfaStats = [ordered]@{
+        phishResistant   = @($mfaRows | Where-Object { $_.MfaStrength -eq 'Phishing-Resistant' }).Count
+        standard         = @($mfaRows | Where-Object { $_.MfaStrength -eq 'Standard' }).Count
+        weak             = @($mfaRows | Where-Object { $_.MfaStrength -eq 'Weak' }).Count
+        none             = @($mfaRows | Where-Object { $_.MfaStrength -eq 'None' -or -not $_.MfaStrength }).Count
+        total            = $mfaRows.Count
+        admins           = @($mfaRows | Where-Object { $_.IsAdmin -eq 'True' -or $_.IsAdmin -eq $true }).Count
+        adminsWithoutMfa = @($mfaRows | Where-Object {
+            ($_.IsAdmin -eq 'True' -or $_.IsAdmin -eq $true) -and
+            ($_.MfaStrength -eq 'None' -or -not $_.MfaStrength)
+        }).Count
+    }
+
+    # ------------------------------------------------------------------
+    # 4. Assemble REPORT_DATA
+    # ------------------------------------------------------------------
+    $get = { param($key) if ($SectionData.ContainsKey($key)) { @($SectionData[$key]) } else { @() } }
+
+    $tenantRows    = & $get 'tenant'
+    $usersRows     = & $get 'users'
+    $scoreRows     = & $get 'score'
+    $licenseRows   = & $get 'licenses'
+    $dnsRows       = & $get 'dns'
+    $caRows        = & $get 'ca'
+    $adminRoleRows = & $get 'admin-roles'
+
+    $reportData = [ordered]@{
+        tenant         = @($tenantRows | Select-Object OrgDisplayName, TenantId, DefaultDomain, CreatedDateTime)
+        users          = @($usersRows  | Select-Object TotalUsers, Licensed, GuestUsers, SyncedFromOnPrem)
+        score          = @($scoreRows  | Select-Object Percentage, AverageComparativeScore, CurrentScore, MaxScore, CreatedDateTime)
+        mfaStats       = $mfaStats
+        findings       = @($findings)
+        domainStats    = $domainStats
+        licenses       = @($licenseRows  | Select-Object License, Assigned, Total)
+        dns            = @($dnsRows      | Select-Object Domain, SPF, DMARC, DMARCPolicy, DKIM, DKIMStatus)
+        ca             = @($caRows       | Select-Object DisplayName, State)
+        'admin-roles'  = @($adminRoleRows | Select-Object RoleName, MemberDisplayName)
+        summary        = @(@{ Items = $findings.Count })
+        whiteLabel     = [bool]$WhiteLabel
+        xlsxFileName   = $XlsxFileName
+    }
+
+    # ------------------------------------------------------------------
+    # 5. Serialize + escape </script> in string values
+    # ------------------------------------------------------------------
+    $json = $reportData | ConvertTo-Json -Depth 10
+    $json = $json -replace '</script>', '<\/script>'
+    return "window.REPORT_DATA = $json;"
+}

--- a/tests/Common/Build-ReportData.Tests.ps1
+++ b/tests/Common/Build-ReportData.Tests.ps1
@@ -1,0 +1,460 @@
+Describe 'Build-ReportData' {
+    BeforeAll {
+        . "$PSScriptRoot/../../src/M365-Assess/Common/Build-ReportData.ps1"
+
+        # Helper: parse the JSON from "window.REPORT_DATA = {...};"
+        function ConvertFrom-ReportDataJson {
+            param([string]$Output)
+            $json = $Output -replace '^window\.REPORT_DATA = ', '' -replace ';$', ''
+            return $json | ConvertFrom-Json
+        }
+
+        # Minimal valid finding row
+        function New-Finding {
+            param(
+                [string]$CheckId      = 'ENTRA-MFA-001.1',
+                [string]$Status       = 'Fail',
+                [string]$Category     = 'MFA',
+                [string]$Setting      = 'MFA for all users',
+                [string]$CurrentValue = 'Disabled',
+                [string]$RecommendedValue = 'Enabled',
+                [string]$Remediation  = 'Enable MFA',
+                [string]$Section      = 'Identity',
+                [string]$RiskSeverity = 'Critical',
+                [hashtable]$Frameworks = @{}
+            )
+            [PSCustomObject]@{
+                CheckId          = $CheckId
+                Status           = $Status
+                Category         = $Category
+                Setting          = $Setting
+                CurrentValue     = $CurrentValue
+                RecommendedValue = $RecommendedValue
+                Remediation      = $Remediation
+                Section          = $Section
+                RiskSeverity     = $RiskSeverity
+                Frameworks       = $Frameworks
+            }
+        }
+
+        # Minimal valid MFA row
+        function New-MfaRow {
+            param([string]$MfaStrength = 'Standard', [string]$IsAdmin = 'False')
+            [PSCustomObject]@{ MfaStrength = $MfaStrength; IsAdmin = $IsAdmin }
+        }
+    }
+
+    # ------------------------------------------------------------------
+    Context 'JSON output wrapper' {
+        It 'should return a string starting with window.REPORT_DATA =' {
+            $result = Build-ReportDataJson
+            $result | Should -Match '^window\.REPORT_DATA = '
+        }
+
+        It 'should return a string ending with ;' {
+            $result = Build-ReportDataJson
+            $result | Should -Match ';$'
+        }
+
+        It 'should produce valid JSON after stripping the wrapper' {
+            $result = Build-ReportDataJson
+            { ConvertFrom-ReportDataJson $result } | Should -Not -Throw
+        }
+
+        It 'should escape script end-tag in string values to prevent HTML injection' {
+            $closing = '</' + 'script>'
+            $escaped = '<\/' + 'script>'
+            $finding = New-Finding -CurrentValue ('foo' + $closing + 'bar')
+            $result = Build-ReportDataJson -AllFindings @($finding)
+            $result.Contains($closing) | Should -Be $false
+            $result.Contains($escaped) | Should -Be $true
+        }
+    }
+
+    # ------------------------------------------------------------------
+    Context 'field mapping' {
+        It 'should map CurrentValue to current' {
+            $f = New-Finding -CurrentValue 'some value'
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @($f))
+            $d.findings[0].current | Should -Be 'some value'
+        }
+
+        It 'should map RecommendedValue to recommended' {
+            $f = New-Finding -RecommendedValue 'best practice'
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @($f))
+            $d.findings[0].recommended | Should -Be 'best practice'
+        }
+
+        It 'should accept Recommended (pre-renamed) field instead of RecommendedValue' {
+            $f = [PSCustomObject]@{
+                CheckId   = 'ENTRA-MFA-001.1'; Status = 'Pass'; Category = 'MFA'
+                Setting   = 'x'; CurrentValue = 'y'; Recommended = 'z'
+                Remediation = ''; Section = 'Identity'; RiskSeverity = 'High'; Frameworks = @{}
+            }
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @($f))
+            $d.findings[0].recommended | Should -Be 'z'
+        }
+
+        It 'should lowercase RiskSeverity into severity' {
+            $f = New-Finding -RiskSeverity 'Critical'
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @($f))
+            $d.findings[0].severity | Should -Be 'critical'
+        }
+
+        It 'should fall back to RegistryData for severity when RiskSeverity is absent' {
+            $f = [PSCustomObject]@{
+                CheckId = 'CA-MFA-ADMIN-001.1'; Status = 'Pass'; Category = 'CA'
+                Setting = 'x'; CurrentValue = 'y'; RecommendedValue = 'z'
+                Remediation = ''; Section = 'Conditional Access'
+            }
+            $registry = @{ 'CA-MFA-ADMIN-001' = @{ riskSeverity = 'High'; frameworks = @{} } }
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @($f) -RegistryData $registry)
+            $d.findings[0].severity | Should -Be 'high'
+        }
+
+        It 'should default severity to medium when no RiskSeverity and no registry entry' {
+            $f = [PSCustomObject]@{
+                CheckId = 'UNKNOWN-001.1'; Status = 'Info'; Category = 'X'
+                Setting = 'x'; CurrentValue = 'y'; RecommendedValue = 'z'
+                Remediation = ''; Section = 'Other'
+            }
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @($f))
+            $d.findings[0].severity | Should -Be 'medium'
+        }
+
+        It 'should strip the .N sub-number suffix before domain derivation' {
+            $f = New-Finding -CheckId 'ENTRA-MFA-001.3'
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @($f))
+            $d.findings[0].domain | Should -Be 'Entra ID'
+        }
+
+        It 'should include all required finding fields' {
+            $f = New-Finding
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @($f))
+            $row = $d.findings[0]
+            $row.PSObject.Properties.Name | Should -Contain 'checkId'
+            $row.PSObject.Properties.Name | Should -Contain 'status'
+            $row.PSObject.Properties.Name | Should -Contain 'severity'
+            $row.PSObject.Properties.Name | Should -Contain 'domain'
+            $row.PSObject.Properties.Name | Should -Contain 'section'
+            $row.PSObject.Properties.Name | Should -Contain 'category'
+            $row.PSObject.Properties.Name | Should -Contain 'setting'
+            $row.PSObject.Properties.Name | Should -Contain 'current'
+            $row.PSObject.Properties.Name | Should -Contain 'recommended'
+            $row.PSObject.Properties.Name | Should -Contain 'remediation'
+            $row.PSObject.Properties.Name | Should -Contain 'frameworks'
+        }
+    }
+
+    # ------------------------------------------------------------------
+    Context 'domain derivation' {
+        It 'maps CA-* to Conditional Access' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @(New-Finding -CheckId 'CA-MFA-001.1'))
+            $d.findings[0].domain | Should -Be 'Conditional Access'
+        }
+
+        It 'maps ENTRA-ENTAPP-* to Enterprise Apps (not Entra ID)' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @(New-Finding -CheckId 'ENTRA-ENTAPP-001.1'))
+            $d.findings[0].domain | Should -Be 'Enterprise Apps'
+        }
+
+        It 'maps ENTRA-* (non-ENTAPP) to Entra ID' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @(New-Finding -CheckId 'ENTRA-MFA-001.1'))
+            $d.findings[0].domain | Should -Be 'Entra ID'
+        }
+
+        It 'maps EXO-* to Exchange Online' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @(New-Finding -CheckId 'EXO-AUTH-001.1'))
+            $d.findings[0].domain | Should -Be 'Exchange Online'
+        }
+
+        It 'maps DNS-* to Exchange Online' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @(New-Finding -CheckId 'DNS-SPF-001.1'))
+            $d.findings[0].domain | Should -Be 'Exchange Online'
+        }
+
+        It 'maps INTUNE-* to Intune' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @(New-Finding -CheckId 'INTUNE-COMP-001.1'))
+            $d.findings[0].domain | Should -Be 'Intune'
+        }
+
+        It 'maps DEFENDER-* to Defender' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @(New-Finding -CheckId 'DEFENDER-ANTIPHISH-001.1'))
+            $d.findings[0].domain | Should -Be 'Defender'
+        }
+
+        It 'maps SPO-* to SharePoint' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @(New-Finding -CheckId 'SPO-SHARING-001.1'))
+            $d.findings[0].domain | Should -Be 'SharePoint'
+        }
+
+        It 'maps TEAMS-* to Teams' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @(New-Finding -CheckId 'TEAMS-GUEST-001.1'))
+            $d.findings[0].domain | Should -Be 'Teams'
+        }
+
+        It 'maps PURVIEW-* to Purview' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @(New-Finding -CheckId 'PURVIEW-AUD-001.1'))
+            $d.findings[0].domain | Should -Be 'Purview'
+        }
+
+        It 'maps COMPLIANCE-* to Purview' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @(New-Finding -CheckId 'COMPLIANCE-DLP-001.1'))
+            $d.findings[0].domain | Should -Be 'Purview'
+        }
+
+        It 'maps DLP-* to Purview' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @(New-Finding -CheckId 'DLP-POLICY-001.1'))
+            $d.findings[0].domain | Should -Be 'Purview'
+        }
+
+        It 'maps POWERBI-* to Power BI' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @(New-Finding -CheckId 'POWERBI-TENANT-001.1'))
+            $d.findings[0].domain | Should -Be 'Power BI'
+        }
+
+        It 'maps PBI-* to Power BI' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @(New-Finding -CheckId 'PBI-EXPORT-001.1'))
+            $d.findings[0].domain | Should -Be 'Power BI'
+        }
+
+        It 'maps FORMS-* to Forms' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @(New-Finding -CheckId 'FORMS-SHARE-001.1'))
+            $d.findings[0].domain | Should -Be 'Forms'
+        }
+
+        It 'maps AD-* to Active Directory' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @(New-Finding -CheckId 'AD-SYNC-001.1'))
+            $d.findings[0].domain | Should -Be 'Active Directory'
+        }
+
+        It 'maps SOC2-* to SOC 2' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @(New-Finding -CheckId 'SOC2-CC1-001.1'))
+            $d.findings[0].domain | Should -Be 'SOC 2'
+        }
+
+        It 'maps VO-* to Value Opportunity' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @(New-Finding -CheckId 'VO-LIC-001.1'))
+            $d.findings[0].domain | Should -Be 'Value Opportunity'
+        }
+
+        It 'maps unknown prefixes to Other' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @(New-Finding -CheckId 'XYZ-UNKNOWN-001.1'))
+            $d.findings[0].domain | Should -Be 'Other'
+        }
+    }
+
+    # ------------------------------------------------------------------
+    Context 'mfaStats' {
+        It 'should count Phishing-Resistant correctly' {
+            $rows = @(
+                New-MfaRow 'Phishing-Resistant'
+                New-MfaRow 'Phishing-Resistant'
+                New-MfaRow 'Standard'
+            )
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -SectionData @{ mfa = $rows })
+            $d.mfaStats.phishResistant | Should -Be 2
+        }
+
+        It 'should count Standard correctly' {
+            $rows = @(New-MfaRow 'Standard'; New-MfaRow 'Standard')
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -SectionData @{ mfa = $rows })
+            $d.mfaStats.standard | Should -Be 2
+        }
+
+        It 'should count Weak correctly' {
+            $rows = @(New-MfaRow 'Weak')
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -SectionData @{ mfa = $rows })
+            $d.mfaStats.weak | Should -Be 1
+        }
+
+        It 'should count None correctly' {
+            $rows = @(New-MfaRow 'None'; New-MfaRow '')
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -SectionData @{ mfa = $rows })
+            $d.mfaStats.none | Should -Be 2
+        }
+
+        It 'should set total to total user count' {
+            $rows = @(New-MfaRow 'Pass'; New-MfaRow 'None'; New-MfaRow 'Standard')
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -SectionData @{ mfa = $rows })
+            $d.mfaStats.total | Should -Be 3
+        }
+
+        It 'should count admin users' {
+            $rows = @(
+                New-MfaRow 'Standard' 'True'
+                New-MfaRow 'Phishing-Resistant' 'True'
+                New-MfaRow 'None' 'False'
+            )
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -SectionData @{ mfa = $rows })
+            $d.mfaStats.admins | Should -Be 2
+        }
+
+        It 'should count admins without MFA' {
+            $rows = @(
+                New-MfaRow 'None' 'True'
+                New-MfaRow 'Standard' 'True'
+                New-MfaRow 'None' 'False'
+            )
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -SectionData @{ mfa = $rows })
+            $d.mfaStats.adminsWithoutMfa | Should -Be 1
+        }
+
+        It 'should produce all-zero mfaStats when mfa key is absent' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson)
+            $d.mfaStats.total | Should -Be 0
+        }
+    }
+
+    # ------------------------------------------------------------------
+    Context 'domainStats' {
+        It 'should group findings by domain and count statuses' {
+            $findings = @(
+                New-Finding -CheckId 'ENTRA-MFA-001.1' -Status 'Fail'
+                New-Finding -CheckId 'ENTRA-PWD-001.1' -Status 'Pass'
+                New-Finding -CheckId 'ENTRA-SEC-001.1' -Status 'Warning'
+            )
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings $findings)
+            $d.domainStats.'Entra ID'.fail    | Should -Be 1
+            $d.domainStats.'Entra ID'.pass    | Should -Be 1
+            $d.domainStats.'Entra ID'.warn    | Should -Be 1
+            $d.domainStats.'Entra ID'.total   | Should -Be 3
+        }
+
+        It 'should separate domains correctly' {
+            $findings = @(
+                New-Finding -CheckId 'ENTRA-MFA-001.1' -Status 'Fail'
+                New-Finding -CheckId 'CA-MFA-001.1'    -Status 'Pass'
+            )
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings $findings)
+            $d.domainStats.'Entra ID'.total             | Should -Be 1
+            $d.domainStats.'Conditional Access'.total   | Should -Be 1
+        }
+
+        It 'should count Review and Info status' {
+            $findings = @(
+                New-Finding -CheckId 'EXO-AUTH-001.1' -Status 'Review'
+                New-Finding -CheckId 'EXO-AUTH-002.1' -Status 'Info'
+            )
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings $findings)
+            $d.domainStats.'Exchange Online'.review | Should -Be 1
+            $d.domainStats.'Exchange Online'.info   | Should -Be 1
+        }
+
+        It 'should produce empty domainStats when AllFindings is empty' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson)
+            @($d.domainStats.PSObject.Properties).Count | Should -Be 0
+        }
+    }
+
+    # ------------------------------------------------------------------
+    Context 'whiteLabel flag' {
+        It 'should set whiteLabel false by default' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson)
+            $d.whiteLabel | Should -Be $false
+        }
+
+        It 'should set whiteLabel true when switch is passed' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -WhiteLabel)
+            $d.whiteLabel | Should -Be $true
+        }
+    }
+
+    # ------------------------------------------------------------------
+    Context 'xlsxFileName' {
+        It 'should embed xlsxFileName in the output' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -XlsxFileName 'Contoso_Report.xlsx')
+            $d.xlsxFileName | Should -Be 'Contoso_Report.xlsx'
+        }
+
+        It 'should default xlsxFileName to empty string' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson)
+            $d.xlsxFileName | Should -Be ''
+        }
+    }
+
+    # ------------------------------------------------------------------
+    Context 'null safety — missing SectionData keys' {
+        It 'should produce empty tenant array when tenant key absent' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson)
+            @($d.tenant).Count | Should -Be 0
+        }
+
+        It 'should produce empty score array when score key absent' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson)
+            @($d.score).Count | Should -Be 0
+        }
+
+        It 'should produce empty ca array when ca key absent' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson)
+            @($d.ca).Count | Should -Be 0
+        }
+
+        It 'should produce empty dns array when dns key absent' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson)
+            @($d.dns).Count | Should -Be 0
+        }
+
+        It 'should produce empty admin-roles array when admin-roles key absent' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson)
+            $d.'admin-roles' | Should -BeNullOrEmpty
+        }
+
+        It 'should always include top-level keys in output' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson)
+            $keys = $d.PSObject.Properties.Name
+            $keys | Should -Contain 'tenant'
+            $keys | Should -Contain 'users'
+            $keys | Should -Contain 'score'
+            $keys | Should -Contain 'mfaStats'
+            $keys | Should -Contain 'findings'
+            $keys | Should -Contain 'domainStats'
+            $keys | Should -Contain 'licenses'
+            $keys | Should -Contain 'dns'
+            $keys | Should -Contain 'ca'
+            $keys | Should -Contain 'summary'
+            $keys | Should -Contain 'whiteLabel'
+            $keys | Should -Contain 'xlsxFileName'
+        }
+    }
+
+    # ------------------------------------------------------------------
+    Context 'summary' {
+        It 'should set summary.Items to the count of findings' {
+            $findings = @(New-Finding; New-Finding -CheckId 'CA-MFA-001.1')
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings $findings)
+            $d.summary[0].Items | Should -Be 2
+        }
+    }
+
+    # ------------------------------------------------------------------
+    Context 'SectionData passthrough' {
+        It 'should include tenant OrgDisplayName in output' {
+            $tenant = [PSCustomObject]@{ OrgDisplayName='Contoso'; TenantId='abc'; DefaultDomain='contoso.com'; CreatedDateTime='2020-01-01' }
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -SectionData @{ tenant = @($tenant) })
+            $d.tenant[0].OrgDisplayName | Should -Be 'Contoso'
+        }
+
+        It 'should include license rows with License, Assigned, Total' {
+            $lic = [PSCustomObject]@{ License='Microsoft 365 E5'; Assigned=10; Total=25 }
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -SectionData @{ licenses = @($lic) })
+            $d.licenses[0].License   | Should -Be 'Microsoft 365 E5'
+            $d.licenses[0].Assigned  | Should -Be 10
+            $d.licenses[0].Total     | Should -Be 25
+        }
+
+        It 'should include dns rows with Domain and SPF' {
+            $dns = [PSCustomObject]@{ Domain='contoso.com'; SPF='v=spf1 -all'; DMARC='v=DMARC1'; DMARCPolicy='reject'; DKIM='Configured'; DKIMStatus='Enabled' }
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -SectionData @{ dns = @($dns) })
+            $d.dns[0].Domain | Should -Be 'contoso.com'
+            $d.dns[0].SPF    | Should -Be 'v=spf1 -all'
+        }
+
+        It 'should include ca rows with DisplayName and State' {
+            $ca = [PSCustomObject]@{ DisplayName='Require MFA'; State='enabled' }
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -SectionData @{ ca = @($ca) })
+            $d.ca[0].DisplayName | Should -Be 'Require MFA'
+            $d.ca[0].State       | Should -Be 'enabled'
+        }
+    }
+}

--- a/tests/Common/Build-ReportData.Tests.ps1
+++ b/tests/Common/Build-ReportData.Tests.ps1
@@ -183,9 +183,9 @@ Describe 'Build-ReportData' {
             $d.findings[0].domain | Should -Be 'Defender'
         }
 
-        It 'maps SPO-* to SharePoint' {
+        It 'maps SPO-* to SharePoint & OneDrive' {
             $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @(New-Finding -CheckId 'SPO-SHARING-001.1'))
-            $d.findings[0].domain | Should -Be 'SharePoint'
+            $d.findings[0].domain | Should -Be 'SharePoint & OneDrive'
         }
 
         It 'maps TEAMS-* to Teams' {
@@ -193,19 +193,19 @@ Describe 'Build-ReportData' {
             $d.findings[0].domain | Should -Be 'Teams'
         }
 
-        It 'maps PURVIEW-* to Purview' {
+        It 'maps PURVIEW-* to Purview / Compliance' {
             $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @(New-Finding -CheckId 'PURVIEW-AUD-001.1'))
-            $d.findings[0].domain | Should -Be 'Purview'
+            $d.findings[0].domain | Should -Be 'Purview / Compliance'
         }
 
-        It 'maps COMPLIANCE-* to Purview' {
+        It 'maps COMPLIANCE-* to Purview / Compliance' {
             $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @(New-Finding -CheckId 'COMPLIANCE-DLP-001.1'))
-            $d.findings[0].domain | Should -Be 'Purview'
+            $d.findings[0].domain | Should -Be 'Purview / Compliance'
         }
 
-        It 'maps DLP-* to Purview' {
+        It 'maps DLP-* to Purview / Compliance' {
             $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @(New-Finding -CheckId 'DLP-POLICY-001.1'))
-            $d.findings[0].domain | Should -Be 'Purview'
+            $d.findings[0].domain | Should -Be 'Purview / Compliance'
         }
 
         It 'maps POWERBI-* to Power BI' {
@@ -409,12 +409,34 @@ Describe 'Build-ReportData' {
             $keys | Should -Contain 'mfaStats'
             $keys | Should -Contain 'findings'
             $keys | Should -Contain 'domainStats'
+            $keys | Should -Contain 'frameworks'
             $keys | Should -Contain 'licenses'
             $keys | Should -Contain 'dns'
             $keys | Should -Contain 'ca'
             $keys | Should -Contain 'summary'
             $keys | Should -Contain 'whiteLabel'
             $keys | Should -Contain 'xlsxFileName'
+        }
+    }
+
+    # ------------------------------------------------------------------
+    Context 'frameworks passthrough' {
+        It 'should produce empty frameworks array when FrameworkDefs not supplied' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson)
+            @($d.frameworks).Count | Should -Be 0
+        }
+
+        It 'should map frameworkId to id and label to full' {
+            $defs = @(
+                @{ frameworkId = 'cis-m365-v6'; label = 'CIS Microsoft 365 v6.0.1' }
+                @{ frameworkId = 'cmmc';         label = 'CMMC 2.0' }
+            )
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -FrameworkDefs $defs)
+            @($d.frameworks).Count | Should -Be 2
+            $d.frameworks[0].id   | Should -Be 'cis-m365-v6'
+            $d.frameworks[0].full | Should -Be 'CIS Microsoft 365 v6.0.1'
+            $d.frameworks[1].id   | Should -Be 'cmmc'
+            $d.frameworks[1].full | Should -Be 'CMMC 2.0'
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds `Common/Build-ReportData.ps1` with `Build-ReportDataJson` function and helper `Get-CheckDomain`
- 58 Pester tests in `tests/Common/Build-ReportData.Tests.ps1`

## What it does

Transforms collector output → `window.REPORT_DATA = {...};` JavaScript assignment for inline embedding in the React HTML report.

**Field mappings:**
- `CurrentValue → current`, `RecommendedValue/Recommended → recommended`
- `RiskSeverity.ToLower() → severity` (falls back to `$RegistryData` then `'medium'`)
- `</script>` escaped as `<\/script>` in all string values (XSS prevention)

**Computed shapes:**
- `domainStats`: group findings by domain prefix, count pass/warn/fail/review/info
- `mfaStats`: aggregate MFA rows by strength bucket (Phishing-Resistant/Standard/Weak/None), admin counts

**Domain derivation** (`Get-CheckDomain`): 18 CheckId prefixes mapped to domain labels. `ENTRA-ENTAPP-*` checked before `ENTRA-*` to correctly route enterprise app checks.

**Null-safe**: all `$SectionData` keys are optional — missing keys produce empty arrays; no CA policies → `ca: []`; no DNS run → `dns: []`

## Test coverage (58 tests)
- JSON output wrapper + `;` terminator
- `</script>` injection prevention
- All field mappings
- All 18 domain prefix mappings (including ENTRA-ENTAPP-* routing)
- mfaStats breakdown (all 7 counters)
- domainStats aggregation and separation
- whiteLabel flag true/false
- xlsxFileName embedding
- Null safety for every SectionData key
- SectionData passthrough (tenant, licenses, dns, ca)

Part of milestone #35 · Closes #530 #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)