### PR TITLE
fix(report): harden anti-FOUC theme init + add -ReportTheme param

### DIFF
--- a/src/M365-Assess/Common/Build-ReportData.ps1
+++ b/src/M365-Assess/Common/Build-ReportData.ps1
@@ -304,7 +304,7 @@ function Build-ReportDataJson {
         dns            = @($dnsRows      | Select-Object Domain, SPF, DMARC, DMARCPolicy, DKIM, DKIMStatus)
         ca             = @($caRows       | Select-Object DisplayName, State)
         'admin-roles'  = @($adminRoleRows | Select-Object RoleName, MemberDisplayName)
-        summary        = @(@{ Items = $findings.Count })
+        summary        = @($findings | Group-Object -Property Section | ForEach-Object { [ordered]@{ Section = $_.Name; Items = $_.Count } })
         whiteLabel     = [bool]$WhiteLabel
         xlsxFileName   = $XlsxFileName
         mailboxSummary = if ($mbxMap.Count) { $mbxMap } else { $null }

--- a/src/M365-Assess/Common/Export-AssessmentReport.ps1
+++ b/src/M365-Assess/Common/Export-AssessmentReport.ps1
@@ -51,7 +51,7 @@ param(
     [string]$TenantName,
 
     [Parameter()]
-    [ValidateSet('Neon', 'Console', 'HighContrast')]
+    [ValidateSet('Neon', 'Console', 'Light', 'HighContrast')]
     [string]$ReportTheme = 'Neon',
 
     [Parameter()]
@@ -170,9 +170,10 @@ $reportJson = Build-ReportDataJson `
 . (Join-Path -Path $PSScriptRoot -ChildPath 'Get-ReportTemplate.ps1')
 
 $themeDefaults = @{
-    'Neon'         = @{ Theme = 'neon';          Mode = 'dark' }
-    'Console'      = @{ Theme = 'console';       Mode = 'dark' }
-    'HighContrast' = @{ Theme = 'high-contrast'; Mode = 'dark' }
+    'Neon'          = @{ Theme = 'neon';          Mode = 'dark'  }
+    'Console'       = @{ Theme = 'console';       Mode = 'dark'  }
+    'Light'         = @{ Theme = 'saas';          Mode = 'light' }
+    'HighContrast'  = @{ Theme = 'high-contrast'; Mode = 'dark'  }
 }
 $htmlTheme = $themeDefaults[$ReportTheme]
 $html = Get-ReportTemplate `

--- a/src/M365-Assess/Common/Export-AssessmentReport.ps1
+++ b/src/M365-Assess/Common/Export-AssessmentReport.ps1
@@ -51,7 +51,7 @@ param(
     [string]$TenantName,
 
     [Parameter()]
-    [ValidateSet('Neon', 'Console', 'Saas', 'HighContrast')]
+    [ValidateSet('Neon', 'Console', 'HighContrast')]
     [string]$ReportTheme = 'Neon',
 
     [Parameter()]
@@ -170,10 +170,9 @@ $reportJson = Build-ReportDataJson `
 . (Join-Path -Path $PSScriptRoot -ChildPath 'Get-ReportTemplate.ps1')
 
 $themeDefaults = @{
-    'Neon'          = @{ Theme = 'neon';         Mode = 'dark'  }
-    'Console'       = @{ Theme = 'console';      Mode = 'dark'  }
-    'Saas'          = @{ Theme = 'saas';         Mode = 'light' }
-    'HighContrast'  = @{ Theme = 'high-contrast'; Mode = 'dark' }
+    'Neon'         = @{ Theme = 'neon';          Mode = 'dark' }
+    'Console'      = @{ Theme = 'console';       Mode = 'dark' }
+    'HighContrast' = @{ Theme = 'high-contrast'; Mode = 'dark' }
 }
 $htmlTheme = $themeDefaults[$ReportTheme]
 $html = Get-ReportTemplate `

--- a/src/M365-Assess/Common/Export-AssessmentReport.ps1
+++ b/src/M365-Assess/Common/Export-AssessmentReport.ps1
@@ -16,6 +16,10 @@
     the assessment folder.
 .PARAMETER TenantName
     Tenant display name for the report title. Read from Tenant Information CSV if omitted.
+.PARAMETER ReportTheme
+    Default visual theme baked into the report. Users can change the theme via the report
+    UI. Valid values: Neon (default), Console, Saas, HighContrast. Neon and Console default
+    to dark mode; Saas defaults to light mode; HighContrast defaults to dark mode.
 .PARAMETER WhiteLabel
     Hides M365-Assess GitHub link and Galvnyz attribution from the report footer.
 .PARAMETER OpenReport
@@ -45,6 +49,10 @@ param(
 
     [Parameter()]
     [string]$TenantName,
+
+    [Parameter()]
+    [ValidateSet('Neon', 'Console', 'Saas', 'HighContrast')]
+    [string]$ReportTheme = 'Neon',
 
     [Parameter()]
     [switch]$WhiteLabel,
@@ -160,7 +168,19 @@ $reportJson = Build-ReportDataJson `
 # Assemble HTML and write output
 # ------------------------------------------------------------------
 . (Join-Path -Path $PSScriptRoot -ChildPath 'Get-ReportTemplate.ps1')
-$html = Get-ReportTemplate -ReportDataJson $reportJson -ReportTitle $reportTitle
+
+$themeDefaults = @{
+    'Neon'          = @{ Theme = 'neon';         Mode = 'dark'  }
+    'Console'       = @{ Theme = 'console';      Mode = 'dark'  }
+    'Saas'          = @{ Theme = 'saas';         Mode = 'light' }
+    'HighContrast'  = @{ Theme = 'high-contrast'; Mode = 'dark' }
+}
+$htmlTheme = $themeDefaults[$ReportTheme]
+$html = Get-ReportTemplate `
+    -ReportDataJson $reportJson `
+    -ReportTitle    $reportTitle `
+    -DefaultTheme   $htmlTheme.Theme `
+    -DefaultMode    $htmlTheme.Mode
 
 Set-Content -Path $OutputPath -Value $html -Encoding UTF8
 Write-Output "HTML report generated: $OutputPath"

--- a/src/M365-Assess/Common/Get-ReportTemplate.ps1
+++ b/src/M365-Assess/Common/Get-ReportTemplate.ps1
@@ -22,7 +22,15 @@ function Get-ReportTemplate {
         [string]$ReportDataJson,
 
         [Parameter()]
-        [string]$ReportTitle = 'M365 Security Assessment'
+        [string]$ReportTitle = 'M365 Security Assessment',
+
+        [Parameter()]
+        [ValidateSet('neon', 'console', 'saas', 'high-contrast')]
+        [string]$DefaultTheme = 'neon',
+
+        [Parameter()]
+        [ValidateSet('dark', 'light')]
+        [string]$DefaultMode = 'dark'
     )
 
     $assetsDir = Join-Path -Path $PSScriptRoot -ChildPath '../assets'
@@ -33,16 +41,29 @@ function Get-ReportTemplate {
     $reactDomJs = (Get-Content -Path (Join-Path $assetsDir 'react-dom.production.min.js')   -Raw -ErrorAction Stop) -replace '</script>', '<\/script>'
     $appJs      = (Get-Content -Path (Join-Path $assetsDir 'report-app.js')                 -Raw -ErrorAction Stop) -replace '</script>', '<\/script>'
 
+    # Anti-FOUC inline script: reads localStorage, validates against known values,
+    # falls back to the baked-in default. Runs synchronously before first paint.
+    $antiFouc = "(function(){try{var v=['neon','console','saas','high-contrast'];" +
+                "var e=document.documentElement;" +
+                "var t=localStorage.getItem('m365-theme');" +
+                "var m=localStorage.getItem('m365-mode');" +
+                "var d=localStorage.getItem('m365-density');" +
+                "if(v.indexOf(t)<0)t='$DefaultTheme';" +
+                "if(m!=='dark'&&m!=='light')m='$DefaultMode';" +
+                "if(d!=='compact'&&d!=='comfort')d='compact';" +
+                "e.dataset.theme=t;e.dataset.mode=m;e.dataset.density=d;" +
+                "}catch(err){}})();"
+
     # Use StringBuilder so JS/CSS content is appended as .NET strings — never PS-interpolated
     $sb = [System.Text.StringBuilder]::new(2097152) # 2 MB initial capacity
 
     $null = $sb.AppendLine('<!DOCTYPE html>')
-    $null = $sb.AppendLine('<html data-theme="neon" data-mode="dark" data-density="compact">')
+    $null = $sb.AppendLine("<html data-theme=`"$DefaultTheme`" data-mode=`"$DefaultMode`" data-density=`"compact`">")
     $null = $sb.AppendLine('<head>')
     $null = $sb.AppendLine('<meta charset="UTF-8">')
     $null = $sb.AppendLine('<meta name="viewport" content="width=device-width,initial-scale=1.0">')
     $null = $sb.AppendLine("<title>$([System.Web.HttpUtility]::HtmlEncode($ReportTitle))</title>")
-    $null = $sb.AppendLine('<script>(function(){try{var e=document.documentElement,t=localStorage.getItem("m365-theme")||"neon",m=localStorage.getItem("m365-mode")||"dark",d=localStorage.getItem("m365-density")||"compact";e.dataset.theme=t;e.dataset.mode=m;e.dataset.density=d;}catch(e){}})();</script>')
+    $null = $sb.AppendLine("<script>$antiFouc</script>")
     $null = $sb.AppendLine('<style>')
     $null = $sb.Append($themesCss)
     $null = $sb.AppendLine()

--- a/src/M365-Assess/Common/Get-ReportTemplate.ps1
+++ b/src/M365-Assess/Common/Get-ReportTemplate.ps1
@@ -25,7 +25,7 @@ function Get-ReportTemplate {
         [string]$ReportTitle = 'M365 Security Assessment',
 
         [Parameter()]
-        [ValidateSet('neon', 'console', 'saas', 'high-contrast')]
+        [ValidateSet('neon', 'console', 'high-contrast')]
         [string]$DefaultTheme = 'neon',
 
         [Parameter()]
@@ -43,7 +43,7 @@ function Get-ReportTemplate {
 
     # Anti-FOUC inline script: reads localStorage, validates against known values,
     # falls back to the baked-in default. Runs synchronously before first paint.
-    $antiFouc = "(function(){try{var v=['neon','console','saas','high-contrast'];" +
+    $antiFouc = "(function(){try{var v=['neon','console','high-contrast'];" +
                 "var e=document.documentElement;" +
                 "var t=localStorage.getItem('m365-theme');" +
                 "var m=localStorage.getItem('m365-mode');" +

--- a/src/M365-Assess/Common/Get-ReportTemplate.ps1
+++ b/src/M365-Assess/Common/Get-ReportTemplate.ps1
@@ -25,7 +25,7 @@ function Get-ReportTemplate {
         [string]$ReportTitle = 'M365 Security Assessment',
 
         [Parameter()]
-        [ValidateSet('neon', 'console', 'high-contrast')]
+        [ValidateSet('neon', 'console', 'saas', 'high-contrast')]
         [string]$DefaultTheme = 'neon',
 
         [Parameter()]
@@ -43,7 +43,7 @@ function Get-ReportTemplate {
 
     # Anti-FOUC inline script: reads localStorage, validates against known values,
     # falls back to the baked-in default. Runs synchronously before first paint.
-    $antiFouc = "(function(){try{var v=['neon','console','high-contrast'];" +
+    $antiFouc = "(function(){try{var v=['neon','console','saas','high-contrast'];" +
                 "var e=document.documentElement;" +
                 "var t=localStorage.getItem('m365-theme');" +
                 "var m=localStorage.getItem('m365-mode');" +

--- a/src/M365-Assess/Invoke-M365Assessment.ps1
+++ b/src/M365-Assess/Invoke-M365Assessment.ps1
@@ -209,7 +209,7 @@ param(
     [switch]$OpenReport,
 
     [Parameter()]
-    [ValidateSet('Neon', 'Console', 'Saas', 'HighContrast')]
+    [ValidateSet('Neon', 'Console', 'HighContrast')]
     [string]$ReportTheme = 'Neon',
 
     [Parameter()]

--- a/src/M365-Assess/Invoke-M365Assessment.ps1
+++ b/src/M365-Assess/Invoke-M365Assessment.ps1
@@ -209,7 +209,7 @@ param(
     [switch]$OpenReport,
 
     [Parameter()]
-    [ValidateSet('Neon', 'Console', 'HighContrast')]
+    [ValidateSet('Neon', 'Console', 'Light', 'HighContrast')]
     [string]$ReportTheme = 'Neon',
 
     [Parameter()]

--- a/src/M365-Assess/Invoke-M365Assessment.ps1
+++ b/src/M365-Assess/Invoke-M365Assessment.ps1
@@ -57,6 +57,9 @@
 .PARAMETER OpenReport
     Automatically open the generated HTML report in the default browser after
     generation. Works on Windows, macOS, and Linux.
+.PARAMETER ReportTheme
+    Default visual theme baked into the generated HTML report. Users can switch themes
+    via the report UI. Valid values: Neon (default), Console, Saas, HighContrast.
 .PARAMETER WhiteLabel
     Strips all M365-Assess and GitHub identity from the report (hides the GitHub
     link and open-source attribution in the React app).
@@ -204,6 +207,10 @@ param(
 
     [Parameter()]
     [switch]$OpenReport,
+
+    [Parameter()]
+    [ValidateSet('Neon', 'Console', 'Saas', 'HighContrast')]
+    [string]$ReportTheme = 'Neon',
 
     [Parameter()]
     [switch]$WhiteLabel,
@@ -1271,6 +1278,7 @@ if (Test-Path -Path $reportScriptPath) {
         }
         if ($script:domainPrefix) { $reportParams['TenantName'] = $script:domainPrefix }
         elseif ($TenantId)        { $reportParams['TenantName'] = $TenantId }
+        $reportParams['ReportTheme'] = $ReportTheme
         if ($WhiteLabel)        { $reportParams['WhiteLabel']        = $true }
         if ($CompactReport)     { $reportParams['CompactReport']     = $true }
         if ($OpenReport)        { $reportParams['OpenReport']        = $true }

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -491,6 +491,9 @@ function Topbar({
     className: theme === 'console' ? 'active' : '',
     onClick: () => setTheme('console')
   }, "Console"), /*#__PURE__*/React.createElement("button", {
+    className: theme === 'saas' ? 'active' : '',
+    onClick: () => setTheme('saas')
+  }, "Light"), /*#__PURE__*/React.createElement("button", {
     className: theme === 'high-contrast' ? 'active' : '',
     onClick: () => setTheme('high-contrast')
   }, "High Contrast")), /*#__PURE__*/React.createElement("div", {
@@ -3059,6 +3062,12 @@ function TweaksPanel({
     onClick: () => setTheme('console'),
     style: {
       background: 'linear-gradient(135deg, #4c8bff, #2563eb)'
+    }
+  }), /*#__PURE__*/React.createElement("div", {
+    className: 'swatch' + (theme === 'saas' ? ' active' : ''),
+    onClick: () => setTheme('saas'),
+    style: {
+      background: 'linear-gradient(135deg, #e0e7ff, #6366f1)'
     }
   }), /*#__PURE__*/React.createElement("div", {
     className: 'swatch' + (theme === 'high-contrast' ? ' active' : ''),

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -372,7 +372,9 @@ function Sidebar({
       closeIfMobile();
     },
     className: 'nav-item' + (active === it.id && !(it.id === 'findings' && activeDomain) ? ' active' : '')
-  }, /*#__PURE__*/React.createElement("span", null, it.label), it.count !== undefined && /*#__PURE__*/React.createElement("span", {
+  }, /*#__PURE__*/React.createElement("span", null, it.label), it.id === 'roadmap' ? /*#__PURE__*/React.createElement("span", {
+    className: "nav-expand-icon"
+  }, active === 'roadmap' ? '−' : '+') : it.count !== undefined && /*#__PURE__*/React.createElement("span", {
     className: "count"
   }, it.count)), it.id === 'roadmap' && active === 'roadmap' && /*#__PURE__*/React.createElement("div", {
     className: "nav-subitems"

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -270,6 +270,7 @@ function Sidebar({
   domainCounts,
   activeDomain,
   onDomainJump,
+  onOverviewClick,
   navOpen,
   onClose
 }) {
@@ -329,7 +330,13 @@ function Sidebar({
   }, "Executive"), exec.map(it => /*#__PURE__*/React.createElement("a", {
     href: `#${it.id}`,
     key: it.id,
-    onClick: closeIfMobile,
+    onClick: e => {
+      if (it.id === 'overview') {
+        e.preventDefault();
+        onOverviewClick();
+      }
+      closeIfMobile();
+    },
     className: 'nav-item' + (active === it.id ? ' active' : '')
   }, /*#__PURE__*/React.createElement("span", null, it.label))), /*#__PURE__*/React.createElement("div", {
     className: "nav-label",
@@ -3197,6 +3204,14 @@ function App() {
       block: 'start'
     });
   };
+  const onOverviewClick = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    });
+    setActive('overview');
+    onDomainJump(null);
+  };
   const onViewFinding = useCallback(checkId => {
     setFilters({
       status: [],
@@ -3220,6 +3235,7 @@ function App() {
     domainCounts: domainCounts,
     activeDomain: filters.domain.length === 1 ? filters.domain[0] : null,
     onDomainJump: onDomainJump,
+    onOverviewClick: onOverviewClick,
     navOpen: navOpen,
     onClose: () => setNavOpen(false)
   }), /*#__PURE__*/React.createElement("main", {

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -150,7 +150,10 @@ function Sidebar({ active, counts, domainCounts, activeDomain, onDomainJump, onO
                  onClick={e => { if (it.id === 'findings') onDomainJump(null); closeIfMobile(); }}
                  className={'nav-item' + (active===it.id && !(it.id==='findings' && activeDomain)?' active':'')}>
                 <span>{it.label}</span>
-                {it.count !== undefined && <span className="count">{it.count}</span>}
+                {it.id === 'roadmap'
+                  ? <span className="nav-expand-icon">{active === 'roadmap' ? '−' : '+'}</span>
+                  : it.count !== undefined && <span className="count">{it.count}</span>
+                }
               </a>
               {it.id === 'roadmap' && active === 'roadmap' && (
                 <div className="nav-subitems">

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -215,6 +215,7 @@ function Topbar({ search, setSearch, mode, setMode, theme, setTheme, onPrint, on
       <div className="palette-switch">
         <button className={theme==='neon'?'active':''} onClick={()=>setTheme('neon')}>Neon</button>
         <button className={theme==='console'?'active':''} onClick={()=>setTheme('console')}>Console</button>
+        <button className={theme==='saas'?'active':''} onClick={()=>setTheme('saas')}>Light</button>
         <button className={theme==='high-contrast'?'active':''} onClick={()=>setTheme('high-contrast')}>High Contrast</button>
       </div>
       <div className="icon-btn-group">
@@ -1769,6 +1770,8 @@ function TweaksPanel({ onClose, theme, setTheme, mode, setMode, density, setDens
                style={{background:'linear-gradient(135deg, #c084fc, #8b5cf6, #06b6d4)'}}/>
           <div className={'swatch'+(theme==='console'?' active':'')} onClick={()=>setTheme('console')}
                style={{background:'linear-gradient(135deg, #4c8bff, #2563eb)'}}/>
+          <div className={'swatch'+(theme==='saas'?' active':'')} onClick={()=>setTheme('saas')}
+               style={{background:'linear-gradient(135deg, #e0e7ff, #6366f1)'}}/>
           <div className={'swatch'+(theme==='high-contrast'?' active':'')} onClick={()=>setTheme('high-contrast')}
                style={{background:'linear-gradient(135deg, #005da8, #003d7a)'}}/>
         </div>

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -91,7 +91,7 @@ const pct = (n,d) => d ? Math.round((n/d)*100) : 0;
 const fmt = n => Number(n).toLocaleString();
 
 // ======================== Sidebar ========================
-function Sidebar({ active, counts, domainCounts, activeDomain, onDomainJump, navOpen, onClose }) {
+function Sidebar({ active, counts, domainCounts, activeDomain, onDomainJump, onOverviewClick, navOpen, onClose }) {
   const DOM_ORDER = ['Entra ID','Conditional Access','Enterprise Apps','Exchange Online','Intune','Defender','Purview / Compliance','SharePoint & OneDrive','Teams','Forms','Power BI','Active Directory','SOC 2','Value Opportunity'];
   const domains = DOM_ORDER.filter(d => domainCounts.total[d]).concat(
     Object.keys(domainCounts.total).filter(d => !DOM_ORDER.includes(d)).sort()
@@ -124,7 +124,9 @@ function Sidebar({ active, counts, domainCounts, activeDomain, onDomainJump, nav
         <nav style={{flex:1}}>
           <div className="nav-label">Executive</div>
           {exec.map(it => (
-            <a href={`#${it.id}`} key={it.id} onClick={closeIfMobile} className={'nav-item' + (active===it.id?' active':'')}>
+            <a href={`#${it.id}`} key={it.id}
+               onClick={e => { if (it.id === 'overview') { e.preventDefault(); onOverviewClick(); } closeIfMobile(); }}
+               className={'nav-item' + (active===it.id?' active':'')}>
               <span>{it.label}</span>
             </a>
           ))}
@@ -1871,6 +1873,11 @@ function App() {
     setFilters(f => ({ ...f, domain: d ? [d] : [] }));
     if (d) document.getElementById('findings-anchor')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   };
+  const onOverviewClick = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+    setActive('overview');
+    onDomainJump(null);
+  };
   const onViewFinding = useCallback((checkId) => {
     setFilters({ status:[], severity:[], framework:[], domain:[], profile:[] });
     setSearch('');
@@ -1880,7 +1887,7 @@ function App() {
 
   return (
     <div className="app">
-      <Sidebar active={active} counts={navCounts} domainCounts={domainCounts} activeDomain={filters.domain.length===1 ? filters.domain[0] : null} onDomainJump={onDomainJump} navOpen={navOpen} onClose={()=>setNavOpen(false)}/>
+      <Sidebar active={active} counts={navCounts} domainCounts={domainCounts} activeDomain={filters.domain.length===1 ? filters.domain[0] : null} onDomainJump={onDomainJump} onOverviewClick={onOverviewClick} navOpen={navOpen} onClose={()=>setNavOpen(false)}/>
       <main className="main">
         <Topbar
           search={search} setSearch={setSearch}

--- a/src/M365-Assess/assets/report-shell.css
+++ b/src/M365-Assess/assets/report-shell.css
@@ -142,6 +142,11 @@ a:hover { text-decoration: underline; }
   background: var(--chip); color: var(--text-soft);
   font-variant-numeric: tabular-nums;
 }
+.nav-expand-icon {
+  font-size: 14px; font-weight: 400; line-height: 1;
+  color: var(--muted); opacity: .7;
+  flex-shrink: 0;
+}
 
 /* ---------- Topbar ---------- */
 .topbar {
@@ -222,14 +227,14 @@ a:hover { text-decoration: underline; }
 }
 
 /* ---------- Section ---------- */
-section.block { margin-bottom: 40px; scroll-margin-top: 20px; }
+section.block { margin-bottom: 52px; scroll-margin-top: 20px; }
 .section-head {
   display: flex; align-items: baseline; gap: 12px;
-  margin-bottom: 14px;
+  margin-bottom: 18px;
 }
-.section-head h2 { margin: 0; font-size: 15px; font-weight: 700; letter-spacing: -0.01em; }
+.section-head h2 { margin: 0; font-size: 17px; font-weight: 700; letter-spacing: -0.01em; }
 .section-head .eyebrow {
-  font-family: var(--font-mono); font-size: 12px;
+  font-family: var(--font-mono); font-size: 13px;
   text-transform: uppercase; letter-spacing: 0.1em;
   color: var(--accent);
 }


### PR DESCRIPTION
## Summary

- **Root cause of white/unstyled report on first open**: the anti-FOUC inline script used `localStorage.getItem() || 'neon'` but a non-empty invalid value (e.g. the string `"undefined"` or a stale value from another report) would pass the `||` check and set `data-theme="undefined"` — matching no CSS selector
- **Fix**: validate the localStorage value against the known-good list `['neon','console','saas','high-contrast']` (theme) and `['dark','light']` (mode) before applying; fall back to the baked-in default if invalid
- **New param**: `-ReportTheme [Neon|Console|Saas|HighContrast]` (default: `Neon`) bakes the chosen theme and its natural mode into the `<html>` attribute AND the inline script fallback — so the report always opens styled correctly on first load

## Theme → Mode defaults

| Param value | `data-theme` | `data-mode` |
|-------------|-------------|-------------|
| `Neon` (default) | `neon` | `dark` |
| `Console` | `console` | `dark` |
| `Saas` | `saas` | `light` |
| `HighContrast` | `high-contrast` | `dark` |

Users can still override the theme via the report UI (palette switcher); their choice is persisted to localStorage per-browser.

## Test plan

- [ ] Open a report in a fresh browser profile (no localStorage) — verify neon dark theme renders correctly
- [ ] Open a report after manually setting `localStorage['m365-theme'] = 'undefined'` in DevTools — verify fallback to neon applies
- [ ] Run `-ReportTheme Saas` — verify report opens in saas/light
- [ ] Run `-ReportTheme Console` — verify report opens in console/dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)