### PR TITLE
feat(hybrid): surface AD/Hybrid panel from Entra when AD collectors not run

### DIFF
--- a/docs/sample-report/_Example-Report.html
+++ b/docs/sample-report/_Example-Report.html
@@ -22392,7 +22392,9 @@ function AdHybridPanel() {
   const pass = adFindings.filter(f => f.status === 'Pass').length;
   const fail = adFindings.filter(f => f.status === 'Fail').length;
   const syncOk = ad.syncEnabled;
+  const phsOk = ad.pwHashSync;
   const syncColor = syncOk ? 'var(--success-text)' : 'var(--danger-text)';
+  const phsColor = phsOk ? 'var(--success-text)' : 'var(--danger-text)';
   const fmtDate = d => {
     if (!d) return 'Unknown';
     try {
@@ -22416,7 +22418,13 @@ function AdHybridPanel() {
     className: "domain-sub-panel"
   }, /*#__PURE__*/React.createElement("div", {
     className: "panel-sublabel"
-  }, "Active Directory \xB7 hybrid posture"), /*#__PURE__*/React.createElement("div", {
+  }, "Active Directory \xB7 hybrid posture", ad.entraOnly && /*#__PURE__*/React.createElement("span", {
+    className: "kpi-hint",
+    style: {
+      marginLeft: 8,
+      fontWeight: 400
+    }
+  }, "(Entra data \u2014 AD collectors not run)")), /*#__PURE__*/React.createElement("div", {
     className: "spo-summary-row"
   }, /*#__PURE__*/React.createElement("div", {
     className: "spo-stat-card"
@@ -22443,9 +22451,31 @@ function AdHybridPanel() {
       marginTop: 6,
       lineHeight: 1.3
     }
-  }, fmtDate(ad.lastSyncTime)), /*#__PURE__*/React.createElement("div", {
+  }, fmtDate(ad.lastSyncTime))), /*#__PURE__*/React.createElement("div", {
+    className: 'spo-stat-card' + (!phsOk ? ' spo-stat-bad' : '')
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "kpi-label"
+  }, "Password hash sync"), /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 13,
+      fontWeight: 700,
+      color: phsColor,
+      marginTop: 6
+    }
+  }, phsOk ? 'Enabled' : 'Disabled'), !phsOk && /*#__PURE__*/React.createElement("div", {
+    className: "kpi-hint",
+    style: {
+      color: 'var(--danger-text)'
+    }
+  }, "Users cannot reset passwords from Entra")), ad.syncErrorCount > 0 && /*#__PURE__*/React.createElement("div", {
+    className: "spo-stat-card spo-stat-bad"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "kpi-label"
+  }, "Sync errors"), /*#__PURE__*/React.createElement("div", {
+    className: "kpi-value"
+  }, ad.syncErrorCount), /*#__PURE__*/React.createElement("div", {
     className: "kpi-hint"
-  }, "Password hash: ", ad.pwHashSync ? 'Yes' : 'No')), adFindings.length > 0 && /*#__PURE__*/React.createElement("div", {
+  }, "provisioning errors")), !ad.entraOnly && adFindings.length > 0 && /*#__PURE__*/React.createElement("div", {
     className: 'spo-stat-card' + (fail > 0 ? ' spo-stat-bad' : '')
   }, /*#__PURE__*/React.createElement("div", {
     className: "kpi-label"
@@ -22464,7 +22494,7 @@ function AdHybridPanel() {
       width: pct(pass, adFindings.length) + '%',
       background: 'var(--success)'
     }
-  }))), ad.highRiskFindings > 0 && /*#__PURE__*/React.createElement("div", {
+  }))), !ad.entraOnly && ad.highRiskFindings > 0 && /*#__PURE__*/React.createElement("div", {
     className: "spo-stat-card spo-stat-bad"
   }, /*#__PURE__*/React.createElement("div", {
     className: "kpi-label"

--- a/src/M365-Assess/Common/Build-ReportData.ps1
+++ b/src/M365-Assess/Common/Build-ReportData.ps1
@@ -247,6 +247,30 @@ function Build-ReportDataJson {
             pwHashSync       = [bool]($row.PasswordHashSyncEnabled -eq 'True')
             securityFindings = $adSecurityRows.Count
             highRiskFindings = $highRiskCount
+            syncErrorCount   = 0
+            entraOnly        = $false
+        }
+    }
+
+    # Entra-side fallback: populate adHybridData from tenant info when AD section was not run.
+    # Get-TenantInfo writes OnPremisesSyncEnabled + PHS datetime fields to 01-Tenant-Info.csv.
+    if ($null -eq $adHybridData -and $tenantRows.Count -gt 0) {
+        $t = $tenantRows[0]
+        $hasSyncField = $t.PSObject.Properties['OnPremisesSyncEnabled']
+        if ($hasSyncField -and $t.OnPremisesSyncEnabled -eq 'True') {
+            $lastSync = if ($t.PSObject.Properties['OnPremisesLastSyncDateTime']) { $t.OnPremisesLastSyncDateTime } else { $null }
+            $phsDate  = if ($t.PSObject.Properties['OnPremisesLastPasswordSyncDateTime']) { $t.OnPremisesLastPasswordSyncDateTime } else { $null }
+            $errCount = if ($t.PSObject.Properties['OnPremisesProvisioningErrorCount']) { [int]$t.OnPremisesProvisioningErrorCount } else { 0 }
+            $adHybridData = [ordered]@{
+                syncEnabled      = $true
+                lastSyncTime     = if ($lastSync) { [string]$lastSync } else { $null }
+                syncType         = $null
+                pwHashSync       = ($null -ne $phsDate -and $phsDate -ne '')
+                securityFindings = 0
+                highRiskFindings = 0
+                syncErrorCount   = $errCount
+                entraOnly        = $true
+            }
         }
     }
 

--- a/src/M365-Assess/Entra/Get-TenantInfo.ps1
+++ b/src/M365-Assess/Entra/Get-TenantInfo.ps1
@@ -82,13 +82,18 @@ $defaultDomain = $domains |
 
 # Handle multiple organizations (typically just one)
 $report = foreach ($org in $organization) {
+    $provisioningErrorCount = if ($org.OnPremisesProvisioningErrors) { @($org.OnPremisesProvisioningErrors).Count } else { 0 }
     [PSCustomObject]@{
-        OrgDisplayName          = $org.DisplayName
-        TenantId                = $org.Id
-        VerifiedDomains         = $verifiedDomainsJoined
-        DefaultDomain           = $defaultDomain
-        SecurityDefaultsEnabled = if ($null -ne $securityDefaults) { $securityDefaults['isEnabled'] } else { 'N/A' }
-        CreatedDateTime         = $org.CreatedDateTime
+        OrgDisplayName                     = $org.DisplayName
+        TenantId                           = $org.Id
+        VerifiedDomains                    = $verifiedDomainsJoined
+        DefaultDomain                      = $defaultDomain
+        SecurityDefaultsEnabled            = if ($null -ne $securityDefaults) { $securityDefaults['isEnabled'] } else { 'N/A' }
+        CreatedDateTime                    = $org.CreatedDateTime
+        OnPremisesSyncEnabled              = $org.OnPremisesSyncEnabled
+        OnPremisesLastSyncDateTime         = $org.OnPremisesLastSyncDateTime
+        OnPremisesLastPasswordSyncDateTime = $org.OnPremisesLastPasswordSyncDateTime
+        OnPremisesProvisioningErrorCount   = $provisioningErrorCount
     }
 }
 

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -1192,7 +1192,9 @@ function AdHybridPanel() {
   const pass = adFindings.filter(f => f.status === 'Pass').length;
   const fail = adFindings.filter(f => f.status === 'Fail').length;
   const syncOk = ad.syncEnabled;
+  const phsOk = ad.pwHashSync;
   const syncColor = syncOk ? 'var(--success-text)' : 'var(--danger-text)';
+  const phsColor = phsOk ? 'var(--success-text)' : 'var(--danger-text)';
   const fmtDate = d => {
     if (!d) return 'Unknown';
     try {
@@ -1216,7 +1218,13 @@ function AdHybridPanel() {
     className: "domain-sub-panel"
   }, /*#__PURE__*/React.createElement("div", {
     className: "panel-sublabel"
-  }, "Active Directory \xB7 hybrid posture"), /*#__PURE__*/React.createElement("div", {
+  }, "Active Directory \xB7 hybrid posture", ad.entraOnly && /*#__PURE__*/React.createElement("span", {
+    className: "kpi-hint",
+    style: {
+      marginLeft: 8,
+      fontWeight: 400
+    }
+  }, "(Entra data \u2014 AD collectors not run)")), /*#__PURE__*/React.createElement("div", {
     className: "spo-summary-row"
   }, /*#__PURE__*/React.createElement("div", {
     className: "spo-stat-card"
@@ -1243,9 +1251,31 @@ function AdHybridPanel() {
       marginTop: 6,
       lineHeight: 1.3
     }
-  }, fmtDate(ad.lastSyncTime)), /*#__PURE__*/React.createElement("div", {
+  }, fmtDate(ad.lastSyncTime))), /*#__PURE__*/React.createElement("div", {
+    className: 'spo-stat-card' + (!phsOk ? ' spo-stat-bad' : '')
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "kpi-label"
+  }, "Password hash sync"), /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 13,
+      fontWeight: 700,
+      color: phsColor,
+      marginTop: 6
+    }
+  }, phsOk ? 'Enabled' : 'Disabled'), !phsOk && /*#__PURE__*/React.createElement("div", {
+    className: "kpi-hint",
+    style: {
+      color: 'var(--danger-text)'
+    }
+  }, "Users cannot reset passwords from Entra")), ad.syncErrorCount > 0 && /*#__PURE__*/React.createElement("div", {
+    className: "spo-stat-card spo-stat-bad"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "kpi-label"
+  }, "Sync errors"), /*#__PURE__*/React.createElement("div", {
+    className: "kpi-value"
+  }, ad.syncErrorCount), /*#__PURE__*/React.createElement("div", {
     className: "kpi-hint"
-  }, "Password hash: ", ad.pwHashSync ? 'Yes' : 'No')), adFindings.length > 0 && /*#__PURE__*/React.createElement("div", {
+  }, "provisioning errors")), !ad.entraOnly && adFindings.length > 0 && /*#__PURE__*/React.createElement("div", {
     className: 'spo-stat-card' + (fail > 0 ? ' spo-stat-bad' : '')
   }, /*#__PURE__*/React.createElement("div", {
     className: "kpi-label"
@@ -1264,7 +1294,7 @@ function AdHybridPanel() {
       width: pct(pass, adFindings.length) + '%',
       background: 'var(--success)'
     }
-  }))), ad.highRiskFindings > 0 && /*#__PURE__*/React.createElement("div", {
+  }))), !ad.entraOnly && ad.highRiskFindings > 0 && /*#__PURE__*/React.createElement("div", {
     className: "spo-stat-card spo-stat-bad"
   }, /*#__PURE__*/React.createElement("div", {
     className: "kpi-label"

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -631,9 +631,11 @@ function AdHybridPanel() {
   const adFindings = FINDINGS.filter(f => f.domain === 'Active Directory');
   const pass = adFindings.filter(f => f.status==='Pass').length;
   const fail = adFindings.filter(f => f.status==='Fail').length;
-  const syncOk   = ad.syncEnabled;
+  const syncOk    = ad.syncEnabled;
+  const phsOk     = ad.pwHashSync;
   const syncColor = syncOk ? 'var(--success-text)' : 'var(--danger-text)';
-  const fmtDate  = d => {
+  const phsColor  = phsOk  ? 'var(--success-text)' : 'var(--danger-text)';
+  const fmtDate   = d => {
     if (!d) return 'Unknown';
     try { return new Date(d).toLocaleDateString(undefined, { year:'numeric', month:'short', day:'numeric' }); }
     catch { return d; }
@@ -643,7 +645,10 @@ function AdHybridPanel() {
     .sort((a,b)=>(SEV_ORDER[b.severity]||0)-(SEV_ORDER[a.severity]||0)).slice(0,3);
   return (
     <div className="domain-sub-panel">
-      <div className="panel-sublabel">Active Directory · hybrid posture</div>
+      <div className="panel-sublabel">
+        Active Directory · hybrid posture
+        {ad.entraOnly && <span className="kpi-hint" style={{marginLeft:8, fontWeight:400}}>(Entra data — AD collectors not run)</span>}
+      </div>
       <div className="spo-summary-row">
         <div className="spo-stat-card">
           <div className="kpi-label">Directory sync</div>
@@ -653,9 +658,20 @@ function AdHybridPanel() {
         <div className="spo-stat-card">
           <div className="kpi-label">Last sync</div>
           <div style={{fontSize:12, fontWeight:600, color:'var(--text-soft)', marginTop:6, lineHeight:1.3}}>{fmtDate(ad.lastSyncTime)}</div>
-          <div className="kpi-hint">Password hash: {ad.pwHashSync ? 'Yes' : 'No'}</div>
         </div>
-        {adFindings.length > 0 && (
+        <div className={'spo-stat-card' + (!phsOk ? ' spo-stat-bad' : '')}>
+          <div className="kpi-label">Password hash sync</div>
+          <div style={{fontSize:13, fontWeight:700, color: phsColor, marginTop:6}}>{phsOk ? 'Enabled' : 'Disabled'}</div>
+          {!phsOk && <div className="kpi-hint" style={{color:'var(--danger-text)'}}>Users cannot reset passwords from Entra</div>}
+        </div>
+        {ad.syncErrorCount > 0 && (
+          <div className="spo-stat-card spo-stat-bad">
+            <div className="kpi-label">Sync errors</div>
+            <div className="kpi-value">{ad.syncErrorCount}</div>
+            <div className="kpi-hint">provisioning errors</div>
+          </div>
+        )}
+        {!ad.entraOnly && adFindings.length > 0 && (
           <div className={'spo-stat-card' + (fail>0?' spo-stat-bad':'')}>
             <div className="kpi-label">AD checks</div>
             <div className="kpi-value">{pct(pass, adFindings.length)}<span style={{fontSize:14}}>%</span></div>
@@ -663,7 +679,7 @@ function AdHybridPanel() {
             <div className="tiny-bar"><span style={{width: pct(pass, adFindings.length)+'%', background:'var(--success)'}}/></div>
           </div>
         )}
-        {ad.highRiskFindings > 0 && (
+        {!ad.entraOnly && ad.highRiskFindings > 0 && (
           <div className="spo-stat-card spo-stat-bad">
             <div className="kpi-label">High/Critical risks</div>
             <div className="kpi-value">{ad.highRiskFindings}</div>

--- a/tests/Common/Build-ReportData.Tests.ps1
+++ b/tests/Common/Build-ReportData.Tests.ps1
@@ -566,12 +566,53 @@ Describe 'Build-ReportData' {
                 'ad-hybrid'   = @($hybrid)
                 'ad-security' = @($sec1, $sec2)
             })
-            $d.adHybrid              | Should -Not -BeNullOrEmpty
-            $d.adHybrid.syncEnabled  | Should -Be $true
-            $d.adHybrid.syncType     | Should -Be 'AADConnect'
-            $d.adHybrid.pwHashSync   | Should -Be $true
+            $d.adHybrid                  | Should -Not -BeNullOrEmpty
+            $d.adHybrid.syncEnabled      | Should -Be $true
+            $d.adHybrid.syncType         | Should -Be 'AADConnect'
+            $d.adHybrid.pwHashSync       | Should -Be $true
             $d.adHybrid.securityFindings | Should -Be 2
             $d.adHybrid.highRiskFindings | Should -Be 1
+            $d.adHybrid.entraOnly        | Should -Be $false
+        }
+
+        It 'should fall back to Entra tenant data when ad-hybrid absent and sync is enabled' {
+            $tenant = [PSCustomObject]@{
+                OrgDisplayName                     = 'Contoso'
+                TenantId                           = 'test-tenant-id'
+                OnPremisesSyncEnabled              = 'True'
+                OnPremisesLastSyncDateTime         = '2026-04-15T12:00:00Z'
+                OnPremisesLastPasswordSyncDateTime = '2026-04-15T12:05:00Z'
+                OnPremisesProvisioningErrorCount   = '2'
+            }
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -SectionData @{ 'tenant' = @($tenant) })
+            $d.adHybrid             | Should -Not -BeNullOrEmpty
+            $d.adHybrid.syncEnabled | Should -Be $true
+            $d.adHybrid.pwHashSync  | Should -Be $true
+            $d.adHybrid.syncErrorCount | Should -Be 2
+            $d.adHybrid.entraOnly   | Should -Be $true
+        }
+
+        It 'should not create Entra fallback when sync is disabled in tenant data' {
+            $tenant = [PSCustomObject]@{
+                OrgDisplayName            = 'Contoso'
+                TenantId                  = 'test-tenant-id'
+                OnPremisesSyncEnabled     = 'False'
+            }
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -SectionData @{ 'tenant' = @($tenant) })
+            $d.adHybrid | Should -BeNullOrEmpty
+        }
+
+        It 'should detect PHS disabled when LastPasswordSyncDateTime is absent' {
+            $tenant = [PSCustomObject]@{
+                OrgDisplayName                     = 'Contoso'
+                TenantId                           = 'test-tenant-id'
+                OnPremisesSyncEnabled              = 'True'
+                OnPremisesLastSyncDateTime         = '2026-04-15T12:00:00Z'
+                OnPremisesLastPasswordSyncDateTime = ''
+                OnPremisesProvisioningErrorCount   = '0'
+            }
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -SectionData @{ 'tenant' = @($tenant) })
+            $d.adHybrid.pwHashSync | Should -Be $false
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Entra-side fallback**: `Get-TenantInfo.ps1` now writes 4 hybrid sync fields to `01-Tenant-Info.csv` (`OnPremisesSyncEnabled`, `OnPremisesLastSyncDateTime`, `OnPremisesLastPasswordSyncDateTime`, `OnPremisesProvisioningErrorCount`). `Build-ReportData.ps1` uses these as a fallback when `23-Hybrid-Sync.csv` (AD section) is absent.
- **PHS card promoted**: Password Hash Sync is now its own dedicated card (was buried in the Last Sync card). Shows danger state + *"Users cannot reset passwords from Entra"* warning when disabled on a hybrid tenant.
- **Sync error count**: surfaces as a bad-state card when `OnPremisesProvisioningErrors` is non-zero.
- **Data source label**: Entra-only panels show `(Entra data — AD collectors not run)` so consultants know the origin.
- **AD-sourced panels**: existing behavior fully preserved; `entraOnly: false` flag added, AD check pass/fail cards still render.

## Why this matters

Consultants frequently run the tool without on-prem AD access (cloud-only access, remote engagement). PHS disabled on a hybrid tenant means on-prem password changes don't sync to Entra — users are locked out of self-service password reset and leaked credential detection is blind. This now surfaces that risk even when the AD section is skipped.

## Test plan

- [x] 73 `Build-ReportData.Tests.ps1` tests pass (4 new: Entra fallback populated, cloud-only no panel, PHS disabled detected, AD-source entraOnly=false)
- [ ] Run a live assessment without AD section — verify hybrid panel appears in Domains section if tenant has `onPremisesSyncEnabled = true`
- [ ] Verify PHS-disabled tenant shows danger card with warning text

🤖 Generated with [Claude Code](https://claude.com/claude-code)