### PR TITLE
feat(report): AD/Hybrid dashboard panel (#562)

### DIFF
--- a/docs/sample-report/_Example-Report.html
+++ b/docs/sample-report/_Example-Report.html
@@ -21918,6 +21918,110 @@ function SharePointSummaryPanel() {
   }, f.setting)))));
 }
 
+// ======================== AD / Hybrid panel ========================
+function AdHybridPanel() {
+  const ad = D.adHybrid;
+  if (!ad) return null;
+  const adFindings = FINDINGS.filter(f => f.domain === 'Active Directory');
+  const pass = adFindings.filter(f => f.status === 'Pass').length;
+  const fail = adFindings.filter(f => f.status === 'Fail').length;
+  const syncOk = ad.syncEnabled;
+  const syncColor = syncOk ? 'var(--success-text)' : 'var(--danger-text)';
+  const fmtDate = d => {
+    if (!d) return 'Unknown';
+    try {
+      return new Date(d).toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric'
+      });
+    } catch {
+      return d;
+    }
+  };
+  const SEV_ORDER = {
+    critical: 4,
+    high: 3,
+    medium: 2,
+    low: 1
+  };
+  const topFails = adFindings.filter(f => f.status === 'Fail').sort((a, b) => (SEV_ORDER[b.severity] || 0) - (SEV_ORDER[a.severity] || 0)).slice(0, 3);
+  return /*#__PURE__*/React.createElement("div", {
+    className: "domain-sub-panel"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "panel-sublabel"
+  }, "Active Directory \xB7 hybrid posture"), /*#__PURE__*/React.createElement("div", {
+    className: "spo-summary-row"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "spo-stat-card"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "kpi-label"
+  }, "Directory sync"), /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 13,
+      fontWeight: 700,
+      color: syncColor,
+      marginTop: 6
+    }
+  }, syncOk ? 'Enabled' : 'Disabled'), ad.syncType && /*#__PURE__*/React.createElement("div", {
+    className: "kpi-hint"
+  }, ad.syncType)), /*#__PURE__*/React.createElement("div", {
+    className: "spo-stat-card"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "kpi-label"
+  }, "Last sync"), /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 12,
+      fontWeight: 600,
+      color: 'var(--text-soft)',
+      marginTop: 6,
+      lineHeight: 1.3
+    }
+  }, fmtDate(ad.lastSyncTime)), /*#__PURE__*/React.createElement("div", {
+    className: "kpi-hint"
+  }, "Password hash: ", ad.pwHashSync ? 'Yes' : 'No')), adFindings.length > 0 && /*#__PURE__*/React.createElement("div", {
+    className: 'spo-stat-card' + (fail > 0 ? ' spo-stat-bad' : '')
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "kpi-label"
+  }, "AD checks"), /*#__PURE__*/React.createElement("div", {
+    className: "kpi-value"
+  }, pct(pass, adFindings.length), /*#__PURE__*/React.createElement("span", {
+    style: {
+      fontSize: 14
+    }
+  }, "%")), /*#__PURE__*/React.createElement("div", {
+    className: "kpi-hint"
+  }, pass, " pass \xB7 ", fail, " fail"), /*#__PURE__*/React.createElement("div", {
+    className: "tiny-bar"
+  }, /*#__PURE__*/React.createElement("span", {
+    style: {
+      width: pct(pass, adFindings.length) + '%',
+      background: 'var(--success)'
+    }
+  }))), ad.highRiskFindings > 0 && /*#__PURE__*/React.createElement("div", {
+    className: "spo-stat-card spo-stat-bad"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "kpi-label"
+  }, "High/Critical risks"), /*#__PURE__*/React.createElement("div", {
+    className: "kpi-value"
+  }, ad.highRiskFindings), /*#__PURE__*/React.createElement("div", {
+    className: "kpi-hint"
+  }, "security findings"))), topFails.length > 0 && /*#__PURE__*/React.createElement("div", {
+    className: "spo-top-fails"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "spo-top-fails-label"
+  }, "Top gaps"), topFails.map((f, i) => /*#__PURE__*/React.createElement("div", {
+    key: i,
+    className: "spo-fail-row"
+  }, /*#__PURE__*/React.createElement("span", {
+    className: 'sev-badge ' + f.severity
+  }, /*#__PURE__*/React.createElement("span", {
+    className: "bar"
+  }, /*#__PURE__*/React.createElement("i", null), /*#__PURE__*/React.createElement("i", null), /*#__PURE__*/React.createElement("i", null), /*#__PURE__*/React.createElement("i", null)), /*#__PURE__*/React.createElement("span", null, SEV_LABEL[f.severity])), /*#__PURE__*/React.createElement("span", {
+    className: "spo-fail-name"
+  }, f.setting)))));
+}
+
 // ======================== Domain rollup ========================
 function DomainRollup({
   onJump
@@ -21978,7 +22082,7 @@ function DomainRollup({
     })), /*#__PURE__*/React.createElement("div", {
       className: "dc-meta"
     }, /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, d.pass), " pass"), /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, d.warn), " warn"), /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, d.fail), " fail"), d.review > 0 && /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, d.review), " review")));
-  })), /*#__PURE__*/React.createElement(IntuneCategoryGrid, null), /*#__PURE__*/React.createElement(MailboxSummaryPanel, null), /*#__PURE__*/React.createElement(SharePointSummaryPanel, null));
+  })), /*#__PURE__*/React.createElement(IntuneCategoryGrid, null), /*#__PURE__*/React.createElement(MailboxSummaryPanel, null), /*#__PURE__*/React.createElement(SharePointSummaryPanel, null), /*#__PURE__*/React.createElement(AdHybridPanel, null));
 }
 
 // ======================== Framework quilt ========================

--- a/src/M365-Assess/Common/Build-ReportData.ps1
+++ b/src/M365-Assess/Common/Build-ReportData.ps1
@@ -233,6 +233,23 @@ function Build-ReportDataJson {
         outboundConnectors = @($mfRows | Where-Object { $_.ItemType -eq 'OutboundConnector' }).Count
     }
 
+    # AD/Hybrid panel — shape hybrid sync + security data for the AdHybridPanel component
+    $adHybridRows   = & $get 'ad-hybrid'
+    $adSecurityRows = & $get 'ad-security'
+    $adHybridData   = $null
+    if ($adHybridRows.Count -gt 0) {
+        $row = $adHybridRows[0]
+        $highRiskCount = @($adSecurityRows | Where-Object { $_.RiskLevel -eq 'High' -or $_.RiskLevel -eq 'Critical' }).Count
+        $adHybridData  = [ordered]@{
+            syncEnabled      = [bool]($row.OnPremisesSyncEnabled -eq 'True')
+            lastSyncTime     = if ($row.LastDirSyncTime) { [string]$row.LastDirSyncTime } else { $null }
+            syncType         = if ($row.SyncType) { [string]$row.SyncType } else { $null }
+            pwHashSync       = [bool]($row.PasswordHashSyncEnabled -eq 'True')
+            securityFindings = $adSecurityRows.Count
+            highRiskFindings = $highRiskCount
+        }
+    }
+
     # SharePoint config — extract sharing level from the security-config collector CSV
     $spoRows = & $get 'sharepoint-config'
     $spoConfig = [ordered]@{}
@@ -269,6 +286,7 @@ function Build-ReportDataJson {
         mailboxSummary = if ($mbxMap.Count) { $mbxMap } else { $null }
         mailflowStats  = if ($mfRows.Count) { $mailflowStats } else { $null }
         sharepointConfig = if ($spoConfig.Count) { $spoConfig } else { $null }
+        adHybrid       = $adHybridData
     }
 
     # ------------------------------------------------------------------

--- a/src/M365-Assess/Common/Build-SectionHtml.ps1
+++ b/src/M365-Assess/Common/Build-SectionHtml.ps1
@@ -47,6 +47,8 @@ $sectionData = @{
     'mailbox-summary'  = & $loadCsv 'Get-MailboxSummary.csv'
     'mailflow'         = & $loadCsv 'Get-MailFlowReport.csv'
     'sharepoint-config'= & $loadCsv 'Get-SharePointSecurityConfig.csv'
+    'ad-hybrid'        = & $loadCsv '23-Hybrid-Sync.csv'
+    'ad-security'      = & $loadCsv '26-AD-Security.csv'
 }
 
 # ------------------------------------------------------------------

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -1184,6 +1184,110 @@ function SharePointSummaryPanel() {
   }, f.setting)))));
 }
 
+// ======================== AD / Hybrid panel ========================
+function AdHybridPanel() {
+  const ad = D.adHybrid;
+  if (!ad) return null;
+  const adFindings = FINDINGS.filter(f => f.domain === 'Active Directory');
+  const pass = adFindings.filter(f => f.status === 'Pass').length;
+  const fail = adFindings.filter(f => f.status === 'Fail').length;
+  const syncOk = ad.syncEnabled;
+  const syncColor = syncOk ? 'var(--success-text)' : 'var(--danger-text)';
+  const fmtDate = d => {
+    if (!d) return 'Unknown';
+    try {
+      return new Date(d).toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric'
+      });
+    } catch {
+      return d;
+    }
+  };
+  const SEV_ORDER = {
+    critical: 4,
+    high: 3,
+    medium: 2,
+    low: 1
+  };
+  const topFails = adFindings.filter(f => f.status === 'Fail').sort((a, b) => (SEV_ORDER[b.severity] || 0) - (SEV_ORDER[a.severity] || 0)).slice(0, 3);
+  return /*#__PURE__*/React.createElement("div", {
+    className: "domain-sub-panel"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "panel-sublabel"
+  }, "Active Directory \xB7 hybrid posture"), /*#__PURE__*/React.createElement("div", {
+    className: "spo-summary-row"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "spo-stat-card"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "kpi-label"
+  }, "Directory sync"), /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 13,
+      fontWeight: 700,
+      color: syncColor,
+      marginTop: 6
+    }
+  }, syncOk ? 'Enabled' : 'Disabled'), ad.syncType && /*#__PURE__*/React.createElement("div", {
+    className: "kpi-hint"
+  }, ad.syncType)), /*#__PURE__*/React.createElement("div", {
+    className: "spo-stat-card"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "kpi-label"
+  }, "Last sync"), /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 12,
+      fontWeight: 600,
+      color: 'var(--text-soft)',
+      marginTop: 6,
+      lineHeight: 1.3
+    }
+  }, fmtDate(ad.lastSyncTime)), /*#__PURE__*/React.createElement("div", {
+    className: "kpi-hint"
+  }, "Password hash: ", ad.pwHashSync ? 'Yes' : 'No')), adFindings.length > 0 && /*#__PURE__*/React.createElement("div", {
+    className: 'spo-stat-card' + (fail > 0 ? ' spo-stat-bad' : '')
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "kpi-label"
+  }, "AD checks"), /*#__PURE__*/React.createElement("div", {
+    className: "kpi-value"
+  }, pct(pass, adFindings.length), /*#__PURE__*/React.createElement("span", {
+    style: {
+      fontSize: 14
+    }
+  }, "%")), /*#__PURE__*/React.createElement("div", {
+    className: "kpi-hint"
+  }, pass, " pass \xB7 ", fail, " fail"), /*#__PURE__*/React.createElement("div", {
+    className: "tiny-bar"
+  }, /*#__PURE__*/React.createElement("span", {
+    style: {
+      width: pct(pass, adFindings.length) + '%',
+      background: 'var(--success)'
+    }
+  }))), ad.highRiskFindings > 0 && /*#__PURE__*/React.createElement("div", {
+    className: "spo-stat-card spo-stat-bad"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "kpi-label"
+  }, "High/Critical risks"), /*#__PURE__*/React.createElement("div", {
+    className: "kpi-value"
+  }, ad.highRiskFindings), /*#__PURE__*/React.createElement("div", {
+    className: "kpi-hint"
+  }, "security findings"))), topFails.length > 0 && /*#__PURE__*/React.createElement("div", {
+    className: "spo-top-fails"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "spo-top-fails-label"
+  }, "Top gaps"), topFails.map((f, i) => /*#__PURE__*/React.createElement("div", {
+    key: i,
+    className: "spo-fail-row"
+  }, /*#__PURE__*/React.createElement("span", {
+    className: 'sev-badge ' + f.severity
+  }, /*#__PURE__*/React.createElement("span", {
+    className: "bar"
+  }, /*#__PURE__*/React.createElement("i", null), /*#__PURE__*/React.createElement("i", null), /*#__PURE__*/React.createElement("i", null), /*#__PURE__*/React.createElement("i", null)), /*#__PURE__*/React.createElement("span", null, SEV_LABEL[f.severity])), /*#__PURE__*/React.createElement("span", {
+    className: "spo-fail-name"
+  }, f.setting)))));
+}
+
 // ======================== Domain rollup ========================
 function DomainRollup({
   onJump
@@ -1244,7 +1348,7 @@ function DomainRollup({
     })), /*#__PURE__*/React.createElement("div", {
       className: "dc-meta"
     }, /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, d.pass), " pass"), /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, d.warn), " warn"), /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, d.fail), " fail"), d.review > 0 && /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, d.review), " review")));
-  })), /*#__PURE__*/React.createElement(IntuneCategoryGrid, null), /*#__PURE__*/React.createElement(MailboxSummaryPanel, null), /*#__PURE__*/React.createElement(SharePointSummaryPanel, null));
+  })), /*#__PURE__*/React.createElement(IntuneCategoryGrid, null), /*#__PURE__*/React.createElement(MailboxSummaryPanel, null), /*#__PURE__*/React.createElement(SharePointSummaryPanel, null), /*#__PURE__*/React.createElement(AdHybridPanel, null));
 }
 
 // ======================== Framework quilt ========================

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -624,6 +624,68 @@ function SharePointSummaryPanel() {
   );
 }
 
+// ======================== AD / Hybrid panel ========================
+function AdHybridPanel() {
+  const ad = D.adHybrid;
+  if (!ad) return null;
+  const adFindings = FINDINGS.filter(f => f.domain === 'Active Directory');
+  const pass = adFindings.filter(f => f.status==='Pass').length;
+  const fail = adFindings.filter(f => f.status==='Fail').length;
+  const syncOk   = ad.syncEnabled;
+  const syncColor = syncOk ? 'var(--success-text)' : 'var(--danger-text)';
+  const fmtDate  = d => {
+    if (!d) return 'Unknown';
+    try { return new Date(d).toLocaleDateString(undefined, { year:'numeric', month:'short', day:'numeric' }); }
+    catch { return d; }
+  };
+  const SEV_ORDER = { critical:4, high:3, medium:2, low:1 };
+  const topFails = adFindings.filter(f=>f.status==='Fail')
+    .sort((a,b)=>(SEV_ORDER[b.severity]||0)-(SEV_ORDER[a.severity]||0)).slice(0,3);
+  return (
+    <div className="domain-sub-panel">
+      <div className="panel-sublabel">Active Directory · hybrid posture</div>
+      <div className="spo-summary-row">
+        <div className="spo-stat-card">
+          <div className="kpi-label">Directory sync</div>
+          <div style={{fontSize:13, fontWeight:700, color: syncColor, marginTop:6}}>{syncOk ? 'Enabled' : 'Disabled'}</div>
+          {ad.syncType && <div className="kpi-hint">{ad.syncType}</div>}
+        </div>
+        <div className="spo-stat-card">
+          <div className="kpi-label">Last sync</div>
+          <div style={{fontSize:12, fontWeight:600, color:'var(--text-soft)', marginTop:6, lineHeight:1.3}}>{fmtDate(ad.lastSyncTime)}</div>
+          <div className="kpi-hint">Password hash: {ad.pwHashSync ? 'Yes' : 'No'}</div>
+        </div>
+        {adFindings.length > 0 && (
+          <div className={'spo-stat-card' + (fail>0?' spo-stat-bad':'')}>
+            <div className="kpi-label">AD checks</div>
+            <div className="kpi-value">{pct(pass, adFindings.length)}<span style={{fontSize:14}}>%</span></div>
+            <div className="kpi-hint">{pass} pass · {fail} fail</div>
+            <div className="tiny-bar"><span style={{width: pct(pass, adFindings.length)+'%', background:'var(--success)'}}/></div>
+          </div>
+        )}
+        {ad.highRiskFindings > 0 && (
+          <div className="spo-stat-card spo-stat-bad">
+            <div className="kpi-label">High/Critical risks</div>
+            <div className="kpi-value">{ad.highRiskFindings}</div>
+            <div className="kpi-hint">security findings</div>
+          </div>
+        )}
+      </div>
+      {topFails.length > 0 && (
+        <div className="spo-top-fails">
+          <div className="spo-top-fails-label">Top gaps</div>
+          {topFails.map((f, i) => (
+            <div key={i} className="spo-fail-row">
+              <span className={'sev-badge ' + f.severity}><span className="bar"><i/><i/><i/><i/></span><span>{SEV_LABEL[f.severity]}</span></span>
+              <span className="spo-fail-name">{f.setting}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ======================== Domain rollup ========================
 function DomainRollup({ onJump }) {
   return (
@@ -665,6 +727,7 @@ function DomainRollup({ onJump }) {
       <IntuneCategoryGrid />
       <MailboxSummaryPanel />
       <SharePointSummaryPanel />
+      <AdHybridPanel />
     </section>
   );
 }

--- a/tests/Common/Build-ReportData.Tests.ps1
+++ b/tests/Common/Build-ReportData.Tests.ps1
@@ -546,4 +546,32 @@ Describe 'Build-ReportData' {
             $ev.PolicyCount | Should -Be 3
         }
     }
+
+    Context 'adHybrid shaping' {
+        It 'should set adHybrid to null when ad-hybrid section data is absent' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson)
+            $d.adHybrid | Should -BeNullOrEmpty
+        }
+
+        It 'should populate adHybrid when hybrid sync row is present' {
+            $hybrid = [PSCustomObject]@{
+                OnPremisesSyncEnabled   = 'True'
+                LastDirSyncTime         = '2026-04-01T00:00:00Z'
+                SyncType                = 'AADConnect'
+                PasswordHashSyncEnabled = 'True'
+            }
+            $sec1 = [PSCustomObject]@{ RiskLevel = 'High'; FindingName = 'Kerberoastable account' }
+            $sec2 = [PSCustomObject]@{ RiskLevel = 'Low';  FindingName = 'Stale user' }
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -SectionData @{
+                'ad-hybrid'   = @($hybrid)
+                'ad-security' = @($sec1, $sec2)
+            })
+            $d.adHybrid              | Should -Not -BeNullOrEmpty
+            $d.adHybrid.syncEnabled  | Should -Be $true
+            $d.adHybrid.syncType     | Should -Be 'AADConnect'
+            $d.adHybrid.pwHashSync   | Should -Be $true
+            $d.adHybrid.securityFindings | Should -Be 2
+            $d.adHybrid.highRiskFindings | Should -Be 1
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- `Build-SectionHtml.ps1`: loads `23-Hybrid-Sync.csv` and `26-AD-Security.csv` into `$sectionData` keys `ad-hybrid` / `ad-security`
- `Build-ReportData.ps1`: shapes `adHybrid` REPORT_DATA object from hybrid sync row — `syncEnabled`, `lastSyncTime`, `syncType`, `pwHashSync`, `securityFindings`, `highRiskFindings` (High + Critical count)
- `report-app.jsx`: adds `AdHybridPanel` React component (57 lines) rendered in `DomainRollup` after `SharePointSummaryPanel`, gated on `D.adHybrid !== null` (hidden for cloud-only tenants)
- 2 new Pester tests: null path (no CSV data → `adHybrid` is null) + populated path (sync row + security rows → all fields shaped correctly)

## Test plan

- [ ] Run `Invoke-Pester -Path './tests/Common/Build-ReportData.Tests.ps1'` — expect 67 tests passing
- [ ] Open sample report — AD/Hybrid panel hidden (cloud-only data fixture, `adHybrid` is null)
- [ ] Manually inject `window.REPORT_DATA.adHybrid = {...}` in browser console and verify panel renders metric cards

Closes #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)