### PR TITLE
style(console): replace oversized ASCII block art with clean terminal card

### DIFF
--- a/src/M365-Assess/Orchestrator/AssessmentHelpers.ps1
+++ b/src/M365-Assess/Orchestrator/AssessmentHelpers.ps1
@@ -190,34 +190,20 @@ function Show-AssessmentHeader {
     param([string]$TenantName, [string]$OutputPath, [string]$LogPath, [string]$Version)
 
     Write-Host ''
-    Write-Host '  ▓▒░  M365-ASSESS // AUTOMATED SECURITY INTELLIGENCE  ░▒▓' -ForegroundColor DarkMagenta
-    Write-Host ''
-    # M365 — hot-pink neon at top, cooling to cyan at base
-    Write-Host '     ███╗   ███╗ ██████╗  ██████╗ ███████╗' -ForegroundColor Magenta
-    Write-Host '     ████╗ ████║ ╚════██╗ ██╔════╝ ██╔════╝' -ForegroundColor Magenta
-    Write-Host '     ██╔████╔██║  █████╔╝ ██████╗  ███████╗' -ForegroundColor DarkMagenta
-    Write-Host '     ██║╚██╔╝██║  ╚═══██╗ ██╔══██╗ ╚════██║' -ForegroundColor Cyan
-    Write-Host '     ██║ ╚═╝ ██║ ██████╔╝ ╚█████╔╝ ███████║' -ForegroundColor Cyan
-    Write-Host '     ╚═╝     ╚═╝ ╚═════╝   ╚════╝  ╚══════╝' -ForegroundColor DarkCyan
-    Write-Host '  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄' -ForegroundColor DarkGray
-    # ASSESS — cyan at top, deep blue at base
-    Write-Host '      █████╗ ███████╗███████╗███████╗███████╗███████╗' -ForegroundColor Cyan
-    Write-Host '     ██╔══██╗██╔════╝██╔════╝██╔════╝██╔════╝██╔════╝' -ForegroundColor Cyan
-    Write-Host '     ███████║███████╗███████╗█████╗  ███████╗███████╗' -ForegroundColor DarkCyan
-    Write-Host '     ██╔══██║╚════██║╚════██║██╔══╝  ╚════██║╚════██║' -ForegroundColor Blue
-    Write-Host '     ██║  ██║███████║███████║███████╗███████║███████║' -ForegroundColor Blue
-    Write-Host '     ╚═╝  ╚═╝╚══════╝╚══════╝╚══════╝╚══════╝╚══════╝' -ForegroundColor DarkBlue
-    Write-Host ''
-    Write-Host '  ▲  SECURITY INTELLIGENCE FOR THE MODERN ENTERPRISE  ▲' -ForegroundColor DarkCyan
-    Write-Host '  ░▒▓████████████████████████████████████████████████▓▒░' -ForegroundColor DarkMagenta
+    Write-Host '  ┌─────────────────────────────────────────────────────────────┐' -ForegroundColor DarkCyan
+    Write-Host '  │                                                             │' -ForegroundColor DarkCyan
+    Write-Host '  │   M365-ASSESS   ◆   Microsoft 365 Security Assessment      │' -ForegroundColor Cyan
+    Write-Host '  │   Automated  ·  Read-Only  ·  Galvnyz                      │' -ForegroundColor Gray
+    Write-Host '  │                                                             │' -ForegroundColor DarkCyan
+    Write-Host '  └─────────────────────────────────────────────────────────────┘' -ForegroundColor DarkCyan
     Write-Host ''
     if ($TenantName) {
         $tenantLine = $TenantName
-        if ($tenantLine.Length -gt 50) { $tenantLine = $tenantLine.Substring(0, 47) + '...' }
-        Write-Host "  ▶ TARGET ◀  $tenantLine" -ForegroundColor White
+        if ($tenantLine.Length -gt 52) { $tenantLine = $tenantLine.Substring(0, 49) + '...' }
+        Write-Host "  Target   $tenantLine" -ForegroundColor White
     }
     if ($Version) {
-        Write-Host "  [ v$Version ]  ◆  M365-ASSESS  ◆  GALVNYZ" -ForegroundColor DarkGray
+        Write-Host "  Version  v$Version" -ForegroundColor DarkGray
     }
     Write-Host ''
 }


### PR DESCRIPTION
Replaces the two 6-row block-letter stacks (M365 + ASSESS with hot-pink/cyan gradients) with a compact 6-line bordered card.

**Before:** 15+ lines, dual block-letter stacks, garish gradient colours  
**After:** Clean `┌─┐` card, 6 lines, cyan accent, grey subtitle

🤖 Generated with [Claude Code](https://claude.com/claude-code)