### PR TITLE
feat: collector schema additions — intentDesign, user staleness, DMARC staged rollout, tenantAgeYears

### DIFF
--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -69,7 +69,7 @@ ENTRA-ADMIN-001.1    First setting assessed under ENTRA-ADMIN-001
 ENTRA-ADMIN-001.2    Second setting assessed under ENTRA-ADMIN-001
 ```
 
-The assessment suite includes **293 security checks** across 16 security config collectors (Entra, CA Evaluator, EntApp, EXO, DNS, Defender, Compliance, Stryker Readiness, Intune, SharePoint, Teams, Power BI, Forms, Purview Retention, SOC2, AzAssess), each mapped to one or more compliance frameworks.
+The assessment suite includes **294 security checks** across 16 security config collectors (Entra, CA Evaluator, EntApp, EXO, DNS, Defender, Compliance, Stryker Readiness, Intune, SharePoint, Teams, Power BI, Forms, Purview Retention, SOC2, AzAssess), each mapped to one or more compliance frameworks.
 
 ## Control Registry
 

--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -73,7 +73,7 @@ The assessment suite includes **294 security checks** across 16 security config 
 
 ## Control Registry
 
-Framework mappings are defined in `controls/registry.json`, which contains **1079 control entries** (CheckID v2.9.0 upstream). Each entry specifies the check ID, description, and mappings to all applicable frameworks.
+Framework mappings are defined in `controls/registry.json`, which contains **1080 control entries** (CheckID v2.9.0 upstream + ENTRA-DISABLED-001). Each entry specifies the check ID, description, and mappings to all applicable frameworks.
 
 To view or edit mappings:
 

--- a/src/M365-Assess/Common/Build-ReportData.ps1
+++ b/src/M365-Assess/Common/Build-ReportData.ps1
@@ -142,19 +142,20 @@ function Build-ReportDataJson {
                        else                                              { '' }
 
         $findings.Add([PSCustomObject]@{
-            checkId     = $f.CheckId
-            status      = $f.Status
-            severity    = $severity
-            domain      = Get-CheckDomain -CheckId $baseCheckId
-            section     = $f.Section
-            category    = $f.Category
-            setting     = $f.Setting
-            current     = $f.CurrentValue
-            recommended = $recommended
-            remediation = $f.Remediation
-            effort      = if ($regEntry) { $e = if ($regEntry -is [hashtable]) { $regEntry['effort'] } else { $regEntry.effort }; if ($e) { $e } else { 'medium' } } else { 'medium' }
-            frameworks  = $frameworks
-            fwMeta      = $fwMeta
+            checkId      = $f.CheckId
+            status       = $f.Status
+            severity     = $severity
+            domain       = Get-CheckDomain -CheckId $baseCheckId
+            section      = $f.Section
+            category     = $f.Category
+            setting      = $f.Setting
+            current      = $f.CurrentValue
+            recommended  = $recommended
+            remediation  = $f.Remediation
+            effort       = if ($regEntry) { $e = if ($regEntry -is [hashtable]) { $regEntry['effort'] } else { $regEntry.effort }; if ($e) { $e } else { 'medium' } } else { 'medium' }
+            frameworks   = $frameworks
+            fwMeta       = $fwMeta
+            intentDesign = [bool]($f.PSObject.Properties['IntentDesign'] -and $f.IntentDesign)
         })
     }
 
@@ -210,9 +211,19 @@ function Build-ReportDataJson {
 
     $frameworkList = @($FrameworkDefs | ForEach-Object { @{ id = $_['frameworkId']; full = $_['label'] } })
 
+    $tenantRows = @($tenantRows | ForEach-Object {
+        $ageYears = $null
+        if ($_.CreatedDateTime) {
+            try { $ageYears = [math]::Round(((Get-Date) - [datetime]$_.CreatedDateTime).TotalDays / 365.25, 1) }
+            catch { Write-Verbose "Could not parse tenant CreatedDateTime: $_" }
+        }
+        $_ | Select-Object OrgDisplayName, TenantId, DefaultDomain, CreatedDateTime,
+            @{ N = 'tenantAgeYears'; E = { $ageYears } }
+    })
+
     $reportData = [ordered]@{
-        tenant         = @($tenantRows | Select-Object OrgDisplayName, TenantId, DefaultDomain, CreatedDateTime)
-        users          = @($usersRows  | Select-Object TotalUsers, Licensed, GuestUsers, SyncedFromOnPrem)
+        tenant         = @($tenantRows)
+        users          = @($usersRows  | Select-Object TotalUsers, Licensed, GuestUsers, SyncedFromOnPrem, DisabledUsers, NeverSignedIn, StaleMember)
         score          = @($scoreRows  | Select-Object Percentage, AverageComparativeScore, CurrentScore, MaxScore, CreatedDateTime)
         mfaStats       = $mfaStats
         findings       = @($findings)

--- a/src/M365-Assess/Common/SecurityConfigHelper.ps1
+++ b/src/M365-Assess/Common/SecurityConfigHelper.ps1
@@ -95,7 +95,10 @@ function Add-SecuritySetting {
         [string]$CheckId = '',
 
         [Parameter()]
-        [string]$Remediation = ''
+        [string]$Remediation = '',
+
+        [Parameter()]
+        [switch]$IntentDesign
     )
 
     # Auto-generate sub-numbered CheckId for individual setting traceability
@@ -123,6 +126,7 @@ function Add-SecuritySetting {
         Status           = $Status
         CheckId          = $subCheckId
         Remediation      = $Remediation
+        IntentDesign     = [bool]$IntentDesign
     })
 
     # Accumulate adoption signal for Value Opportunity analysis

--- a/src/M365-Assess/Entra/EntraUserGroupChecks.ps1
+++ b/src/M365-Assess/Entra/EntraUserGroupChecks.ps1
@@ -749,15 +749,15 @@ Add-Setting @settingParams
 # ------------------------------------------------------------------
 try {
     Write-Verbose "Counting disabled member accounts..."
-    $countHeaders = @{ 'ConsistencyLevel' = 'eventual' }
-    $totalCount    = Invoke-MgGraphRequest -Method GET `
+    $countHeaders  = @{ 'ConsistencyLevel' = 'eventual' }
+    $totalCount    = [int](Invoke-MgGraphRequest -Method GET `
         -Uri "/v1.0/users/`$count?`$filter=userType eq 'Member'" `
-        -Headers $countHeaders -ErrorAction Stop
-    $disabledCount = Invoke-MgGraphRequest -Method GET `
+        -Headers $countHeaders -ErrorAction Stop)
+    $disabledCount = [int](Invoke-MgGraphRequest -Method GET `
         -Uri "/v1.0/users/`$count?`$filter=accountEnabled eq false and userType eq 'Member'" `
-        -Headers $countHeaders -ErrorAction Stop
+        -Headers $countHeaders -ErrorAction Stop)
     $pct = if ($totalCount -gt 0) { [math]::Round($disabledCount / $totalCount * 100, 1) } else { 0 }
-    Add-Setting @{
+    $settingParams = @{
         CheckId          = 'ENTRA-DISABLED-001'
         Category         = 'Directory Health'
         Setting          = 'Disabled Member Accounts'
@@ -766,10 +766,11 @@ try {
         Status           = 'Info'
         Remediation      = 'Review disabled accounts and remove any that are no longer needed. Entra admin center > Users > All users > filter by Account status: Disabled.'
     }
+    Add-Setting @settingParams
 }
 catch {
     Write-Warning "Could not count disabled member accounts: $_"
-    Add-Setting @{
+    $settingParams = @{
         CheckId          = 'ENTRA-DISABLED-001'
         Category         = 'Directory Health'
         Setting          = 'Disabled Member Accounts'
@@ -778,4 +779,5 @@ catch {
         Status           = 'Skipped'
         Remediation      = 'Check Graph API permissions (User.Read.All) and retry.'
     }
+    Add-Setting @settingParams
 }

--- a/src/M365-Assess/Entra/EntraUserGroupChecks.ps1
+++ b/src/M365-Assess/Entra/EntraUserGroupChecks.ps1
@@ -743,3 +743,39 @@ $settingParams = @{
     Remediation      = 'M365 admin center > Settings > Org settings > Bookings > restrict shared booking pages to selected staff members.'
 }
 Add-Setting @settingParams
+
+# ------------------------------------------------------------------
+# Disabled Member Account Count
+# ------------------------------------------------------------------
+try {
+    Write-Verbose "Counting disabled member accounts..."
+    $countHeaders = @{ 'ConsistencyLevel' = 'eventual' }
+    $totalCount    = Invoke-MgGraphRequest -Method GET `
+        -Uri "/v1.0/users/`$count?`$filter=userType eq 'Member'" `
+        -Headers $countHeaders -ErrorAction Stop
+    $disabledCount = Invoke-MgGraphRequest -Method GET `
+        -Uri "/v1.0/users/`$count?`$filter=accountEnabled eq false and userType eq 'Member'" `
+        -Headers $countHeaders -ErrorAction Stop
+    $pct = if ($totalCount -gt 0) { [math]::Round($disabledCount / $totalCount * 100, 1) } else { 0 }
+    Add-Setting @{
+        CheckId          = 'ENTRA-DISABLED-001'
+        Category         = 'Directory Health'
+        Setting          = 'Disabled Member Accounts'
+        CurrentValue     = "$disabledCount disabled of $totalCount total members ($pct%)"
+        RecommendedValue = 'Review periodically; remove accounts no longer needed'
+        Status           = 'Info'
+        Remediation      = 'Review disabled accounts and remove any that are no longer needed. Entra admin center > Users > All users > filter by Account status: Disabled.'
+    }
+}
+catch {
+    Write-Warning "Could not count disabled member accounts: $_"
+    Add-Setting @{
+        CheckId          = 'ENTRA-DISABLED-001'
+        Category         = 'Directory Health'
+        Setting          = 'Disabled Member Accounts'
+        CurrentValue     = "Error: $($_.Exception.Message)"
+        RecommendedValue = 'Review periodically; remove accounts no longer needed'
+        Status           = 'Skipped'
+        Remediation      = 'Check Graph API permissions (User.Read.All) and retry.'
+    }
+}

--- a/src/M365-Assess/Entra/Get-UserSummary.ps1
+++ b/src/M365-Assess/Entra/Get-UserSummary.ps1
@@ -96,6 +96,10 @@ $disabledCount = 0
 $syncedCount = 0
 $cloudOnlyCount = 0
 $activeSignInCount = 0
+$neverSignedInCount = $null
+$staleMemberCount = $null
+
+$staleThreshold = (Get-Date).AddDays(-90)
 
 foreach ($user in $allUsers) {
     if ($user.assignedLicenses -and @($user.assignedLicenses).Count -gt 0) {
@@ -118,8 +122,23 @@ foreach ($user in $allUsers) {
     }
 
     # Sign-in activity (available only with AuditLog.Read.All + AAD Premium)
-    if (-not $fallback -and $user.signInActivity.lastSignInDateTime) {
-        $activeSignInCount++
+    if (-not $fallback) {
+        $lastSignIn = $user.signInActivity?.lastSignInDateTime
+        if ($lastSignIn) {
+            $activeSignInCount++
+        }
+        else {
+            if ($null -eq $neverSignedInCount) { $neverSignedInCount = 0 }
+            $neverSignedInCount++
+        }
+
+        # Stale member: enabled member account with no sign-in in 90 days (or never)
+        if ($user.accountEnabled -eq $true -and $user.userType -ne 'Guest') {
+            if ($null -eq $staleMemberCount) { $staleMemberCount = 0 }
+            if (-not $lastSignIn -or [datetime]$lastSignIn -lt $staleThreshold) {
+                $staleMemberCount++
+            }
+        }
     }
 }
 
@@ -131,6 +150,8 @@ $report = @([PSCustomObject]@{
     SyncedFromOnPrem = $syncedCount
     CloudOnly        = $cloudOnlyCount
     WithMFA          = $activeSignInCount
+    NeverSignedIn    = $neverSignedInCount
+    StaleMember      = $staleMemberCount
 })
 
 Write-Verbose "User summary: $totalUsers total, $licensedCount licensed, $guestCount guests, $disabledCount disabled"

--- a/src/M365-Assess/Exchange-Online/Get-DnsSecurityConfig.ps1
+++ b/src/M365-Assess/Exchange-Online/Get-DnsSecurityConfig.ps1
@@ -299,9 +299,10 @@ else {
     # ------------------------------------------------------------------
     try {
         Write-Verbose "Checking DMARC records..."
-        $dmarcMissing = @()
-        $dmarcWeak = @()
-        $dmarcStrong = @()
+        $dmarcMissing    = @()
+        $dmarcNone       = @()   # p=none — monitoring only, no enforcement
+        $dmarcQuarantine = @()   # p=quarantine — staged rollout in progress
+        $dmarcReject     = @()   # p=reject — fully enforced
         foreach ($domain in $authDomains) {
             $domainName = $domain.DomainName
             if ($servfailDomains.Contains($domainName)) { continue }
@@ -312,40 +313,60 @@ else {
             }
             else {
                 $policy = ($dmarcRecord.Strings | Select-Object -First 1)
-                if ($policy -match 'p=(quarantine|reject)') {
-                    $dmarcStrong += $domainName
+                if ($policy -match 'p=reject') {
+                    $dmarcReject += $domainName
                     $null = $dmarcEnforcingDomains.Add($domainName)
                 }
-                else { $dmarcWeak += $domainName }
+                elseif ($policy -match 'p=quarantine') {
+                    $dmarcQuarantine += $domainName
+                    $null = $dmarcEnforcingDomains.Add($domainName)
+                }
+                else {
+                    $dmarcNone += $domainName
+                }
             }
         }
 
-        $totalGood = $dmarcStrong.Count
-        $totalDomains = $dmarcStrong.Count + $dmarcWeak.Count + $dmarcMissing.Count
-        if ($dmarcMissing.Count -eq 0 -and $dmarcWeak.Count -eq 0) {
+        $totalDomains = $dmarcReject.Count + $dmarcQuarantine.Count + $dmarcNone.Count + $dmarcMissing.Count
+        if ($dmarcMissing.Count -eq 0 -and $dmarcNone.Count -eq 0 -and $dmarcQuarantine.Count -eq 0) {
+            # All domains at p=reject
             $settingParams = @{
                 Category         = 'DNS Authentication'
                 Setting          = 'DMARC Records'
-                CurrentValue     = "$totalGood/$totalDomains domains have enforcing DMARC"
-                RecommendedValue = 'DMARC p=quarantine or p=reject for all'
+                CurrentValue     = "$($dmarcReject.Count)/$totalDomains domains at p=reject"
+                RecommendedValue = 'DMARC p=reject for all domains'
                 Status           = 'Pass'
                 CheckId          = 'DNS-DMARC-001'
                 Remediation      = 'No action needed.'
             }
             Add-Setting @settingParams
         }
-        else {
-            $issues = @()
-            if ($dmarcMissing.Count -gt 0) { $issues += "missing: $($dmarcMissing -join ', ')" }
-            if ($dmarcWeak.Count -gt 0) { $issues += "p=none: $($dmarcWeak -join ', ')" }
+        elseif ($dmarcMissing.Count -eq 0 -and $dmarcNone.Count -eq 0) {
+            # All domains at quarantine or reject — staged rollout in progress
             $settingParams = @{
                 Category         = 'DNS Authentication'
                 Setting          = 'DMARC Records'
-                CurrentValue     = "$totalGood/$totalDomains enforcing -- $($issues -join '; ')"
-                RecommendedValue = 'DMARC p=quarantine or p=reject for all'
+                CurrentValue     = "$($dmarcReject.Count)/$totalDomains at p=reject; $($dmarcQuarantine.Count) at p=quarantine (staged): $($dmarcQuarantine -join ', ')"
+                RecommendedValue = 'DMARC p=reject for all domains'
+                Status           = 'Warning'
+                CheckId          = 'DNS-DMARC-001'
+                Remediation      = "Advance p=quarantine domains to p=reject once DMARC reports confirm no legitimate mail is failing: $($dmarcQuarantine -join ', ')"
+            }
+            Add-Setting @settingParams
+        }
+        else {
+            $issues = @()
+            if ($dmarcMissing.Count -gt 0) { $issues += "missing: $($dmarcMissing -join ', ')" }
+            if ($dmarcNone.Count -gt 0) { $issues += "p=none: $($dmarcNone -join ', ')" }
+            if ($dmarcQuarantine.Count -gt 0) { $issues += "p=quarantine (staged): $($dmarcQuarantine -join ', ')" }
+            $settingParams = @{
+                Category         = 'DNS Authentication'
+                Setting          = 'DMARC Records'
+                CurrentValue     = "$($dmarcReject.Count)/$totalDomains at p=reject -- $($issues -join '; ')"
+                RecommendedValue = 'DMARC p=reject for all domains'
                 Status           = 'Fail'
                 CheckId          = 'DNS-DMARC-001'
-                Remediation      = "Add/update DMARC for: $($issues -join '; '). Example: v=DMARC1; p=reject; rua=mailto:dmarc@yourdomain.com"
+                Remediation      = "Add/update DMARC for: $($issues -join '; '). Start with p=none + rua= to gather reports, then advance to p=quarantine, then p=reject. Example: v=DMARC1; p=reject; rua=mailto:dmarc@yourdomain.com"
             }
             Add-Setting @settingParams
         }

--- a/src/M365-Assess/controls/local-extensions.json
+++ b/src/M365-Assess/controls/local-extensions.json
@@ -83,5 +83,37 @@
       "rationale": "Failure to route email through Exchange Online mail flow exposes the tenant to: Security control bypass; mail not traversing Exchange Online skips ATP scanning, DLP policies, mail flow rules, and anti-phishing defenses.",
       "scfWeighting": 7
     }
+  },
+  {
+    "checkId": "ENTRA-DISABLED-001",
+    "name": "Disabled Member Account Count",
+    "category": "DIRECTORY",
+    "collector": "Entra",
+    "hasAutomatedCheck": true,
+    "licensing": {
+      "minimum": "E3"
+    },
+    "frameworks": {
+      "nist-800-53": {
+        "controlId": "AC-2;AC-02(03)"
+      },
+      "cis-controls-v8": {
+        "controlId": "5.3;6.1"
+      },
+      "iso-27001": {
+        "controlId": "5.15;5.18"
+      },
+      "nist-csf": {
+        "controlId": "PR.AA-01"
+      },
+      "soc2": {
+        "controlId": "CC6.2;CC6.3"
+      }
+    },
+    "impactRating": {
+      "severity": "Info",
+      "rationale": "Informational: surfaces the total count of disabled member accounts alongside total directory size. High ratios may indicate accounts pending removal or an offboarding gap.",
+      "scfWeighting": 3
+    }
   }
 ]

--- a/tests/Entra/Get-EntraSecurityConfig.Tests.ps1
+++ b/tests/Entra/Get-EntraSecurityConfig.Tests.ps1
@@ -160,7 +160,7 @@ Describe 'Get-EntraSecurityConfig' {
     }
 
     It 'All Status values are valid' {
-        $validStatuses = @('Pass', 'Fail', 'Warning', 'Review', 'Info', 'N/A')
+        $validStatuses = @('Pass', 'Fail', 'Warning', 'Review', 'Info', 'N/A', 'Skipped')
         foreach ($s in $settings) {
             $s.Status | Should -BeIn $validStatuses `
                 -Because "Setting '$($s.Setting)' has status '$($s.Status)'"


### PR DESCRIPTION
## Summary

Collector-side data additions that unblock display features in the private report templates.

- **intentDesign flag** — `Add-SecuritySetting` gains `-IntentDesign` switch; `Build-ReportData.ps1` emits it as a bool on every finding. The HTML report uses this to render a "By Design" chip instead of a Fail/Warning status badge for accepted exceptions.

- **User staleness counts** — `Get-UserSummary.ps1` now tracks `NeverSignedIn` (any user with no recorded sign-in) and `StaleMember` (enabled member accounts with no sign-in in 90 days). Both are `null` when `signInActivity` is unavailable (non-Premium tenants / missing `AuditLog.Read.All`), so downstream consumers can distinguish "not available" from "zero".

- **Tenant age** — `Build-ReportData.ps1` computes `tenantAgeYears` from `CreatedDateTime` and includes it in the `tenant` object.

- **DMARC staged rollout** — `Get-DnsSecurityConfig.ps1` now distinguishes three DMARC states:
  - `p=reject` only → **Pass**
  - All domains at `p=quarantine` or `p=reject`, none at `p=none` → **Warning** ("staged rollout in progress")
  - Any `p=none` or missing → **Fail**
  
  Both `p=quarantine` and `p=reject` domains are still added to `$dmarcEnforcingDomains` so downstream routing/MX checks are unaffected.

## Test plan

- [ ] `Invoke-Pester -Path ./tests -Output Detailed` — no new failures
- [ ] `Invoke-ScriptAnalyzer` — no new warnings on modified files
- [ ] Generate a report with a known DMARC-quarantine domain; verify finding status is Warning not Pass
- [ ] Verify `intentDesign = false` on all findings when `-IntentDesign` is not passed
- [ ] In a non-Premium tenant (no signInActivity), verify `NeverSignedIn` and `StaleMember` are null not 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)