### PR TITLE
style(console): restore block letters with single-color scheme + box outline

### DIFF
--- a/src/M365-Assess/Orchestrator/AssessmentHelpers.ps1
+++ b/src/M365-Assess/Orchestrator/AssessmentHelpers.ps1
@@ -190,12 +190,18 @@ function Show-AssessmentHeader {
     param([string]$TenantName, [string]$OutputPath, [string]$LogPath, [string]$Version)
 
     Write-Host ''
-    Write-Host '  ┌─────────────────────────────────────────────────────────────┐' -ForegroundColor DarkCyan
-    Write-Host '  │                                                             │' -ForegroundColor DarkCyan
-    Write-Host '  │   M365-ASSESS   ◆   Microsoft 365 Security Assessment      │' -ForegroundColor Cyan
-    Write-Host '  │   Automated  ·  Read-Only  ·  Galvnyz                      │' -ForegroundColor Gray
-    Write-Host '  │                                                             │' -ForegroundColor DarkCyan
-    Write-Host '  └─────────────────────────────────────────────────────────────┘' -ForegroundColor DarkCyan
+    Write-Host '  ╔══════════════════════════════════════════════════════════╗' -ForegroundColor DarkCyan
+    Write-Host '  ║                                                          ║' -ForegroundColor DarkCyan
+    Write-Host '  ║  ███╗   ███╗ ██████╗  ██████╗ ███████╗                  ║' -ForegroundColor Cyan
+    Write-Host '  ║  ████╗ ████║╚════██╗ ██╔════╝ ██╔════╝                  ║' -ForegroundColor Cyan
+    Write-Host '  ║  ██╔████╔██║ █████╔╝ ██████╗  ███████╗                  ║' -ForegroundColor Cyan
+    Write-Host '  ║  ██║╚██╔╝██║ ╚═══██╗ ██╔══██╗ ╚════██║                  ║' -ForegroundColor Cyan
+    Write-Host '  ║  ██║ ╚═╝ ██║ ██████╔╝╚█████╔╝ ███████║                  ║' -ForegroundColor Cyan
+    Write-Host '  ║  ╚═╝     ╚═╝ ╚═════╝  ╚════╝  ╚══════╝                  ║' -ForegroundColor Cyan
+    Write-Host '  ║                                                          ║' -ForegroundColor DarkCyan
+    Write-Host '  ║  A S S E S S  ·  Microsoft 365 Security Assessment       ║' -ForegroundColor Cyan
+    Write-Host '  ║  Automated  ·  Read-Only  ·  Galvnyz                     ║' -ForegroundColor DarkCyan
+    Write-Host '  ╚══════════════════════════════════════════════════════════╝' -ForegroundColor DarkCyan
     Write-Host ''
     if ($TenantName) {
         $tenantLine = $TenantName

--- a/src/M365-Assess/Orchestrator/AssessmentHelpers.ps1
+++ b/src/M365-Assess/Orchestrator/AssessmentHelpers.ps1
@@ -190,34 +190,20 @@ function Show-AssessmentHeader {
     param([string]$TenantName, [string]$OutputPath, [string]$LogPath, [string]$Version)
 
     Write-Host ''
-    Write-Host '  ▓▒░  M365-ASSESS // AUTOMATED SECURITY INTELLIGENCE  ░▒▓' -ForegroundColor DarkMagenta
-    Write-Host ''
-    # M365 — hot-pink neon at top, cooling to cyan at base
-    Write-Host '     ███╗   ███╗ ██████╗  ██████╗ ███████╗' -ForegroundColor Magenta
-    Write-Host '     ████╗ ████║ ╚════██╗ ██╔════╝ ██╔════╝' -ForegroundColor Magenta
-    Write-Host '     ██╔████╔██║  █████╔╝ ██████╗  ███████╗' -ForegroundColor DarkMagenta
-    Write-Host '     ██║╚██╔╝██║  ╚═══██╗ ██╔══██╗ ╚════██║' -ForegroundColor Cyan
-    Write-Host '     ██║ ╚═╝ ██║ ██████╔╝ ╚█████╔╝ ███████║' -ForegroundColor Cyan
-    Write-Host '     ╚═╝     ╚═╝ ╚═════╝   ╚════╝  ╚══════╝' -ForegroundColor DarkCyan
-    Write-Host '  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄' -ForegroundColor DarkGray
-    # ASSESS — cyan at top, deep blue at base
-    Write-Host '      █████╗ ███████╗███████╗███████╗███████╗███████╗' -ForegroundColor Cyan
-    Write-Host '     ██╔══██╗██╔════╝██╔════╝██╔════╝██╔════╝██╔════╝' -ForegroundColor Cyan
-    Write-Host '     ███████║███████╗███████╗█████╗  ███████╗███████╗' -ForegroundColor DarkCyan
-    Write-Host '     ██╔══██║╚════██║╚════██║██╔══╝  ╚════██║╚════██║' -ForegroundColor Blue
-    Write-Host '     ██║  ██║███████║███████║███████╗███████║███████║' -ForegroundColor Blue
-    Write-Host '     ╚═╝  ╚═╝╚══════╝╚══════╝╚══════╝╚══════╝╚══════╝' -ForegroundColor DarkBlue
-    Write-Host ''
-    Write-Host '  ▲  SECURITY INTELLIGENCE FOR THE MODERN ENTERPRISE  ▲' -ForegroundColor DarkCyan
-    Write-Host '  ░▒▓████████████████████████████████████████████████▓▒░' -ForegroundColor DarkMagenta
+    Write-Host '  ┌─────────────────────────────────────────────────────────────┐' -ForegroundColor DarkCyan
+    Write-Host '  │                                                             │' -ForegroundColor DarkCyan
+    Write-Host '  │   M365-ASSESS   ◆   Microsoft 365 Security Assessment      │' -ForegroundColor Cyan
+    Write-Host '  │   Automated  ·  Read-Only  ·  Galvnyz                      │' -ForegroundColor Gray
+    Write-Host '  │                                                             │' -ForegroundColor DarkCyan
+    Write-Host '  └─────────────────────────────────────────────────────────────┘' -ForegroundColor DarkCyan
     Write-Host ''
     if ($TenantName) {
         $tenantLine = $TenantName
-        if ($tenantLine.Length -gt 50) { $tenantLine = $tenantLine.Substring(0, 47) + '...' }
-        Write-Host "  ▶ TARGET ◀  $tenantLine" -ForegroundColor White
+        if ($tenantLine.Length -gt 52) { $tenantLine = $tenantLine.Substring(0, 49) + '...' }
+        Write-Host "  Target   $tenantLine" -ForegroundColor White
     }
     if ($Version) {
-        Write-Host "  [ v$Version ]  ◆  M365-ASSESS  ◆  GALVNYZ" -ForegroundColor DarkGray
+        Write-Host "  Version  v$Version" -ForegroundColor DarkGray
     }
     Write-Host ''
 }


### PR DESCRIPTION
Brings back the M365 block art in uniform Cyan — no row gradient. Clean double-line ╔═╗ border. ASSESS as spaced subtitle letters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)