### PR TITLE
fix(params): enumerate TenantId in all parameter sets — resolves PS 7.6+ binding failure

### DIFF
--- a/src/M365-Assess/Invoke-M365Assessment.ps1
+++ b/src/M365-Assess/Invoke-M365Assessment.ps1
@@ -156,11 +156,17 @@ param(
                  'PowerBI', 'Hybrid', 'Inventory', 'ActiveDirectory', 'SOC2', 'ValueOpportunity', 'All')]
     [string[]]$Section = @('Tenant', 'Identity', 'Licensing', 'Email', 'Intune', 'Security', 'Collaboration', 'PowerBI', 'Hybrid'),
 
-    # TenantId: optional in Interactive/DeviceCode/ManagedIdentity/SkipConnection sets;
-    # mandatory in app-only sets where the tenant cannot be inferred interactively.
-    [Parameter(ParameterSetName = 'AppOnlyCert',   Mandatory)]
-    [Parameter(ParameterSetName = 'AppOnlySecret', Mandatory)]
-    [Parameter()]
+    # TenantId: optional in interactive sets; mandatory in app-only sets where the
+    # tenant cannot be inferred interactively. Must be listed explicitly in every
+    # set — mixing named-set attributes with a bare [Parameter()] (__AllParameterSets)
+    # causes parameter-set resolution failures in PowerShell 7.6+.
+    [Parameter(ParameterSetName = 'AppOnlyCert',      Mandatory)]
+    [Parameter(ParameterSetName = 'AppOnlySecret',    Mandatory)]
+    [Parameter(ParameterSetName = 'Interactive')]
+    [Parameter(ParameterSetName = 'DeviceCode')]
+    [Parameter(ParameterSetName = 'ManagedIdentity')]
+    [Parameter(ParameterSetName = 'SkipConnection')]
+    [Parameter(ParameterSetName = 'ConnectionProfile')]
     [string]$TenantId,
 
     [Parameter()]


### PR DESCRIPTION
## Summary

- **Root cause**: `$TenantId` had both explicit `[Parameter(ParameterSetName='AppOnlyCert/AppOnlySecret', Mandatory)]` attributes *and* a bare `[Parameter()]` (which implies `__AllParameterSets`). PowerShell 7.6+ changed how it handles this mix, producing "Parameter set cannot be resolved" even when the call was logically unambiguous (e.g. `-TenantId x -UserPrincipalName y` should clearly land in the `Interactive` set).
- **Fix**: Explicitly list `TenantId` in all 7 parameter sets — `Mandatory` in `AppOnlyCert`/`AppOnlySecret`, optional everywhere else. The bare `[Parameter()]` is removed.
- **Verified**: `Get-Command` output confirms `TenantId` is now in all 7 sets with correct `IsMandatory` values; `-TenantId x -UserPrincipalName y` and `-TenantId x` both bind without error.

## Test plan

- [ ] `Invoke-M365Assessment -TenantId 'x.onmicrosoft.com' -UserPrincipalName 'admin@x.onmicrosoft.com'` — must resolve to `Interactive` set, no binding error
- [ ] `Invoke-M365Assessment -TenantId 'x.onmicrosoft.com' -UseDeviceCode` — must resolve to `DeviceCode` set
- [ ] `Invoke-M365Assessment -TenantId 'x' -ClientId 'y' -CertificateThumbprint 'z'` — must resolve to `AppOnlyCert` set with `TenantId` as Mandatory
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)