### PR TITLE
feat(v2): remove -CustomBranding, -FindingsNarrative, -CustomerProfile; drop New-M365BrandingConfig from public API

### DIFF
--- a/src/M365-Assess/Common/Export-AssessmentReport.ps1
+++ b/src/M365-Assess/Common/Export-AssessmentReport.ps1
@@ -18,14 +18,6 @@
     Tenant display name for the report title. Read from Tenant Information CSV if omitted.
 .PARAMETER WhiteLabel
     Hides M365-Assess GitHub link and Galvnyz attribution from the report footer.
-.PARAMETER FindingsNarrative
-    Deprecated — no longer rendered in the React report. Retained for backwards compatibility.
-.PARAMETER CompactReport
-    Retained for backwards compatibility. Has no effect in the React report engine.
-.PARAMETER CustomBranding
-    Passed through to the XLSX compliance matrix. No effect on the HTML report.
-.PARAMETER CustomerProfile
-    Path to a .psd1 profile that can supply CustomBranding values for the XLSX.
 .PARAMETER OpenReport
     Automatically opens the generated HTML report in the default browser.
 .PARAMETER QuickScan
@@ -58,17 +50,7 @@ param(
     [switch]$WhiteLabel,
 
     [Parameter()]
-    [string]$FindingsNarrative,
-
-    [Parameter()]
     [switch]$CompactReport,
-
-    [Parameter()]
-    [hashtable]$CustomBranding,
-
-    [Parameter()]
-    [ValidateScript({ -not $_ -or (Test-Path -Path $_ -PathType Leaf) })]
-    [string]$CustomerProfile,
 
     [Parameter()]
     [switch]$OpenReport,
@@ -152,16 +134,6 @@ if (-not $OutputPath) {
     $suffix  = if ($reportDomainPrefix) { "_$reportDomainPrefix" } else { '' }
     $OutputPath = Join-Path -Path $AssessmentFolder -ChildPath "_Assessment-Report$suffix.html"
 }
-
-# CustomerProfile: forward CustomBranding to XLSX if provided
-if ($CustomerProfile) {
-    $cpData = Import-PowerShellDataFile -Path $CustomerProfile
-    if ($cpData.CustomBranding -and -not $PSBoundParameters.ContainsKey('CustomBranding')) {
-        $CustomBranding = $cpData.CustomBranding
-    }
-    $WhiteLabel = $true
-}
-if ($PSBoundParameters.ContainsKey('CustomBranding') -and -not $WhiteLabel) { $WhiteLabel = $true }
 
 # ------------------------------------------------------------------
 # Load section data, build findings list, and export XLSX

--- a/src/M365-Assess/Invoke-M365Assessment.ps1
+++ b/src/M365-Assess/Invoke-M365Assessment.ps1
@@ -57,22 +57,9 @@
 .PARAMETER OpenReport
     Automatically open the generated HTML report in the default browser after
     generation. Works on Windows, macOS, and Linux.
-.PARAMETER CustomBranding
-    Hashtable for white-label reports. Keys: CompanyName, LogoPath, AccentColor,
-    ClientLogoPath, ClientName, ReportNote, Disclaimer, SidebarSubtitle, FooterText,
-    FooterUrl, PrimaryColor, ReportTitle. Automatically enables -WhiteLabel.
 .PARAMETER WhiteLabel
-    Strips all M365-Assess and GitHub identity from the report. With -CustomBranding
-    produces a fully branded consultant deliverable (Mode A). Without -CustomBranding
-    produces a neutral, tool-agnostic report (Mode C).
-.PARAMETER CustomerProfile
-    Path to a .psd1 configuration file with CustomBranding and FindingsNarrative
-    keys. Merged into the equivalent parameters — direct params win on conflict.
-    Enables reusable per-customer configuration. Automatically enables -WhiteLabel.
-.PARAMETER FindingsNarrative
-    Path to a .txt or .md file (or an inline string) containing consultant-authored
-    findings commentary. Rendered as a narrative card before the Executive Summary,
-    alongside auto-populated severity chip counts.
+    Strips all M365-Assess and GitHub identity from the report (hides the GitHub
+    link and open-source attribution in the React app).
 .PARAMETER CompactReport
     Omit cover page, executive summary, and compliance overview from the HTML
     report. Produces a lean, findings-focused report. Automatically set by
@@ -213,17 +200,7 @@ param(
     [switch]$OpenReport,
 
     [Parameter()]
-    [hashtable]$CustomBranding,
-
-    [Parameter()]
     [switch]$WhiteLabel,
-
-    [Parameter()]
-    [ValidateScript({ -not $_ -or (Test-Path -Path $_ -PathType Leaf) })]
-    [string]$CustomerProfile,
-
-    [Parameter()]
-    [string]$FindingsNarrative,
 
     [Parameter()]
     [switch]$CompactReport,
@@ -282,31 +259,6 @@ if (-not (Get-Command -Name Show-InteractiveWizard -ErrorAction SilentlyContinue
     Get-ChildItem -Path (Join-Path $projectRoot 'Orchestrator') -Filter '*.ps1' |
         ForEach-Object { . $_.FullName }
 }
-# ------------------------------------------------------------------
-# CustomerProfile — merge .psd1 into params (direct params win)
-# ------------------------------------------------------------------
-if ($CustomerProfile) {
-    $cpData = Import-PowerShellDataFile -Path $CustomerProfile
-    if ($cpData.ContainsKey('CustomBranding')) {
-        if (-not $PSBoundParameters.ContainsKey('CustomBranding')) {
-            $CustomBranding = $cpData['CustomBranding']
-        } else {
-            foreach ($key in $cpData['CustomBranding'].Keys) {
-                if (-not $CustomBranding.ContainsKey($key)) { $CustomBranding[$key] = $cpData['CustomBranding'][$key] }
-            }
-        }
-    }
-    if ($cpData.ContainsKey('FindingsNarrative') -and -not $PSBoundParameters.ContainsKey('FindingsNarrative')) {
-        $FindingsNarrative = $cpData['FindingsNarrative']
-    }
-    $WhiteLabel = $true
-}
-
-# CustomBranding implicitly enables WhiteLabel
-if ($PSBoundParameters.ContainsKey('CustomBranding') -and -not $WhiteLabel) {
-    $WhiteLabel = $true
-}
-
 # Show-InteractiveWizard -- extracted to Orchestrator/Show-InteractiveWizard.ps1
 # Resolve-M365Environment -- extracted to Orchestrator/Resolve-M365Environment.ps1
 
@@ -1314,10 +1266,8 @@ if (Test-Path -Path $reportScriptPath) {
         if ($script:domainPrefix) { $reportParams['TenantName'] = $script:domainPrefix }
         elseif ($TenantId)        { $reportParams['TenantName'] = $TenantId }
         if ($WhiteLabel)        { $reportParams['WhiteLabel']        = $true }
-        if ($FindingsNarrative) { $reportParams['FindingsNarrative'] = $FindingsNarrative }
         if ($CompactReport)     { $reportParams['CompactReport']     = $true }
         if ($OpenReport)        { $reportParams['OpenReport']        = $true }
-        if ($CustomBranding)    { $reportParams['CustomBranding']    = $CustomBranding }
         if ($QuickScan)         { $reportParams['QuickScan']         = $true }
         if ($driftReport.Count -gt 0 -or $driftBaselineLabel) {
             $reportParams['DriftReport']            = $driftReport

--- a/src/M365-Assess/M365-Assess.psd1
+++ b/src/M365-Assess/M365-Assess.psd1
@@ -51,7 +51,6 @@
         'Remove-M365ConnectionProfile'
         'Get-M365ConnectionProfile'
         'Compare-M365Baseline'
-        'New-M365BrandingConfig'
     )
     CmdletsToExport   = @()
     VariablesToExport = @()

--- a/src/M365-Assess/M365-Assess.psm1
+++ b/src/M365-Assess/M365-Assess.psm1
@@ -7,8 +7,6 @@ Get-ChildItem -Path "$PSScriptRoot\Orchestrator\*.ps1" | ForEach-Object { . $_.F
 . "$PSScriptRoot\Common\SecurityConfigHelper.ps1"
 . "$PSScriptRoot\Common\Resolve-DnsRecord.ps1"
 . "$PSScriptRoot\Orchestrator\Compare-M365Baseline.ps1"
-. "$PSScriptRoot\Common\New-M365BrandingConfig.ps1"
-
 # Dot-source the main orchestrator to import Invoke-M365Assessment function
 . $PSScriptRoot\Invoke-M365Assessment.ps1
 
@@ -212,7 +210,6 @@ Export-ModuleMember -Function @(
     'Get-M365PowerBISecurityConfig'
     'Get-M365PurviewRetentionConfig'
     'Compare-M365Baseline'
-    'New-M365BrandingConfig'
     'Grant-M365AssessConsent'
     'New-M365ConnectionProfile'
     'Set-M365ConnectionProfile'

--- a/tests/Common/Build-SectionHtml.Tests.ps1
+++ b/tests/Common/Build-SectionHtml.Tests.ps1
@@ -126,7 +126,6 @@ contoso.com,Pass,Pass,reject,Pass,Pass
         $allFrameworks    = @()
         $cisFrameworkId   = 'cis-m365-v6'
         $WhiteLabel       = $false
-        $CustomBranding   = $null
         $DriftReport      = @()
         $reportDomainPrefix = 'test'
 


### PR DESCRIPTION
## Summary

Breaking API changes for v2.0.0 param cleanup (plan Step 8 + 10):

- **`Invoke-M365Assessment.ps1`** — removed `-CustomBranding`, `-CustomerProfile`, `-FindingsNarrative` param declarations, help text, CustomerProfile `.psd1` merge block, and CustomBranding→WhiteLabel implicit enable
- **`Export-AssessmentReport.ps1`** — same three params removed; CustomerProfile merge block removed
- **`M365-Assess.psd1`** — `New-M365BrandingConfig` removed from `FunctionsToExport`
- **`M365-Assess.psm1`** — `New-M365BrandingConfig.ps1` dot-source removed from module loader; `New-M365BrandingConfig` removed from `Export-ModuleMember`
- **`Common/New-M365BrandingConfig.ps1`** — file retained on disk (used by private mods repo); tests for it remain and still pass
- **`ReportHelpers.ps1` / `ConvertTo-HtmlSafe`** — kept; still has active callers in `Build-RemediationPlanHtml`, `Build-IntuneOverviewHtml`, `Build-ValueOpportunityHtml`, `Export-ComplianceOverview`

## Test plan

- [x] 1990 Pester tests pass, 0 fail
- [x] `New-M365BrandingConfig.Tests.ps1` still passes (function file on disk, dot-sourced directly)
- [x] No stale param references remain in any test file
- [x] PSGallery readiness smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)