### PR TITLE
fix(console): uniform color for license-skipped check entries

### DIFF
--- a/src/M365-Assess/Common/Show-CheckProgress.ps1
+++ b/src/M365-Assess/Common/Show-CheckProgress.ps1
@@ -207,7 +207,7 @@ function Initialize-CheckProgress {
             $planList = ($skipInfo.RequiredPlans | ForEach-Object {
                 if ($planFriendlyNames.ContainsKey($_)) { $planFriendlyNames[$_] } else { $_ }
             }) -join ' or '
-            Write-Host "    $([char]0x25B8) $($skipEntry.Key): $($skipInfo.Name)" -ForegroundColor DarkYellow
+            Write-Host "    $([char]0x25B8) $($skipEntry.Key): $($skipInfo.Name)" -ForegroundColor DarkGray
             Write-Host "      Requires: $planList" -ForegroundColor DarkGray
         }
     }


### PR DESCRIPTION
## Summary

- Check names in the skipped-checks section used `DarkYellow`; `Requires:` lines used `DarkGray` — caused alternating colors on every other line
- Both now use `DarkGray` to match the collector list style above
- Section header `N checks skipped (tenant lacks required license):` retains `DarkYellow` as a visual callout

## Test plan

- [ ] CI passes (doc-only adjacent change, no logic touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)