### PR TITLE
fix(entra): ENTRA-SECDEFAULT-001 passes when Conditional Access is active

### DIFF
--- a/src/M365-Assess/Entra/EntraPasswordAuthChecks.ps1
+++ b/src/M365-Assess/Entra/EntraPasswordAuthChecks.ps1
@@ -10,17 +10,50 @@ param()
 # ------------------------------------------------------------------
 # 1. Security Defaults
 # ------------------------------------------------------------------
+$secDefaultsCaPolicies = $null  # pre-fetched here, reused in check 1b
 try {
     Write-Verbose "Checking security defaults..."
     $secDefaults = Invoke-MgGraphRequest -Method GET -Uri '/v1.0/policies/identitySecurityDefaultsEnforcementPolicy' -ErrorAction Stop
     if (-not $secDefaults) { throw "API returned null response" }
     $isEnabled = $secDefaults['isEnabled']
+
+    # When SD is disabled, check whether CA policies provide equivalent coverage.
+    # SD disabled is the correct state for any tenant using Conditional Access — Microsoft
+    # blocks enabling SD when CA policies are active. Only flag as Fail when there is
+    # no MFA control at all (no CA and no SD).
+    if (-not $isEnabled) {
+        try {
+            $caResp = Invoke-MgGraphRequest -Method GET -Uri '/v1.0/identity/conditionalAccess/policies' -ErrorAction Stop
+            $secDefaultsCaPolicies = if ($caResp -and $caResp['value']) { @($caResp['value']) } else { @() }
+        }
+        catch {
+            Write-Verbose "Could not pre-fetch CA policies for security defaults check: $_"
+            $secDefaultsCaPolicies = @()
+        }
+    }
+
+    $caEnabledCount = if ($secDefaultsCaPolicies) {
+        @($secDefaultsCaPolicies | Where-Object { $_['state'] -eq 'enabled' }).Count
+    } else { 0 }
+
+    $sdStatus = if ($isEnabled) { 'Pass' }
+                elseif ($caEnabledCount -gt 0) { 'Pass' }
+                else { 'Fail' }
+
+    $sdCurrentValue = if ($isEnabled) {
+        'True'
+    } elseif ($caEnabledCount -gt 0) {
+        "False (Conditional Access active: $caEnabledCount enabled policies)"
+    } else {
+        'False'
+    }
+
     $settingParams = @{
         Category         = 'Security Defaults'
         Setting          = 'Security Defaults Enabled'
-        CurrentValue     = "$isEnabled"
+        CurrentValue     = $sdCurrentValue
         RecommendedValue = 'True (if no Conditional Access)'
-        Status           = $(if ($isEnabled) { 'Pass' } else { 'Fail' })
+        Status           = $sdStatus
         CheckId          = 'ENTRA-SECDEFAULT-001'
         Remediation      = 'Run: Update-MgPolicyIdentitySecurityDefaultsEnforcementPolicy -IsEnabled $true. Entra admin center > Properties > Manage security defaults.'
         Evidence         = [PSCustomObject]@{ IsSecurityDefaultsEnabled = [bool]$isEnabled }
@@ -47,8 +80,13 @@ catch {
 if ($isEnabled -eq $false) {
     try {
         Write-Verbose "Security Defaults OFF -- evaluating CA policy coverage..."
-        $caResponse = Invoke-MgGraphRequest -Method GET -Uri '/v1.0/identity/conditionalAccess/policies' -ErrorAction Stop
-        $caPolicies = if ($caResponse -and $caResponse['value']) { @($caResponse['value']) } else { @() }
+        # Reuse policies pre-fetched in check 1; fall back to a fresh call if unavailable.
+        $caPolicies = if ($null -ne $secDefaultsCaPolicies) {
+            $secDefaultsCaPolicies
+        } else {
+            $caResponse = Invoke-MgGraphRequest -Method GET -Uri '/v1.0/identity/conditionalAccess/policies' -ErrorAction Stop
+            if ($caResponse -and $caResponse['value']) { @($caResponse['value']) } else { @() }
+        }
         $caEnabled = @($caPolicies | Where-Object { $_['state'] -eq 'enabled' })
 
         $coverageAreas = [ordered]@{

--- a/tests/Entra/EntraPasswordAuthChecks.Tests.ps1
+++ b/tests/Entra/EntraPasswordAuthChecks.Tests.ps1
@@ -223,6 +223,13 @@ Describe 'EntraPasswordAuthChecks' {
         $check.Status | Should -Be 'Pass'
     }
 
+    It 'Security defaults enabled check passes when SD is off but CA policies are active' {
+        $check = $settings | Where-Object { $_.Setting -eq 'Security Defaults Enabled' }
+        $check | Should -Not -BeNullOrEmpty
+        $check.Status | Should -Be 'Pass' -Because 'CA policies provide equivalent coverage'
+        $check.CurrentValue | Should -Match 'Conditional Access active'
+    }
+
     It 'Security defaults gap analysis passes when all areas covered by CA' {
         $check = $settings | Where-Object { $_.Setting -eq 'Security Defaults Gap Analysis' }
         $check | Should -Not -BeNullOrEmpty
@@ -322,6 +329,97 @@ Describe 'EntraPasswordAuthChecks - Security Defaults ON' {
         $check = $settings | Where-Object { $_.Setting -like 'Password Expiration:*' }
         $check | Should -Not -BeNullOrEmpty
         $check[0].Status | Should -Be 'Fail'
+    }
+
+    AfterAll {
+        Remove-Item Function:\Update-CheckProgress -ErrorAction SilentlyContinue
+        Remove-Item Function:\Get-MgContext -ErrorAction SilentlyContinue
+        Remove-Item Function:\Add-Setting -ErrorAction SilentlyContinue
+    }
+}
+
+Describe 'EntraPasswordAuthChecks - Security Defaults OFF no CA' {
+    BeforeAll {
+        function global:Update-CheckProgress {
+            param($CheckId, $Setting, $Status)
+        }
+
+        function global:Get-MgContext {
+            return @{ TenantId = 'test-tenant-id' }
+        }
+
+        Mock Import-Module { }
+
+        Mock Invoke-MgGraphRequest {
+            param($Method, $Uri, $Headers, $ErrorAction)
+            switch -Wildcard ($Uri) {
+                '*/identitySecurityDefaultsEnforcementPolicy' {
+                    return @{ isEnabled = $false }
+                }
+                '*/identity/conditionalAccess/policies' {
+                    return @{ value = @() }
+                }
+                '*/policies/authenticationMethodsPolicy' {
+                    return @{
+                        authenticationMethodConfigurations = @()
+                        registrationEnforcement            = @{
+                            authenticationMethodsRegistrationCampaign = @{
+                                state          = 'disabled'
+                                includeTargets = @()
+                            }
+                        }
+                    }
+                }
+                '*/v1.0/settings' { return @{ value = @() } }
+                '*/v1.0/domains' {
+                    return @{ value = @(
+                        @{ id = 'contoso.com'; isVerified = $true; passwordValidityPeriodInDays = 2147483647 }
+                    )}
+                }
+                '*/v1.0/organization' {
+                    return @{ value = @(
+                        @{ onPremisesSyncEnabled = $false; onPremisesLastPasswordSyncDateTime = $null }
+                    )}
+                }
+                default { return @{ value = @() } }
+            }
+        }
+
+        . "$PSScriptRoot/../../src/M365-Assess/Orchestrator/AssessmentHelpers.ps1"
+        . "$PSScriptRoot/../../src/M365-Assess/Common/SecurityConfigHelper.ps1"
+
+        $ctx            = Initialize-SecurityConfig
+        $settings       = $ctx.Settings
+        $checkIdCounter = $ctx.CheckIdCounter
+
+        function Add-Setting {
+            param([string]$Category, [string]$Setting, [string]$CurrentValue,
+                  [string]$RecommendedValue, [string]$Status,
+                  [string]$CheckId = '', [string]$Remediation = '')
+            Add-SecuritySetting -Settings $settings -CheckIdCounter $checkIdCounter `
+                -Category $Category -Setting $Setting -CurrentValue $CurrentValue `
+                -RecommendedValue $RecommendedValue -Status $Status `
+                -CheckId $CheckId -Remediation $Remediation
+        }
+
+        $sspr       = $null
+        $orgSettings = $null
+        $pwSettings  = $null
+
+        . "$PSScriptRoot/../../src/M365-Assess/Entra/EntraPasswordAuthChecks.ps1"
+    }
+
+    It 'Security defaults enabled check fails when SD is off and no CA policies exist' {
+        $check = $settings | Where-Object { $_.Setting -eq 'Security Defaults Enabled' }
+        $check | Should -Not -BeNullOrEmpty
+        $check.Status | Should -Be 'Fail' -Because 'no MFA control is active'
+        $check.CurrentValue | Should -Be 'False'
+    }
+
+    It 'Security defaults gap analysis fails when no CA areas are covered' {
+        $check = $settings | Where-Object { $_.Setting -eq 'Security Defaults Gap Analysis' }
+        $check | Should -Not -BeNullOrEmpty
+        $check.Status | Should -Be 'Fail'
     }
 
     AfterAll {


### PR DESCRIPTION
## Summary

- `ENTRA-SECDEFAULT-001` was always `Fail` when Security Defaults is disabled, regardless of whether Conditional Access policies provide equivalent MFA coverage
- Security Defaults disabled is the **correct state** for any tenant using CA — Microsoft blocks enabling SD when CA policies are active
- This generated false noise for every well-governed tenant

## Changes

**`src/M365-Assess/Entra/EntraPasswordAuthChecks.ps1`**
- Pre-fetch CA policies when SD is off (reused in check 1b to avoid a double Graph call)
- `ENTRA-SECDEFAULT-001` → `Pass` with `"False (Conditional Access active: N enabled policies)"` when CA is present
- `ENTRA-SECDEFAULT-001` → `Fail` only when SD is off **and** no CA policies exist (bare tenant with no MFA)
- `ENTRA-SECDEFAULT-002` gap analysis unchanged — still evaluates CA coverage areas

**`tests/Entra/EntraPasswordAuthChecks.Tests.ps1`**
- New test: SD off + CA active → ENTRA-SECDEFAULT-001 Pass
- New `Describe` block: SD off + no CA → both ENTRA-SECDEFAULT-001 and ENTRA-SECDEFAULT-002 Fail
- 18/18 tests pass

## Test plan

- [ ] Run `pwsh -NoProfile -Command "Invoke-Pester -Path './tests/Entra/EntraPasswordAuthChecks.Tests.ps1' -Output Detailed"` — 18 pass
- [ ] CI quality gates + Pester matrix pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)