### PR TITLE
feat(console): synthwave ASCII logo for Show-AssessmentHeader

### DIFF
--- a/src/M365-Assess/Orchestrator/AssessmentHelpers.ps1
+++ b/src/M365-Assess/Orchestrator/AssessmentHelpers.ps1
@@ -190,27 +190,34 @@ function Show-AssessmentHeader {
     param([string]$TenantName, [string]$OutputPath, [string]$LogPath, [string]$Version)
 
     Write-Host ''
-    Write-Host '      ███╗   ███╗ ██████╗  ██████╗ ███████╗' -ForegroundColor Cyan
-    Write-Host '      ████╗ ████║ ╚════██╗ ██╔════╝ ██╔════╝' -ForegroundColor Cyan
-    Write-Host '      ██╔████╔██║  █████╔╝ ██████╗  ███████╗' -ForegroundColor Cyan
-    Write-Host '      ██║╚██╔╝██║  ╚═══██╗ ██╔══██╗ ╚════██║' -ForegroundColor Cyan
-    Write-Host '      ██║ ╚═╝ ██║ ██████╔╝ ╚█████╔╝ ███████║' -ForegroundColor Cyan
-    Write-Host '      ╚═╝     ╚═╝ ╚═════╝   ╚════╝  ╚══════╝' -ForegroundColor Cyan
-    Write-Host '     ─────────────────────────────────────────' -ForegroundColor DarkCyan
-    Write-Host '       █████╗ ███████╗███████╗███████╗███████╗███████╗' -ForegroundColor DarkCyan
-    Write-Host '      ██╔══██╗██╔════╝██╔════╝██╔════╝██╔════╝██╔════╝' -ForegroundColor DarkCyan
-    Write-Host '      ███████║███████╗███████╗█████╗  ███████╗███████╗' -ForegroundColor DarkCyan
-    Write-Host '      ██╔══██║╚════██║╚════██║██╔══╝  ╚════██║╚════██║' -ForegroundColor DarkCyan
-    Write-Host '      ██║  ██║███████║███████║███████╗███████║███████║' -ForegroundColor DarkCyan
-    Write-Host '      ╚═╝  ╚═╝╚══════╝╚══════╝╚══════╝╚══════╝╚══════╝' -ForegroundColor DarkCyan
+    Write-Host '  ▓▒░  M365-ASSESS // AUTOMATED SECURITY INTELLIGENCE  ░▒▓' -ForegroundColor DarkMagenta
+    Write-Host ''
+    # M365 — hot-pink neon at top, cooling to cyan at base
+    Write-Host '     ███╗   ███╗ ██████╗  ██████╗ ███████╗' -ForegroundColor Magenta
+    Write-Host '     ████╗ ████║ ╚════██╗ ██╔════╝ ██╔════╝' -ForegroundColor Magenta
+    Write-Host '     ██╔████╔██║  █████╔╝ ██████╗  ███████╗' -ForegroundColor DarkMagenta
+    Write-Host '     ██║╚██╔╝██║  ╚═══██╗ ██╔══██╗ ╚════██║' -ForegroundColor Cyan
+    Write-Host '     ██║ ╚═╝ ██║ ██████╔╝ ╚█████╔╝ ███████║' -ForegroundColor Cyan
+    Write-Host '     ╚═╝     ╚═╝ ╚═════╝   ╚════╝  ╚══════╝' -ForegroundColor DarkCyan
+    Write-Host '  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄' -ForegroundColor DarkGray
+    # ASSESS — cyan at top, deep blue at base
+    Write-Host '      █████╗ ███████╗███████╗███████╗███████╗███████╗' -ForegroundColor Cyan
+    Write-Host '     ██╔══██╗██╔════╝██╔════╝██╔════╝██╔════╝██╔════╝' -ForegroundColor Cyan
+    Write-Host '     ███████║███████╗███████╗█████╗  ███████╗███████╗' -ForegroundColor DarkCyan
+    Write-Host '     ██╔══██║╚════██║╚════██║██╔══╝  ╚════██║╚════██║' -ForegroundColor Blue
+    Write-Host '     ██║  ██║███████║███████║███████╗███████║███████║' -ForegroundColor Blue
+    Write-Host '     ╚═╝  ╚═╝╚══════╝╚══════╝╚══════╝╚══════╝╚══════╝' -ForegroundColor DarkBlue
+    Write-Host ''
+    Write-Host '  ▲  SECURITY INTELLIGENCE FOR THE MODERN ENTERPRISE  ▲' -ForegroundColor DarkCyan
+    Write-Host '  ░▒▓████████████████████████████████████████████████▓▒░' -ForegroundColor DarkMagenta
     Write-Host ''
     if ($TenantName) {
         $tenantLine = $TenantName
-        if ($tenantLine.Length -gt 45) { $tenantLine = $tenantLine.Substring(0, 42) + '...' }
-        Write-Host "        ░▒▓█  $tenantLine" -ForegroundColor White
+        if ($tenantLine.Length -gt 50) { $tenantLine = $tenantLine.Substring(0, 47) + '...' }
+        Write-Host "  ▶ TARGET ◀  $tenantLine" -ForegroundColor White
     }
     if ($Version) {
-        Write-Host "        ░▒▓█  v$Version  █▓▒░" -ForegroundColor DarkGray
+        Write-Host "  [ v$Version ]  ◆  M365-ASSESS  ◆  GALVNYZ" -ForegroundColor DarkGray
     }
     Write-Host ''
 }


### PR DESCRIPTION
## Summary
- Redesigns the `Show-AssessmentHeader` console banner with a retro 80s/cyberpunk synthwave aesthetic
- Gradient flows Magenta→DarkMagenta (M365 block) separated by a DarkGray dotted divider, then Cyan→DarkCyan→Blue→DarkBlue (ASSESS block)
- DarkMagenta frame lines top and bottom; target/version footer in White/DarkGray
- All ASCII art lines verified ≤ 58 chars (well within the 80-char limit)
- No new PSScriptAnalyzer warnings introduced

## Test plan
- [x] Line-length verification: max 58 chars (limit 80)
- [x] PSScriptAnalyzer lint: zero new warnings
- [x] Visual review: gradient confirmed via terminal rendering

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)