### PR TITLE
chore(release): v2.1.0 — version bump, CHANGELOG, README badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to M365 Assess are documented here. This project uses [Conve
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-04-20
+
+### Added
+- Dashboard panels: DNS authentication summary, Intune device categories, mailbox summary, and SharePoint config panels in the report home view (#601)
+- Sidebar sub-navigation for long section lists — collapses into a scrollable sub-menu (#599)
+- Roadmap deep-link: clicking a finding in the Findings panel now deep-links to its entry in the Remediation Roadmap (#599)
+- `intentDesign` flag on findings — collector sets this to suppress false-positive guidance for intentional configurations (#597)
+- User staleness metrics (`NeverSignedIn`, `StaleMember` columns) added to user summary data (#597)
+- DMARC staged-rollout detection — policy `none` with active reporting now emits a `Review` instead of `Fail` (#597)
+- `tenantAgeYears` computed field added to tenant data (derived from `CreatedDateTime`) (#597)
+- Framework description and official homepage URL now sourced from registry JSON and surfaced in the framework detail panel; `FW_BLURB` constants serve as fallback (#606, closes #592)
+
+### Changed
+- Secure Score card splits `CurrentScore / MaxScore` into two separate stat values — easier to read at a glance (#599)
+
+### Fixed
+- Report theme and mode were not applied on initial load — `data-theme="dark"` and `data-mode="comfort"` were invalid CSS selector values; replaced with correct defaults (`neon`/`dark`) and added anti-flash inline script in `<head>` (#604)
+- `localStorage` access wrapped in `try/catch` to prevent `SecurityError` when report is opened from `file://` URLs in strict browser environments (#604)
+
+### Changed (infrastructure)
+- CheckID registry synced to v2.14.0 — 14 new upstream checks across EXO, Entra, Intune, and Teams domains (#603)
+
 ## [2.0.0] - 2026-04-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [![Coverage](https://img.shields.io/badge/coverage-check%20CI-informational)](https://github.com/Galvnyz/M365-Assess/actions/workflows/ci.yml)
 [![PowerShell 7.x](https://img.shields.io/badge/PowerShell-7.x-blue?logo=powershell&logoColor=white)](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows)
 [![Read-Only](https://img.shields.io/badge/Operations-Read--Only-brightgreen)](.)
-[![Version](https://img.shields.io/badge/version-2.0.0-blue)](.)
+[![Version](https://img.shields.io/badge/version-2.1.0-blue)](.)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 </div>

--- a/src/M365-Assess/M365-Assess.psd1
+++ b/src/M365-Assess/M365-Assess.psd1
@@ -3,7 +3,7 @@
     # Generated: 2026-03-08
 
     RootModule        = 'M365-Assess.psm1'
-    ModuleVersion     = '2.0.0'
+    ModuleVersion     = '2.1.0'
     GUID              = 'f7e3b2a1-4c5d-6e8f-9a0b-1c2d3e4f5a6b'
     Author            = 'Galvnyz'
     CompanyName       = 'Community'
@@ -230,7 +230,7 @@
             IconUri      = 'https://raw.githubusercontent.com/Galvnyz/M365-Assess/main/src/M365-Assess/assets/m365-assess-logo.png'
             LicenseUri   = 'https://github.com/Galvnyz/M365-Assess/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/Galvnyz/M365-Assess'
-            ReleaseNotes = 'v2.0.0 - React 18 report engine: single-file HTML with inline CSS/JS, window.REPORT_DATA JSON bridge, real Secure Score sparkline, framework blurbs and links, tenant + MFA sidebar cards, single-column remediation roadmap, findings panel without duplicate remediation block; synthwave ASCII banner; dark h/c mode brand-mark fix; removed -CustomBranding, -FindingsNarrative, -CustomerProfile, New-M365BrandingConfig'
+            ReleaseNotes = 'v2.1.0 - New dashboard panels (DNS auth, Intune categories, mailbox summary, SPO config); UX quick wins (score split, roadmap deep-link, sidebar sub-nav); collector schema additions (intentDesign, user staleness, DMARC staged rollout, tenantAgeYears); framework description and homepage URL surfaced from registry; report theme FOUC fix; CheckID v2.14.0 sync'
         }
     }
 }


### PR DESCRIPTION
## Summary
- Bumps `ModuleVersion` to `2.1.0` in `M365-Assess.psd1`
- Updates `ReleaseNotes` in `M365-Assess.psd1`
- Updates version badge in `README.md`
- Adds `## [2.1.0]` section to `CHANGELOG.md`

Closes v2.1.0 milestone. All feature PRs (#597, #599, #601, #603, #604, #606) already merged to main.

## Test plan
- [ ] `ModuleVersion` reads `2.1.0` in psd1
- [ ] README badge shows `version-2.1.0`
- [ ] CHANGELOG `[2.1.0]` section present with correct date

🤖 Generated with [Claude Code](https://claude.com/claude-code)