### PR TITLE
fix(progress): restore newline+cursor-up bar erase strategy

### DIFF
--- a/src/M365-Assess/Common/Show-CheckProgress.ps1
+++ b/src/M365-Assess/Common/Show-CheckProgress.ps1
@@ -67,7 +67,7 @@ function global:Write-M365GradientBar {
     }
     $bar    = ($chars) -join ''
     $status = "$($State.Completed) / $($State.Total) checks complete"
-    [Console]::Write("  ${e}[38;2;180;180;210mM365 Security Assessment${reset} [${bar}${reset}] ${e}[38;2;120;130;150m${status}${reset}`r")
+    [Console]::Write("  ${e}[38;2;180;180;210mM365 Security Assessment${reset} [${bar}${reset}] ${e}[38;2;120;130;150m${status}${reset}`n")
     $State.BarActive = $true
 }
 
@@ -76,7 +76,7 @@ function global:Clear-M365GradientBar {
     param([hashtable]$State)
     if (-not $State -or -not $State.BarActive) { return }
     $e = [char]27
-    [Console]::Write("`r${e}[2K")
+    [Console]::Write("${e}[1A${e}[2K`r")
     $State.BarActive = $false
 }
 


### PR DESCRIPTION
Closing — superseded by a full revert of the gradient bar feature (PR #579). The escape-code fix is moot since the entire ANSI bar is being removed.