### PR TITLE
fix(frameworks): clarify ISO 27001 label as 27001+27002, add AI disclosure (#618)

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,5 +462,5 @@ This project is licensed under the MIT License. See [LICENSE](LICENSE) for detai
 ---
 
 <div align="center">
-<sub>Built by <a href="https://github.com/Daren9m">Daren9m</a> and contributors</sub>
+<sub>Built by <a href="https://github.com/Daren9m">Daren9m</a> and contributors &nbsp;·&nbsp; Developed with <a href="https://claude.ai/code">Claude Code</a> (Anthropic)</sub>
 </div>

--- a/src/M365-Assess/controls/frameworks/iso-27001.json
+++ b/src/M365-Assess/controls/frameworks/iso-27001.json
@@ -1,8 +1,8 @@
 {
   "frameworkId": "iso-27001",
-  "label": "ISO/IEC 27001:2022",
+  "label": "ISO/IEC 27001 + 27002:2022",
   "version": "2022",
-  "description": "International standard for information security management systems (ISMS). Specifies requirements for establishing, implementing, maintaining, and continually improving organizational information security.",
+  "description": "Findings evaluated against ISO/IEC 27002:2022 implementation guidance and mapped to ISO/IEC 27001:2022 Annex A control IDs. Pass/Fail reflects whether the technical control is implemented per 27002 guidance — not whether the ISO 27001 certification requirement itself is met, as 27001 is risk-based and does not prescribe specific technical configurations.",
   "homepageUrl": "https://www.iso.org/standard/27001",
   "css": "fw-iso",
   "totalControls": 93,


### PR DESCRIPTION
## Summary

- `iso-27001.json`: rename label to `ISO/IEC 27001 + 27002:2022`; update description to clarify that Pass/Fail reflects ISO 27002:2022 implementation guidance mapped to ISO 27001:2022 Annex A control IDs — not the risk-based ISO 27001 certification requirement itself
- `README.md`: add Claude Code (Anthropic) co-development disclosure to footer

## Context

Raised in #618 by a certified ISO 27001:2022 Lead Auditor. ISO 27001 is principles-based and does not prescribe specific technical configurations (e.g. MFA); that prescriptive guidance lives in ISO 27002. Our checks evaluate against 27002 implementation guidance and map to 27001 Annex A IDs — the old label implied the FAIL was against the ISO 27001 standard itself, which could mislead inexperienced auditors.

## Test plan

- [ ] Open sample report — framework filter chip should show "ISO/IEC 27001 + 27002:2022"
- [ ] Framework detail panel description should reflect the updated 27001/27002 distinction
- [ ] README footer renders correctly on GitHub

Closes #618

🤖 Generated with [Claude Code](https://claude.com/claude-code)