### PR TITLE
feat(entra): disabled member account count check (ENTRA-DISABLED-001)

### DIFF
--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -69,7 +69,7 @@ ENTRA-ADMIN-001.1    First setting assessed under ENTRA-ADMIN-001
 ENTRA-ADMIN-001.2    Second setting assessed under ENTRA-ADMIN-001
 ```
 
-The assessment suite includes **293 security checks** across 16 security config collectors (Entra, CA Evaluator, EntApp, EXO, DNS, Defender, Compliance, Stryker Readiness, Intune, SharePoint, Teams, Power BI, Forms, Purview Retention, SOC2, AzAssess), each mapped to one or more compliance frameworks.
+The assessment suite includes **294 security checks** across 16 security config collectors (Entra, CA Evaluator, EntApp, EXO, DNS, Defender, Compliance, Stryker Readiness, Intune, SharePoint, Teams, Power BI, Forms, Purview Retention, SOC2, AzAssess), each mapped to one or more compliance frameworks.
 
 ## Control Registry
 

--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -73,7 +73,7 @@ The assessment suite includes **294 security checks** across 16 security config 
 
 ## Control Registry
 
-Framework mappings are defined in `controls/registry.json`, which contains **1079 control entries** (CheckID v2.9.0 upstream). Each entry specifies the check ID, description, and mappings to all applicable frameworks.
+Framework mappings are defined in `controls/registry.json`, which contains **1080 control entries** (CheckID v2.9.0 upstream + ENTRA-DISABLED-001). Each entry specifies the check ID, description, and mappings to all applicable frameworks.
 
 To view or edit mappings:
 

--- a/src/M365-Assess/Entra/EntraUserGroupChecks.ps1
+++ b/src/M365-Assess/Entra/EntraUserGroupChecks.ps1
@@ -749,15 +749,15 @@ Add-Setting @settingParams
 # ------------------------------------------------------------------
 try {
     Write-Verbose "Counting disabled member accounts..."
-    $countHeaders = @{ 'ConsistencyLevel' = 'eventual' }
-    $totalCount    = Invoke-MgGraphRequest -Method GET `
+    $countHeaders  = @{ 'ConsistencyLevel' = 'eventual' }
+    $totalCount    = [int](Invoke-MgGraphRequest -Method GET `
         -Uri "/v1.0/users/`$count?`$filter=userType eq 'Member'" `
-        -Headers $countHeaders -ErrorAction Stop
-    $disabledCount = Invoke-MgGraphRequest -Method GET `
+        -Headers $countHeaders -ErrorAction Stop)
+    $disabledCount = [int](Invoke-MgGraphRequest -Method GET `
         -Uri "/v1.0/users/`$count?`$filter=accountEnabled eq false and userType eq 'Member'" `
-        -Headers $countHeaders -ErrorAction Stop
+        -Headers $countHeaders -ErrorAction Stop)
     $pct = if ($totalCount -gt 0) { [math]::Round($disabledCount / $totalCount * 100, 1) } else { 0 }
-    Add-Setting @{
+    $settingParams = @{
         CheckId          = 'ENTRA-DISABLED-001'
         Category         = 'Directory Health'
         Setting          = 'Disabled Member Accounts'
@@ -766,10 +766,11 @@ try {
         Status           = 'Info'
         Remediation      = 'Review disabled accounts and remove any that are no longer needed. Entra admin center > Users > All users > filter by Account status: Disabled.'
     }
+    Add-Setting @settingParams
 }
 catch {
     Write-Warning "Could not count disabled member accounts: $_"
-    Add-Setting @{
+    $settingParams = @{
         CheckId          = 'ENTRA-DISABLED-001'
         Category         = 'Directory Health'
         Setting          = 'Disabled Member Accounts'
@@ -778,4 +779,5 @@ catch {
         Status           = 'Skipped'
         Remediation      = 'Check Graph API permissions (User.Read.All) and retry.'
     }
+    Add-Setting @settingParams
 }

--- a/src/M365-Assess/Entra/EntraUserGroupChecks.ps1
+++ b/src/M365-Assess/Entra/EntraUserGroupChecks.ps1
@@ -743,3 +743,39 @@ $settingParams = @{
     Remediation      = 'M365 admin center > Settings > Org settings > Bookings > restrict shared booking pages to selected staff members.'
 }
 Add-Setting @settingParams
+
+# ------------------------------------------------------------------
+# Disabled Member Account Count
+# ------------------------------------------------------------------
+try {
+    Write-Verbose "Counting disabled member accounts..."
+    $countHeaders = @{ 'ConsistencyLevel' = 'eventual' }
+    $totalCount    = Invoke-MgGraphRequest -Method GET `
+        -Uri "/v1.0/users/`$count?`$filter=userType eq 'Member'" `
+        -Headers $countHeaders -ErrorAction Stop
+    $disabledCount = Invoke-MgGraphRequest -Method GET `
+        -Uri "/v1.0/users/`$count?`$filter=accountEnabled eq false and userType eq 'Member'" `
+        -Headers $countHeaders -ErrorAction Stop
+    $pct = if ($totalCount -gt 0) { [math]::Round($disabledCount / $totalCount * 100, 1) } else { 0 }
+    Add-Setting @{
+        CheckId          = 'ENTRA-DISABLED-001'
+        Category         = 'Directory Health'
+        Setting          = 'Disabled Member Accounts'
+        CurrentValue     = "$disabledCount disabled of $totalCount total members ($pct%)"
+        RecommendedValue = 'Review periodically; remove accounts no longer needed'
+        Status           = 'Info'
+        Remediation      = 'Review disabled accounts and remove any that are no longer needed. Entra admin center > Users > All users > filter by Account status: Disabled.'
+    }
+}
+catch {
+    Write-Warning "Could not count disabled member accounts: $_"
+    Add-Setting @{
+        CheckId          = 'ENTRA-DISABLED-001'
+        Category         = 'Directory Health'
+        Setting          = 'Disabled Member Accounts'
+        CurrentValue     = "Error: $($_.Exception.Message)"
+        RecommendedValue = 'Review periodically; remove accounts no longer needed'
+        Status           = 'Skipped'
+        Remediation      = 'Check Graph API permissions (User.Read.All) and retry.'
+    }
+}

--- a/src/M365-Assess/controls/local-extensions.json
+++ b/src/M365-Assess/controls/local-extensions.json
@@ -83,5 +83,37 @@
       "rationale": "Failure to route email through Exchange Online mail flow exposes the tenant to: Security control bypass; mail not traversing Exchange Online skips ATP scanning, DLP policies, mail flow rules, and anti-phishing defenses.",
       "scfWeighting": 7
     }
+  },
+  {
+    "checkId": "ENTRA-DISABLED-001",
+    "name": "Disabled Member Account Count",
+    "category": "DIRECTORY",
+    "collector": "Entra",
+    "hasAutomatedCheck": true,
+    "licensing": {
+      "minimum": "E3"
+    },
+    "frameworks": {
+      "nist-800-53": {
+        "controlId": "AC-2;AC-02(03)"
+      },
+      "cis-controls-v8": {
+        "controlId": "5.3;6.1"
+      },
+      "iso-27001": {
+        "controlId": "5.15;5.18"
+      },
+      "nist-csf": {
+        "controlId": "PR.AA-01"
+      },
+      "soc2": {
+        "controlId": "CC6.2;CC6.3"
+      }
+    },
+    "impactRating": {
+      "severity": "Info",
+      "rationale": "Informational: surfaces the total count of disabled member accounts alongside total directory size. High ratios may indicate accounts pending removal or an offboarding gap.",
+      "scfWeighting": 3
+    }
   }
 ]

--- a/tests/Entra/Get-EntraSecurityConfig.Tests.ps1
+++ b/tests/Entra/Get-EntraSecurityConfig.Tests.ps1
@@ -160,7 +160,7 @@ Describe 'Get-EntraSecurityConfig' {
     }
 
     It 'All Status values are valid' {
-        $validStatuses = @('Pass', 'Fail', 'Warning', 'Review', 'Info', 'N/A')
+        $validStatuses = @('Pass', 'Fail', 'Warning', 'Review', 'Info', 'N/A', 'Skipped')
         foreach ($s in $settings) {
             $s.Status | Should -BeIn $validStatuses `
                 -Because "Setting '$($s.Setting)' has status '$($s.Status)'"


### PR DESCRIPTION
## Summary

- Adds `ENTRA-DISABLED-001` — **Disabled Member Accounts** — to `EntraUserGroupChecks.ps1`
- Two `$count` Graph queries with `ConsistencyLevel: eventual` surface disabled member count alongside total directory size
- Output: `42 disabled of 350 total members (12%)` — `Info` status, no threshold enforcement
- Registry entry with NIST 800-53 AC-2, CIS Controls 5.3/6.1, ISO 27001 5.15/5.18, NIST CSF PR.AA-01, SOC 2 CC6.2/CC6.3
- COMPLIANCE.md updated: 293 → 294 checks

## Test plan

- [ ] Registry integrity tests pass (SOC 2 / NIST cross-ref)
- [ ] Script syntax validation passes
- [ ] sku-feature-map cross-reference passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)