### PR TITLE
chore(v2.2.0): version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,19 @@ All notable changes to M365 Assess are documented here. This project uses [Conve
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-04-20
+
 ### Added
 - Roadmap CSV export — "Download CSV" button in the Remediation Roadmap exports the current roadmap table (reflecting any localStorage lane overrides) with columns: Lane, Setting, CheckID, Severity, Effort, Domain, Section, CurrentValue, RecommendedValue, Remediation, LearnMore, ControlRef (#549)
 - Evidence field Phase 1 — 5 collectors (CA-MFA-ADMIN-001, ENTRA-SECDEFAULT-001, DEFENDER-ANTIPHISH-001, EXO-AUTH-001, SPO-SHARING-001) emit structured evidence data wired through `REPORT_DATA.findings[].evidence`; React finding detail panel shows a collapsible `<details>` Evidence block (#546)
 - AD/Hybrid dashboard panel — `AdHybridPanel` React component in the report home view surfaces hybrid sync status, last sync time, sync type, password hash sync, and AD security finding counts when ActiveDirectory section is in scope (#562)
+
+### Changed
+- ISO/IEC 27001 framework label updated to "ISO/IEC 27001 + 27002:2022"; description clarifies that Pass/Fail reflects ISO 27002 implementation guidance mapped to ISO 27001 Annex A control IDs — not the risk-based certification requirement (#618)
+- README footer now discloses Claude Code (Anthropic) co-development
+
+### Changed (infrastructure)
+- CheckID registry synced to v2.17.0 — 1096 total control entries; BACKUP-ENABLED-001 marked hasAutomatedCheck=false (no collector implemented) (#619)
 
 ## [2.1.0] - 2026-04-20
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [![Coverage](https://img.shields.io/badge/coverage-check%20CI-informational)](https://github.com/Galvnyz/M365-Assess/actions/workflows/ci.yml)
 [![PowerShell 7.x](https://img.shields.io/badge/PowerShell-7.x-blue?logo=powershell&logoColor=white)](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows)
 [![Read-Only](https://img.shields.io/badge/Operations-Read--Only-brightgreen)](.)
-[![Version](https://img.shields.io/badge/version-2.1.0-blue)](.)
+[![Version](https://img.shields.io/badge/version-2.2.0-blue)](.)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 </div>

--- a/src/M365-Assess/M365-Assess.psd1
+++ b/src/M365-Assess/M365-Assess.psd1
@@ -3,7 +3,7 @@
     # Generated: 2026-03-08
 
     RootModule        = 'M365-Assess.psm1'
-    ModuleVersion     = '2.1.0'
+    ModuleVersion     = '2.2.0'
     GUID              = 'f7e3b2a1-4c5d-6e8f-9a0b-1c2d3e4f5a6b'
     Author            = 'Galvnyz'
     CompanyName       = 'Community'
@@ -231,7 +231,7 @@
             IconUri      = 'https://raw.githubusercontent.com/Galvnyz/M365-Assess/main/src/M365-Assess/assets/m365-assess-logo.png'
             LicenseUri   = 'https://github.com/Galvnyz/M365-Assess/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/Galvnyz/M365-Assess'
-            ReleaseNotes = 'v2.1.0 - New dashboard panels (DNS auth, Intune categories, mailbox summary, SPO config); UX quick wins (score split, roadmap deep-link, sidebar sub-nav); collector schema additions (intentDesign, user staleness, DMARC staged rollout, tenantAgeYears); framework description and homepage URL surfaced from registry; report theme FOUC fix; CheckID v2.14.0 sync'
+            ReleaseNotes = 'v2.2.0 - Roadmap CSV export; Evidence field Phase 1 (5 collectors); AD/Hybrid dashboard panel; ISO 27001+27002 label clarification; AI disclosure; CheckID v2.17.0 sync'
         }
     }
 }


### PR DESCRIPTION
## Summary

Bumps version to 2.2.0 across all 4 locations:

- `M365-Assess.psd1` ModuleVersion: `2.1.0` → `2.2.0`
- `M365-Assess.psd1` ReleaseNotes: updated
- `README.md` version badge: `2.1.0` → `2.2.0`
- `CHANGELOG.md`: `[Unreleased]` promoted to `[2.2.0] - 2026-04-20`

## What's in v2.2.0

- Roadmap CSV export (#549, PR #614)
- Evidence field Phase 1 — 5 collectors (#546, PR #615)
- AD/Hybrid dashboard panel (#562, PR #616)
- Docs / awesome-lists update (#551, PR #617)
- ISO 27001+27002 label clarification + AI disclosure (#618, PR #620)
- CheckID v2.17.0 sync (#619)

🤖 Generated with [Claude Code](https://claude.com/claude-code)