### PR TITLE
fix: MicrosoftScore split, score gradient, email auth panel

### DIFF
--- a/docs/sample-report/_Example-Report.html
+++ b/docs/sample-report/_Example-Report.html
@@ -751,6 +751,7 @@ section.block { margin-bottom: 40px; scroll-margin-top: 20px; }
   margin-bottom: 4px;
 }
 .score-num {
+  display: inline-block;
   font-size: 72px; line-height: 1; font-weight: 800;
   letter-spacing: -0.04em;
   color: var(--accent);

--- a/docs/sample-report/_Example-Report.html
+++ b/docs/sample-report/_Example-Report.html
@@ -753,9 +753,10 @@ section.block { margin-bottom: 40px; scroll-margin-top: 20px; }
 .score-num {
   font-size: 72px; line-height: 1; font-weight: 800;
   letter-spacing: -0.04em;
+  color: var(--accent);
   background: var(--accent-grad);
   -webkit-background-clip: text; background-clip: text;
-  color: transparent;
+  -webkit-text-fill-color: transparent;
   font-variant-numeric: tabular-nums;
   font-family: var(--font-display);
 }
@@ -22578,7 +22579,7 @@ function DomainRollup({
     })), /*#__PURE__*/React.createElement("div", {
       className: "dc-meta"
     }, /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, d.pass), " pass"), /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, d.warn), " warn"), /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, d.fail), " fail"), d.review > 0 && /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, d.review), " review")));
-  })), /*#__PURE__*/React.createElement(IntuneCategoryGrid, null), /*#__PURE__*/React.createElement(MailboxSummaryPanel, null), /*#__PURE__*/React.createElement(SharePointSummaryPanel, null), /*#__PURE__*/React.createElement(AdHybridPanel, null));
+  })), /*#__PURE__*/React.createElement(IntuneCategoryGrid, null), /*#__PURE__*/React.createElement(MailboxSummaryPanel, null), /*#__PURE__*/React.createElement(SharePointSummaryPanel, null), /*#__PURE__*/React.createElement(AdHybridPanel, null), /*#__PURE__*/React.createElement(DnsAuthPanel, null));
 }
 
 // ======================== Framework quilt ========================
@@ -24112,7 +24113,7 @@ function Appendix() {
       fontVariantNumeric: 'tabular-nums',
       color: 'var(--muted)'
     }
-  }, l.Total)))))), /*#__PURE__*/React.createElement(DnsAuthPanel, null), /*#__PURE__*/React.createElement("div", {
+  }, l.Total)))))), /*#__PURE__*/React.createElement("div", {
     className: "card"
   }, /*#__PURE__*/React.createElement("div", {
     style: {

--- a/src/M365-Assess/Security/Get-SecureScoreReport.ps1
+++ b/src/M365-Assess/Security/Get-SecureScoreReport.ps1
@@ -96,18 +96,20 @@ if ($latestScore.AverageComparativeScores) {
 
 Write-Verbose "Secure Score: $currentScore / $maxScore ($percentage%) as of $($latestScore.CreatedDateTime)"
 
-# Compute Microsoft-managed vs customer-earned score split via control profiles
+# Compute Microsoft-managed vs customer-earned score split via control profiles.
+# Microsoft-managed controls have actionType = 'ProviderGenerated'. Add $top=250
+# to avoid the default 100-item page limit (Secure Score has 290+ controls).
 $microsoftScore = 0.0
 $customerScore  = 0.0
 try {
-    $profilesResp = Invoke-MgGraphRequest -Method GET -Uri '/v1.0/security/secureScoreControlProfiles' -ErrorAction Stop
+    $profilesResp = Invoke-MgGraphRequest -Method GET -Uri '/v1.0/security/secureScoreControlProfiles?$top=250' -ErrorAction Stop
     $profileMap = @{}
     foreach ($prof in $profilesResp.value) {
         $profileMap[$prof.id] = $prof.actionType
     }
     foreach ($ctrl in $latestScore.ControlScores) {
         $earned = if ($null -ne $ctrl.Score) { [double]$ctrl.Score } else { 0.0 }
-        if ($profileMap[$ctrl.ControlName] -eq 'Provider') {
+        if ($profileMap[$ctrl.ControlName] -eq 'ProviderGenerated') {
             $microsoftScore += $earned
         } else {
             $customerScore += $earned

--- a/src/M365-Assess/Security/Get-SecureScoreReport.ps1
+++ b/src/M365-Assess/Security/Get-SecureScoreReport.ps1
@@ -96,20 +96,18 @@ if ($latestScore.AverageComparativeScores) {
 
 Write-Verbose "Secure Score: $currentScore / $maxScore ($percentage%) as of $($latestScore.CreatedDateTime)"
 
-# Compute Microsoft-managed vs customer-earned score split via control profiles.
-# Microsoft-managed controls have actionType = 'ProviderGenerated'. Add $top=250
-# to avoid the default 100-item page limit (Secure Score has 290+ controls).
+# Compute Microsoft-managed vs customer-earned score split via control profiles
 $microsoftScore = 0.0
 $customerScore  = 0.0
 try {
-    $profilesResp = Invoke-MgGraphRequest -Method GET -Uri '/v1.0/security/secureScoreControlProfiles?$top=250' -ErrorAction Stop
+    $profilesResp = Invoke-MgGraphRequest -Method GET -Uri '/v1.0/security/secureScoreControlProfiles' -ErrorAction Stop
     $profileMap = @{}
     foreach ($prof in $profilesResp.value) {
         $profileMap[$prof.id] = $prof.actionType
     }
     foreach ($ctrl in $latestScore.ControlScores) {
         $earned = if ($null -ne $ctrl.Score) { [double]$ctrl.Score } else { 0.0 }
-        if ($profileMap[$ctrl.ControlName] -eq 'ProviderGenerated') {
+        if ($profileMap[$ctrl.ControlName] -eq 'Provider') {
             $microsoftScore += $earned
         } else {
             $customerScore += $earned

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -1378,7 +1378,7 @@ function DomainRollup({
     })), /*#__PURE__*/React.createElement("div", {
       className: "dc-meta"
     }, /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, d.pass), " pass"), /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, d.warn), " warn"), /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, d.fail), " fail"), d.review > 0 && /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, d.review), " review")));
-  })), /*#__PURE__*/React.createElement(IntuneCategoryGrid, null), /*#__PURE__*/React.createElement(MailboxSummaryPanel, null), /*#__PURE__*/React.createElement(SharePointSummaryPanel, null), /*#__PURE__*/React.createElement(AdHybridPanel, null));
+  })), /*#__PURE__*/React.createElement(IntuneCategoryGrid, null), /*#__PURE__*/React.createElement(MailboxSummaryPanel, null), /*#__PURE__*/React.createElement(SharePointSummaryPanel, null), /*#__PURE__*/React.createElement(AdHybridPanel, null), /*#__PURE__*/React.createElement(DnsAuthPanel, null));
 }
 
 // ======================== Framework quilt ========================
@@ -2912,7 +2912,7 @@ function Appendix() {
       fontVariantNumeric: 'tabular-nums',
       color: 'var(--muted)'
     }
-  }, l.Total)))))), /*#__PURE__*/React.createElement(DnsAuthPanel, null), /*#__PURE__*/React.createElement("div", {
+  }, l.Total)))))), /*#__PURE__*/React.createElement("div", {
     className: "card"
   }, /*#__PURE__*/React.createElement("div", {
     style: {

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -744,6 +744,7 @@ function DomainRollup({ onJump }) {
       <MailboxSummaryPanel />
       <SharePointSummaryPanel />
       <AdHybridPanel />
+      <DnsAuthPanel />
     </section>
   );
 }
@@ -1712,7 +1713,6 @@ function Appendix() {
             </tbody>
           </table>
         </div>
-        <DnsAuthPanel />
         <div className="card">
           <div style={{fontSize:12,color:'var(--muted)',textTransform:'uppercase',letterSpacing:'.08em',fontWeight:600,marginBottom:10}}>Conditional Access policies</div>
           <table style={{width:'100%',fontSize:12,borderCollapse:'collapse'}}>

--- a/src/M365-Assess/assets/report-shell.css
+++ b/src/M365-Assess/assets/report-shell.css
@@ -277,6 +277,7 @@ section.block { margin-bottom: 40px; scroll-margin-top: 20px; }
   margin-bottom: 4px;
 }
 .score-num {
+  display: inline-block;
   font-size: 72px; line-height: 1; font-weight: 800;
   letter-spacing: -0.04em;
   color: var(--accent);

--- a/src/M365-Assess/assets/report-shell.css
+++ b/src/M365-Assess/assets/report-shell.css
@@ -279,9 +279,10 @@ section.block { margin-bottom: 40px; scroll-margin-top: 20px; }
 .score-num {
   font-size: 72px; line-height: 1; font-weight: 800;
   letter-spacing: -0.04em;
+  color: var(--accent);
   background: var(--accent-grad);
   -webkit-background-clip: text; background-clip: text;
-  color: transparent;
+  -webkit-text-fill-color: transparent;
   font-variant-numeric: tabular-nums;
   font-family: var(--font-display);
 }


### PR DESCRIPTION
## Summary

- **MicrosoftScore always 0**: `actionType` for Microsoft-managed Secure Score controls is `'ProviderGenerated'`, not `'Provider'`. Fixed the comparison so the MS-managed/customer split now populates correctly. Also added `$top=250` to the control profiles request to cover all 290+ controls (default page limit is 100).
- **Score number invisible**: `.score-num` used `color: transparent` alone which leaves no fallback when `background-clip: text` fails to render. Added `-webkit-text-fill-color: transparent` (more reliable) and `color: var(--accent)` as a visible solid fallback.
- **Email authentication posture**: Moved `DnsAuthPanel` from the Appendix to the Overview/Dashboard, rendered after `AdHybridPanel` — gives it first-class posture visibility instead of burying it in reference tables.

## Test plan

- [ ] Re-run assessment on a live tenant and verify Microsoft-managed shows non-zero points
- [ ] Verify score number is visible in neon/console/saas/high-contrast themes (dark + light)
- [ ] Verify email authentication posture panel appears in Overview, below Active Directory panel
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)