### PR TITLE
feat: edit mode — hide findings, roadmap lane overrides, finalize del…

### DIFF
--- a/src/M365-Assess/Common/Build-ReportData.ps1
+++ b/src/M365-Assess/Common/Build-ReportData.ps1
@@ -141,7 +141,7 @@ function Build-ReportDataJson {
                        elseif ($f.PSObject.Properties['Recommended'])   { $f.Recommended }
                        else                                              { '' }
 
-        $learnMore = if ($regEntry -and $regEntry.learnMore) { [string]$regEntry.learnMore } else { $null }
+        $learnMore = if ($regEntry -and $regEntry.references -and $regEntry.references.Count -gt 0) { [string]$regEntry.references[0].url } else { $null }
         $evidence  = if ($f.PSObject.Properties['Evidence'] -and $null -ne $f.Evidence) {
                          $f.Evidence | ConvertTo-Json -Depth 5 -Compress
                      } else { $null }

--- a/src/M365-Assess/Common/Get-ReportTemplate.ps1
+++ b/src/M365-Assess/Common/Get-ReportTemplate.ps1
@@ -77,6 +77,7 @@ function Get-ReportTemplate {
     $null = $sb.Append($ReportDataJson)
     $null = $sb.AppendLine()
     $null = $sb.AppendLine('</script>')
+    $null = $sb.AppendLine('<script id="report-overrides">window.REPORT_OVERRIDES = null;</script>')
     $null = $sb.AppendLine('<script>')
     $null = $sb.Append($reactJs)
     $null = $sb.AppendLine()

--- a/src/M365-Assess/Entra/EntraAdminRoleChecks.ps1
+++ b/src/M365-Assess/Entra/EntraAdminRoleChecks.ps1
@@ -61,6 +61,11 @@ try {
             Status           = $gaStatus
             CheckId          = 'ENTRA-ADMIN-001'
             Remediation      = 'Run: Get-MgDirectoryRole -Filter "displayName eq ''Global Administrator''" | Get-MgDirectoryRoleMember. Maintain 2-4 global admins using dedicated accounts (break-glass accounts are excluded from this count).'
+            Evidence         = [PSCustomObject]@{
+                OperationalAdmins = @($operationalAdmins | ForEach-Object { [PSCustomObject]@{ DisplayName = $_['displayName']; UserPrincipalName = $_['userPrincipalName']; Type = $_['@odata.type'] } })
+                BreakGlassCount   = $bgExcluded
+                TotalCount        = $allAdmins.Count
+            }
         }
         Add-Setting @settingParams
     }

--- a/src/M365-Assess/Entra/Get-CASecurityConfig.ps1
+++ b/src/M365-Assess/Entra/Get-CASecurityConfig.ps1
@@ -210,6 +210,11 @@ try {
         ($_['grantControls']['builtInControls'] -contains 'mfa')
     })
 
+    $mfaAllEvidence = [PSCustomObject]@{
+        PolicyCount = $mfaAllPolicies.Count
+        PolicyNames = @($mfaAllPolicies | ForEach-Object { $_['displayName'] })
+    }
+
     if ($mfaAllPolicies.Count -gt 0) {
         $names = ($mfaAllPolicies | ForEach-Object { $_['displayName'] }) -join '; '
         $settingParams = @{
@@ -220,6 +225,7 @@ try {
             Status           = 'Pass'
             CheckId          = 'CA-MFA-ALL-001'
             Remediation      = 'No action needed.'
+            Evidence         = $mfaAllEvidence
         }
         Add-Setting @settingParams
     }
@@ -232,6 +238,7 @@ try {
             Status           = 'Info'
             CheckId          = 'CA-MFA-ALL-001'
             Remediation      = 'Security Defaults enforces MFA for all users. For granular control, disable Security Defaults and create Conditional Access policies.'
+            Evidence         = $mfaAllEvidence
         }
         Add-Setting @settingParams
     }
@@ -244,6 +251,7 @@ try {
             Status           = 'Fail'
             CheckId          = 'CA-MFA-ALL-001'
             Remediation      = 'Create a CA policy: Target All users > All cloud apps > Grant > Require multifactor authentication. Entra admin center > Protection > Conditional Access > New policy.'
+            Evidence         = $mfaAllEvidence
         }
         Add-Setting @settingParams
     }
@@ -263,6 +271,11 @@ try {
         ($_['grantControls']['builtInControls'] -contains 'block')
     })
 
+    $legacyAuthEvidence = [PSCustomObject]@{
+        PolicyCount = $legacyBlockPolicies.Count
+        PolicyNames = @($legacyBlockPolicies | ForEach-Object { $_['displayName'] })
+    }
+
     if ($legacyBlockPolicies.Count -gt 0) {
         $names = ($legacyBlockPolicies | ForEach-Object { $_['displayName'] }) -join '; '
         $settingParams = @{
@@ -273,6 +286,7 @@ try {
             Status           = 'Pass'
             CheckId          = 'CA-LEGACYAUTH-001'
             Remediation      = 'No action needed.'
+            Evidence         = $legacyAuthEvidence
         }
         Add-Setting @settingParams
     }
@@ -285,6 +299,7 @@ try {
             Status           = 'Info'
             CheckId          = 'CA-LEGACYAUTH-001'
             Remediation      = 'Security Defaults blocks legacy authentication protocols. For granular control, disable Security Defaults and create Conditional Access policies.'
+            Evidence         = $legacyAuthEvidence
         }
         Add-Setting @settingParams
     }
@@ -297,6 +312,7 @@ try {
             Status           = 'Fail'
             CheckId          = 'CA-LEGACYAUTH-001'
             Remediation      = 'Create a CA policy: Target All users > Conditions > Client apps > Exchange ActiveSync clients + Other clients > Grant > Block access. Entra admin center > Protection > Conditional Access.'
+            Evidence         = $legacyAuthEvidence
         }
         Add-Setting @settingParams
     }

--- a/src/M365-Assess/Entra/Get-EntAppSecurityConfig.ps1
+++ b/src/M365-Assess/Entra/Get-EntAppSecurityConfig.ps1
@@ -51,7 +51,8 @@ function Add-Setting {
     param(
         [string]$Category, [string]$Setting, [string]$CurrentValue,
         [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = ''
+        [string]$CheckId = '', [string]$Remediation = '',
+        [PSCustomObject]$Evidence = $null
     )
     $p = @{
         Settings         = $settings
@@ -63,6 +64,7 @@ function Add-Setting {
         Status           = $Status
         CheckId          = $CheckId
         Remediation      = $Remediation
+        Evidence         = $Evidence
     }
     Add-SecuritySetting @p
 }
@@ -418,6 +420,7 @@ try {
         Status           = $(if ($foreignTier0.Count -eq 0) { 'Pass' } else { 'Fail' })
         CheckId          = 'ENTRA-ENTAPP-003'
         Remediation      = 'Entra admin center > Enterprise applications > review foreign apps with Tier 0 permissions. These permissions have documented attack paths to Global Administrator. Remove or replace with least-privilege alternatives.'
+        Evidence         = [PSCustomObject]@{ Findings = @($foreignTier0); Count = $foreignTier0.Count }
     }
     Add-Setting @settingParams
 
@@ -430,6 +433,7 @@ try {
         Status           = $(if ($foreignTier1.Count -eq 0) { 'Pass' } else { 'Warning' })
         CheckId          = 'ENTRA-ENTAPP-011'
         Remediation      = 'Entra admin center > Enterprise applications > review foreign apps with broad data access (Mail.ReadWrite, Files.ReadWrite.All, etc.). Scope to least-privilege or remove.'
+        Evidence         = [PSCustomObject]@{ Findings = @($foreignTier1); Count = $foreignTier1.Count }
     }
     Add-Setting @settingParams
 }
@@ -464,6 +468,7 @@ try {
         Status           = $(if ($foreignDangerousDelegated.Count -eq 0) { 'Pass' } else { 'Fail' })
         CheckId          = 'ENTRA-ENTAPP-004'
         Remediation      = 'Entra admin center > Enterprise applications > review foreign apps with high-privilege delegated permissions. Revoke admin consent or remove the app.'
+        Evidence         = [PSCustomObject]@{ Findings = @($foreignDangerousDelegated); Count = $foreignDangerousDelegated.Count }
     }
     Add-Setting @settingParams
 }

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -15,6 +15,34 @@ const SCORE = D.score[0] || {};
 const MFA_STATS = D.mfaStats;
 const FINDINGS = D.findings;
 const DOMAIN_STATS = D.domainStats;
+const LS = key => `${key}-${TENANT.TenantId || 'anon'}`;
+const RO = window.REPORT_OVERRIDES || null;
+function finalizeReport({
+  hiddenFindings,
+  roadmapOverrides
+}) {
+  const overridesEl = document.getElementById('report-overrides');
+  if (!overridesEl) {
+    alert('This report is missing the overrides injection point. Regenerate it with the latest template.');
+    return;
+  }
+  const overrides = {
+    hiddenFindings: [...(hiddenFindings || [])],
+    roadmapOverrides: roadmapOverrides || {}
+  };
+  const clone = document.documentElement.cloneNode(true);
+  clone.querySelector('#report-overrides').textContent = `window.REPORT_OVERRIDES = ${JSON.stringify(overrides)};`;
+  clone.querySelector('#root').replaceChildren();
+  const blob = new Blob(['<!DOCTYPE html>\n' + clone.outerHTML], {
+    type: 'text/html'
+  });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = (TENANT.OrgDisplayName || 'Assessment').replace(/[^a-z0-9 ]/gi, '').trim().replace(/\s+/g, '-') + '-M365-Report.html';
+  a.click();
+  URL.revokeObjectURL(url);
+}
 
 // Pre-compute roadmap lane counts for sidebar sub-nav (mirrors Roadmap bucketing logic)
 const _RM = FINDINGS.filter(f => f.status !== 'Pass' && f.status !== 'Info');
@@ -462,9 +490,14 @@ function Topbar({
   setTheme,
   onPrint,
   onTweaks,
-  onHamburger
+  onHamburger,
+  editMode,
+  onEditToggle,
+  onFinalize,
+  onReset,
+  hiddenCount
 }) {
-  return /*#__PURE__*/React.createElement("div", {
+  return /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement("div", {
     className: "topbar"
   }, /*#__PURE__*/React.createElement("button", {
     className: "hamburger-btn",
@@ -515,7 +548,22 @@ function Topbar({
     className: "icon-btn",
     title: "Tweaks",
     onClick: onTweaks
-  }, /*#__PURE__*/React.createElement(Icon.sliders, null))));
+  }, /*#__PURE__*/React.createElement(Icon.sliders, null)))), editMode && /*#__PURE__*/React.createElement("div", {
+    className: "edit-toolbar"
+  }, /*#__PURE__*/React.createElement("span", {
+    className: "edit-toolbar-badge"
+  }, "\u270E Edit Mode"), hiddenCount > 0 && /*#__PURE__*/React.createElement("span", {
+    className: "edit-toolbar-info"
+  }, hiddenCount, " finding", hiddenCount === 1 ? '' : 's', " hidden"), /*#__PURE__*/React.createElement("button", {
+    className: "edit-toolbar-reset",
+    onClick: onReset
+  }, "\u21BA Reset all"), /*#__PURE__*/React.createElement("button", {
+    className: "edit-toolbar-finalize",
+    onClick: onFinalize
+  }, "\u2193 Finalize report"), /*#__PURE__*/React.createElement("button", {
+    className: "edit-toolbar-exit",
+    onClick: onEditToggle
+  }, "\u2715 Exit edit mode")));
 }
 
 // ======================== Posture hero ========================
@@ -2001,6 +2049,30 @@ function FilterBar({
   }, "Clear ", active, " filter", active === 1 ? '' : 's')));
 }
 
+// ======================== Search highlight helper ========================
+function Highlight({
+  text,
+  query
+}) {
+  if (!query || !text) return text || null;
+  const str = String(text);
+  const q = query.toLowerCase();
+  const parts = [];
+  let lower = str.toLowerCase();
+  let last = 0,
+    idx;
+  while ((idx = lower.indexOf(q, last)) !== -1) {
+    if (idx > last) parts.push(str.slice(last, idx));
+    parts.push(/*#__PURE__*/React.createElement("mark", {
+      key: idx,
+      className: "search-hl"
+    }, str.slice(idx, idx + q.length)));
+    last = idx + q.length;
+  }
+  if (last < str.length) parts.push(str.slice(last));
+  return parts.length ? parts : text;
+}
+
 // ======================== Findings table ========================
 const ALL_COLS = [{
   id: 'status',
@@ -2036,7 +2108,12 @@ function FindingsTable({
   filters,
   search,
   focusFinding,
-  onFocusClear
+  onFocusClear,
+  editMode,
+  hiddenFindings,
+  onHide,
+  onHideBulk,
+  onRestoreAll
 }) {
   const [open, setOpen] = useState(new Set());
   const [visibleCols, setVisibleCols] = useState(DEFAULT_COLS);
@@ -2082,6 +2159,7 @@ function FindingsTable({
   const filtered = useMemo(() => {
     const s = search.toLowerCase();
     return FINDINGS.filter(f => {
+      if (!editMode && hiddenFindings?.has(f.checkId)) return false;
       if (filters.status.length && !filters.status.includes(f.status)) return false;
       if (filters.severity.length && !filters.severity.includes(f.severity)) return false;
       if (filters.framework.length && !f.frameworks.some(fw => filters.framework.includes(fw))) return false;
@@ -2097,7 +2175,7 @@ function FindingsTable({
       }
       return true;
     });
-  }, [filters, search]);
+  }, [filters, search, editMode, hiddenFindings]);
   const toggle = i => setOpen(o => {
     const n = new Set(o);
     if (n.has(i)) n.delete(i);else n.add(i);
@@ -2119,14 +2197,23 @@ function FindingsTable({
           className: "finding-title"
         }, /*#__PURE__*/React.createElement("div", {
           className: "t"
-        }, f.setting), /*#__PURE__*/React.createElement("div", {
+        }, /*#__PURE__*/React.createElement(Highlight, {
+          text: f.setting,
+          query: search
+        })), /*#__PURE__*/React.createElement("div", {
           className: "sub"
-        }, f.section));
+        }, /*#__PURE__*/React.createElement(Highlight, {
+          text: f.section,
+          query: search
+        })));
       case 'domain':
         return /*#__PURE__*/React.createElement("div", {
           key: "domain",
           className: "finding-dom"
-        }, f.domain);
+        }, /*#__PURE__*/React.createElement(Highlight, {
+          text: f.domain,
+          query: search
+        }));
       case 'controlId':
         {
           const activeFw = filters.framework.length === 1 ? filters.framework[0] : null;
@@ -2179,7 +2266,10 @@ function FindingsTable({
         return /*#__PURE__*/React.createElement("div", {
           key: "checkId",
           className: "check-id"
-        }, f.checkId);
+        }, /*#__PURE__*/React.createElement(Highlight, {
+          text: f.checkId,
+          query: search
+        }));
       case 'severity':
         return /*#__PURE__*/React.createElement("div", {
           key: "severity"
@@ -2213,7 +2303,10 @@ function FindingsTable({
       color: 'var(--muted)',
       fontSize: 13
     }
-  }, "\xB7 ", filtered.length, " of ", FINDINGS.length)), /*#__PURE__*/React.createElement("div", {
+  }, "\xB7 ", filtered.length, " of ", FINDINGS.length)), editMode && hiddenFindings?.size > 0 && /*#__PURE__*/React.createElement("button", {
+    className: "restore-all-btn",
+    onClick: onRestoreAll
+  }, "\u21A9 Restore ", hiddenFindings.size, " hidden"), /*#__PURE__*/React.createElement("div", {
     ref: colPickerRef,
     style: {
       position: 'relative',
@@ -2277,16 +2370,24 @@ function FindingsTable({
     className: "empty"
   }, "No findings match your filters."), filtered.map((f, i) => {
     const isOpen = open.has(i);
+    const isHidden = hiddenFindings?.has(f.checkId);
     return /*#__PURE__*/React.createElement(React.Fragment, {
       key: i
     }, /*#__PURE__*/React.createElement("div", {
       id: 'finding-row-' + (f.checkId || '').replace(/\./g, '-'),
-      className: 'finding-row' + (isOpen ? ' open' : ''),
+      className: 'finding-row' + (isOpen ? ' open' : '') + (isHidden ? ' finding-hidden' : ''),
       onClick: () => toggle(i),
       style: {
         gridTemplateColumns: gridTpl
       }
-    }, cols.map(c => renderCell(c.id, f)), /*#__PURE__*/React.createElement("div", {
+    }, cols.map(c => renderCell(c.id, f)), editMode ? /*#__PURE__*/React.createElement("button", {
+      className: 'hide-finding-btn' + (isHidden ? ' restore' : ''),
+      title: isHidden ? 'Restore finding' : 'Hide from report',
+      onClick: e => {
+        e.stopPropagation();
+        onHide?.(f.checkId);
+      }
+    }, isHidden ? '↩' : '✕') : /*#__PURE__*/React.createElement("div", {
       className: "caret"
     }, /*#__PURE__*/React.createElement(Icon.chevron, null))), isOpen && /*#__PURE__*/React.createElement("div", {
       className: "finding-detail"
@@ -2367,47 +2468,37 @@ function whyItMatters(f) {
 
 // ======================== Roadmap ========================
 function Roadmap({
-  onViewFinding
+  onViewFinding,
+  editMode,
+  hiddenFindings,
+  roadmapOverrides,
+  onRoadmapChange
 }) {
-  const OVERRIDE_KEY = 'm365-roadmap-overrides';
   const [open, setOpen] = useState(null);
-  const [overrides, setOverrides] = useState(() => {
-    try {
-      return JSON.parse(localStorage.getItem(OVERRIDE_KEY) || '{}');
-    } catch {
-      return {};
-    }
-  });
-  const saveOverrides = next => {
-    setOverrides(next);
-    try {
-      localStorage.setItem(OVERRIDE_KEY, JSON.stringify(next));
-    } catch {}
-  };
   const moveTo = (checkId, lane) => {
-    saveOverrides({
-      ...overrides,
+    onRoadmapChange({
+      ...roadmapOverrides,
       [checkId]: lane
     });
     if (open === checkId) setOpen(null);
   };
   const resetCard = checkId => {
     const next = {
-      ...overrides
+      ...roadmapOverrides
     };
     delete next[checkId];
-    saveOverrides(next);
+    onRoadmapChange(next);
   };
   const resetLane = laneItems => {
     const next = {
-      ...overrides
+      ...roadmapOverrides
     };
     laneItems.forEach(t => {
       delete next[t.checkId];
     });
-    saveOverrides(next);
+    onRoadmapChange(next);
   };
-  const tasks = FINDINGS.filter(f => f.status !== 'Pass' && f.status !== 'Info').map(f => ({
+  const tasks = FINDINGS.filter(f => f.status !== 'Pass' && f.status !== 'Info' && !hiddenFindings?.has(f.checkId)).map(f => ({
     ...f
   }));
   const score = f => {
@@ -2458,7 +2549,7 @@ function Roadmap({
     if (t.severity === 'high' || t.severity === 'medium' && t.effort !== 'large') return 'soon';
     return 'later';
   };
-  const getEffectiveLane = t => overrides[t.checkId] || getNaturalLane(t);
+  const getEffectiveLane = t => roadmapOverrides[t.checkId] || getNaturalLane(t);
   const LANE_LABEL = {
     now: 'Now',
     soon: 'Next',
@@ -2468,7 +2559,7 @@ function Roadmap({
   const soon = tasks.filter(t => getEffectiveLane(t) === 'soon');
   const later = tasks.filter(t => getEffectiveLane(t) === 'later');
   const priorityReason = (t, lane) => {
-    if (overrides[t.checkId]) {
+    if (roadmapOverrides[t.checkId]) {
       const natural = LANE_LABEL[getNaturalLane(t)];
       return `Manually moved to ${LANE_LABEL[lane]}. Default lane was ${natural}. Click Reset to restore.`;
     }
@@ -2486,7 +2577,7 @@ function Roadmap({
   const renderTask = (t, lane) => {
     const key = t.checkId;
     const isOpen = open === key;
-    const isCustom = !!overrides[key];
+    const isCustom = !!roadmapOverrides[key];
     return /*#__PURE__*/React.createElement("div", {
       className: 'task' + (isOpen ? ' task-open' : '') + (isCustom ? ' task-custom' : ''),
       key: key
@@ -2612,7 +2703,7 @@ function Roadmap({
   const LaneReset = ({
     laneItems
   }) => {
-    const hasCustom = laneItems.some(t => overrides[t.checkId]);
+    const hasCustom = laneItems.some(t => roadmapOverrides[t.checkId]);
     if (!hasCustom) return null;
     return /*#__PURE__*/React.createElement("button", {
       className: "lane-reset-btn",
@@ -2644,7 +2735,7 @@ function Roadmap({
     style: {
       color: 'var(--muted)'
     }
-  }, "Click any task to expand it, or use the move buttons on each card to reprioritize. Overrides persist across page refreshes."))), /*#__PURE__*/React.createElement("div", {
+  }, "Click any task to expand it, or use the move buttons on each card to reprioritize. Use Finalize (\u270E) to bake lane changes into the report."))), /*#__PURE__*/React.createElement("div", {
     className: "roadmap"
   }, /*#__PURE__*/React.createElement("div", {
     className: "lane"
@@ -3139,6 +3230,23 @@ function App() {
   const [showTweaks, setShowTweaks] = useState(false);
   const [navOpen, setNavOpen] = useState(false);
   const [focusFinding, setFocusFinding] = useState(null);
+  const [editMode, setEditMode] = useState(false);
+  const [hiddenFindings, setHiddenFindings] = useState(() => new Set(RO?.hiddenFindings || []));
+  const [roadmapOverrides, setRoadmapOverrides] = useState(() => RO?.roadmapOverrides || {});
+  const toggleHideFinding = id => setHiddenFindings(prev => {
+    const s = new Set(prev);
+    s.has(id) ? s.delete(id) : s.add(id);
+    return s;
+  });
+  const restoreAllFindings = () => setHiddenFindings(new Set());
+  const handleFinalize = () => finalizeReport({
+    hiddenFindings: [...hiddenFindings],
+    roadmapOverrides
+  });
+  const handleResetAll = () => {
+    setHiddenFindings(new Set());
+    setRoadmapOverrides({});
+  };
   useEffect(() => {
     document.documentElement.dataset.theme = theme;
     document.documentElement.dataset.mode = mode;
@@ -3272,7 +3380,12 @@ function App() {
     setTheme: setTheme,
     onPrint: () => window.print(),
     onTweaks: () => setShowTweaks(s => !s),
-    onHamburger: () => setNavOpen(o => !o)
+    onHamburger: () => setNavOpen(o => !o),
+    editMode: editMode,
+    onEditToggle: () => setEditMode(e => !e),
+    onFinalize: handleFinalize,
+    onReset: handleResetAll,
+    hiddenCount: hiddenFindings.size
   }), /*#__PURE__*/React.createElement(Overview, null), /*#__PURE__*/React.createElement(Posture, null), /*#__PURE__*/React.createElement(DomainRollup, {
     onJump: onDomainJump
   }), /*#__PURE__*/React.createElement(FrameworkQuilt, {
@@ -3295,9 +3408,17 @@ function App() {
     filters: filters,
     search: search,
     focusFinding: focusFinding,
-    onFocusClear: () => setFocusFinding(null)
+    onFocusClear: () => setFocusFinding(null),
+    editMode: editMode,
+    hiddenFindings: hiddenFindings,
+    onHide: toggleHideFinding,
+    onRestoreAll: restoreAllFindings
   }), /*#__PURE__*/React.createElement(Roadmap, {
-    onViewFinding: onViewFinding
+    onViewFinding: onViewFinding,
+    editMode: editMode,
+    hiddenFindings: hiddenFindings,
+    roadmapOverrides: roadmapOverrides,
+    onRoadmapChange: setRoadmapOverrides
   }), /*#__PURE__*/React.createElement(Appendix, null), !D.whiteLabel && /*#__PURE__*/React.createElement("div", {
     style: {
       textAlign: 'center',
@@ -3305,7 +3426,11 @@ function App() {
       fontSize: 12,
       color: 'var(--muted)',
       fontFamily: 'var(--font-mono)',
-      letterSpacing: '.06em'
+      letterSpacing: '.06em',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 16
     }
   }, /*#__PURE__*/React.createElement("a", {
     href: "https://github.com/Galvnyz/M365-Assess",
@@ -3325,7 +3450,11 @@ function App() {
       textDecoration: 'underline',
       textUnderlineOffset: 3
     }
-  }, "GALVNYZ"))), showTweaks && /*#__PURE__*/React.createElement(TweaksPanel, {
+  }, "GALVNYZ"), /*#__PURE__*/React.createElement("button", {
+    className: 'edit-mode-toggle' + (editMode ? ' active' : ''),
+    onClick: () => setEditMode(e => !e),
+    title: "Toggle edit mode"
+  }, "\u270E"))), showTweaks && /*#__PURE__*/React.createElement(TweaksPanel, {
     onClose: () => setShowTweaks(false),
     theme: theme,
     setTheme: setTheme,
@@ -3335,15 +3464,5 @@ function App() {
     setDensity: setDensity
   }));
 }
-
-// ---- Edit-mode protocol (Tweaks toolbar) ----
-window.addEventListener('message', e => {
-  if (e.data?.type === '__activate_edit_mode') {
-    // No-op: the in-page Tweaks button already provides the UI
-  }
-});
-window.parent?.postMessage({
-  type: '__edit_mode_available'
-}, '*');
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(/*#__PURE__*/React.createElement(App, null));

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -10,6 +10,31 @@ const MFA_STATS = D.mfaStats;
 const FINDINGS = D.findings;
 const DOMAIN_STATS = D.domainStats;
 
+const LS = key => `${key}-${TENANT.TenantId || 'anon'}`;
+const RO = window.REPORT_OVERRIDES || null;
+
+function finalizeReport({ hiddenFindings, roadmapOverrides }) {
+  const overridesEl = document.getElementById('report-overrides');
+  if (!overridesEl) {
+    alert('This report is missing the overrides injection point. Regenerate it with the latest template.');
+    return;
+  }
+  const overrides = {
+    hiddenFindings:   [...(hiddenFindings || [])],
+    roadmapOverrides: roadmapOverrides || {},
+  };
+  const clone = document.documentElement.cloneNode(true);
+  clone.querySelector('#report-overrides').textContent = `window.REPORT_OVERRIDES = ${JSON.stringify(overrides)};`;
+  clone.querySelector('#root').replaceChildren();
+  const blob = new Blob(['<!DOCTYPE html>\n' + clone.outerHTML], { type: 'text/html' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = (TENANT.OrgDisplayName || 'Assessment').replace(/[^a-z0-9 ]/gi, '').trim().replace(/\s+/g, '-') + '-M365-Report.html';
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
 // Pre-compute roadmap lane counts for sidebar sub-nav (mirrors Roadmap bucketing logic)
 const _RM = FINDINGS.filter(f => f.status !== 'Pass' && f.status !== 'Info');
 const _RM_NOW   = _RM.filter(t => t.severity === 'critical' || (t.severity === 'high' && t.effort === 'small'));
@@ -198,37 +223,50 @@ function Sidebar({ active, counts, domainCounts, activeDomain, onDomainJump, onO
 }
 
 // ======================== Topbar ========================
-function Topbar({ search, setSearch, mode, setMode, theme, setTheme, onPrint, onTweaks, onHamburger }) {
+function Topbar({ search, setSearch, mode, setMode, theme, setTheme, onPrint, onTweaks, onHamburger, editMode, onEditToggle, onFinalize, onReset, hiddenCount }) {
   return (
-    <div className="topbar">
-      <button className="hamburger-btn" onClick={onHamburger} aria-label="Open navigation"><Icon.menu/></button>
-      <div className="title">
-        Security posture report
-        <span className="title-sub">· {TENANT.OrgDisplayName}</span>
+    <>
+      <div className="topbar">
+        <button className="hamburger-btn" onClick={onHamburger} aria-label="Open navigation"><Icon.menu/></button>
+        <div className="title">
+          Security posture report
+          <span className="title-sub">· {TENANT.OrgDisplayName}</span>
+        </div>
+        <div className="spacer" />
+        <div className="search">
+          <Icon.search />
+          <input value={search} onChange={e=>setSearch(e.target.value)} placeholder="Search findings, check IDs, remediation…" />
+          <kbd>/</kbd>
+        </div>
+        <div className="palette-switch">
+          <button className={theme==='neon'?'active':''} onClick={()=>setTheme('neon')}>Neon</button>
+          <button className={theme==='console'?'active':''} onClick={()=>setTheme('console')}>Console</button>
+          <button className={theme==='saas'?'active':''} onClick={()=>setTheme('saas')}>Light</button>
+          <button className={theme==='high-contrast'?'active':''} onClick={()=>setTheme('high-contrast')}>High Contrast</button>
+        </div>
+        <div className="icon-btn-group">
+          <button className="icon-btn" title={mode==='dark'?'Light mode':'Dark mode'} onClick={()=>setMode(mode==='dark'?'light':'dark')}>
+            {mode==='dark' ? <Icon.sun/> : <Icon.moon/>}
+          </button>
+          {D.xlsxFileName && (
+            <a className="icon-btn" href={D.xlsxFileName} download title={`Download compliance matrix — ${D.xlsxFileName}`}><Icon.xlsx/></a>
+          )}
+          <button className="icon-btn" title="Print / PDF" onClick={onPrint}><Icon.print/></button>
+          <button className="icon-btn" title="Tweaks" onClick={onTweaks}><Icon.sliders/></button>
+        </div>
       </div>
-      <div className="spacer" />
-      <div className="search">
-        <Icon.search />
-        <input value={search} onChange={e=>setSearch(e.target.value)} placeholder="Search findings, check IDs, remediation…" />
-        <kbd>/</kbd>
-      </div>
-      <div className="palette-switch">
-        <button className={theme==='neon'?'active':''} onClick={()=>setTheme('neon')}>Neon</button>
-        <button className={theme==='console'?'active':''} onClick={()=>setTheme('console')}>Console</button>
-        <button className={theme==='saas'?'active':''} onClick={()=>setTheme('saas')}>Light</button>
-        <button className={theme==='high-contrast'?'active':''} onClick={()=>setTheme('high-contrast')}>High Contrast</button>
-      </div>
-      <div className="icon-btn-group">
-        <button className="icon-btn" title={mode==='dark'?'Light mode':'Dark mode'} onClick={()=>setMode(mode==='dark'?'light':'dark')}>
-          {mode==='dark' ? <Icon.sun/> : <Icon.moon/>}
-        </button>
-        {D.xlsxFileName && (
-          <a className="icon-btn" href={D.xlsxFileName} download title={`Download compliance matrix — ${D.xlsxFileName}`}><Icon.xlsx/></a>
-        )}
-        <button className="icon-btn" title="Print / PDF" onClick={onPrint}><Icon.print/></button>
-        <button className="icon-btn" title="Tweaks" onClick={onTweaks}><Icon.sliders/></button>
-      </div>
-    </div>
+      {editMode && (
+        <div className="edit-toolbar">
+          <span className="edit-toolbar-badge">✎ Edit Mode</span>
+          {hiddenCount > 0 && (
+            <span className="edit-toolbar-info">{hiddenCount} finding{hiddenCount===1?'':'s'} hidden</span>
+          )}
+          <button className="edit-toolbar-reset" onClick={onReset}>↺ Reset all</button>
+          <button className="edit-toolbar-finalize" onClick={onFinalize}>↓ Finalize report</button>
+          <button className="edit-toolbar-exit" onClick={onEditToggle}>✕ Exit edit mode</button>
+        </div>
+      )}
+    </>
   );
 }
 
@@ -1129,6 +1167,23 @@ function FilterBar({ filters, setFilters, counts, total, search, setSearch }) {
   );
 }
 
+// ======================== Search highlight helper ========================
+function Highlight({ text, query }) {
+  if (!query || !text) return text || null;
+  const str = String(text);
+  const q = query.toLowerCase();
+  const parts = [];
+  let lower = str.toLowerCase();
+  let last = 0, idx;
+  while ((idx = lower.indexOf(q, last)) !== -1) {
+    if (idx > last) parts.push(str.slice(last, idx));
+    parts.push(<mark key={idx} className="search-hl">{str.slice(idx, idx + q.length)}</mark>);
+    last = idx + q.length;
+  }
+  if (last < str.length) parts.push(str.slice(last));
+  return parts.length ? parts : text;
+}
+
 // ======================== Findings table ========================
 const ALL_COLS = [
   { id: 'status',    label: 'Status',    width: '80px'  },
@@ -1141,7 +1196,7 @@ const ALL_COLS = [
 ];
 const DEFAULT_COLS = ['status', 'finding', 'domain', 'controlId', 'checkId', 'severity'];
 
-function FindingsTable({ filters, search, focusFinding, onFocusClear }) {
+function FindingsTable({ filters, search, focusFinding, onFocusClear, editMode, hiddenFindings, onHide, onHideBulk, onRestoreAll }) {
   const [open, setOpen] = useState(new Set());
   const [visibleCols, setVisibleCols] = useState(DEFAULT_COLS);
   const [colPickerOpen, setColPickerOpen] = useState(false);
@@ -1183,6 +1238,7 @@ function FindingsTable({ filters, search, focusFinding, onFocusClear }) {
   const filtered = useMemo(() => {
     const s = search.toLowerCase();
     return FINDINGS.filter(f => {
+      if (!editMode && hiddenFindings?.has(f.checkId)) return false;
       if (filters.status.length && !filters.status.includes(f.status)) return false;
       if (filters.severity.length && !filters.severity.includes(f.severity)) return false;
       if (filters.framework.length && !f.frameworks.some(fw => filters.framework.includes(fw))) return false;
@@ -1198,7 +1254,7 @@ function FindingsTable({ filters, search, focusFinding, onFocusClear }) {
       }
       return true;
     });
-  }, [filters, search]);
+  }, [filters, search, editMode, hiddenFindings]);
 
   const toggle = i => setOpen(o => {
     const n = new Set(o);
@@ -1217,11 +1273,11 @@ function FindingsTable({ filters, search, focusFinding, onFocusClear }) {
       );
       case 'finding': return (
         <div key="finding" className="finding-title">
-          <div className="t">{f.setting}</div>
-          <div className="sub">{f.section}</div>
+          <div className="t"><Highlight text={f.setting} query={search}/></div>
+          <div className="sub"><Highlight text={f.section} query={search}/></div>
         </div>
       );
-      case 'domain':    return <div key="domain" className="finding-dom">{f.domain}</div>;
+      case 'domain':    return <div key="domain" className="finding-dom"><Highlight text={f.domain} query={search}/></div>;
       case 'controlId': {
         const activeFw = filters.framework.length === 1 ? filters.framework[0] : null;
         const meta = activeFw ? f.fwMeta?.[activeFw] : null;
@@ -1255,7 +1311,7 @@ function FindingsTable({ filters, search, focusFinding, onFocusClear }) {
         );
       }
       case 'checkId': return (
-        <div key="checkId" className="check-id">{f.checkId}</div>
+        <div key="checkId" className="check-id"><Highlight text={f.checkId} query={search}/></div>
       );
       case 'severity':  return (
         <div key="severity">
@@ -1279,6 +1335,11 @@ function FindingsTable({ filters, search, focusFinding, onFocusClear }) {
       <div className="section-head">
         <span className="eyebrow">03 · Detail</span>
         <h2>All findings <span style={{fontWeight:400, color:'var(--muted)', fontSize:13}}>· {filtered.length} of {FINDINGS.length}</span></h2>
+        {editMode && (hiddenFindings?.size > 0) && (
+          <button className="restore-all-btn" onClick={onRestoreAll}>
+            ↩ Restore {hiddenFindings.size} hidden
+          </button>
+        )}
         <div ref={colPickerRef} style={{position:'relative', marginLeft:12, flexShrink:0}}>
           <button className={'chip chip-more' + (visibleCols.length !== DEFAULT_COLS.length ? ' selected' : '')}
                   onClick={() => setColPickerOpen(o => !o)} title="Choose columns">
@@ -1307,13 +1368,21 @@ function FindingsTable({ filters, search, focusFinding, onFocusClear }) {
         {filtered.length === 0 && <div className="empty">No findings match your filters.</div>}
         {filtered.map((f,i) => {
           const isOpen = open.has(i);
+          const isHidden = hiddenFindings?.has(f.checkId);
           return (
             <React.Fragment key={i}>
               <div id={'finding-row-'+(f.checkId||'').replace(/\./g,'-')}
-                   className={'finding-row' + (isOpen?' open':'')} onClick={() => toggle(i)}
+                   className={'finding-row' + (isOpen?' open':'') + (isHidden?' finding-hidden':'')} onClick={() => toggle(i)}
                    style={{gridTemplateColumns: gridTpl}}>
                 {cols.map(c => renderCell(c.id, f))}
-                <div className="caret"><Icon.chevron/></div>
+                {editMode
+                  ? <button className={'hide-finding-btn'+(isHidden?' restore':'')}
+                      title={isHidden?'Restore finding':'Hide from report'}
+                      onClick={e => { e.stopPropagation(); onHide?.(f.checkId); }}>
+                      {isHidden ? '↩' : '✕'}
+                    </button>
+                  : <div className="caret"><Icon.chevron/></div>
+                }
               </div>
               {isOpen && (
                 <div className="finding-detail">
@@ -1394,37 +1463,27 @@ function whyItMatters(f) {
 }
 
 // ======================== Roadmap ========================
-function Roadmap({ onViewFinding }) {
-  const OVERRIDE_KEY = 'm365-roadmap-overrides';
+function Roadmap({ onViewFinding, editMode, hiddenFindings, roadmapOverrides, onRoadmapChange }) {
   const [open, setOpen] = useState(null);
-  const [overrides, setOverrides] = useState(() => {
-    try { return JSON.parse(localStorage.getItem(OVERRIDE_KEY) || '{}'); }
-    catch { return {}; }
-  });
-
-  const saveOverrides = next => {
-    setOverrides(next);
-    try { localStorage.setItem(OVERRIDE_KEY, JSON.stringify(next)); } catch {}
-  };
 
   const moveTo = (checkId, lane) => {
-    saveOverrides({ ...overrides, [checkId]: lane });
+    onRoadmapChange({ ...roadmapOverrides, [checkId]: lane });
     if (open === checkId) setOpen(null);
   };
 
   const resetCard = checkId => {
-    const next = { ...overrides };
+    const next = { ...roadmapOverrides };
     delete next[checkId];
-    saveOverrides(next);
+    onRoadmapChange(next);
   };
 
   const resetLane = laneItems => {
-    const next = { ...overrides };
+    const next = { ...roadmapOverrides };
     laneItems.forEach(t => { delete next[t.checkId]; });
-    saveOverrides(next);
+    onRoadmapChange(next);
   };
 
-  const tasks = FINDINGS.filter(f => f.status !== 'Pass' && f.status !== 'Info').map(f => ({ ...f }));
+  const tasks = FINDINGS.filter(f => f.status !== 'Pass' && f.status !== 'Info' && !hiddenFindings?.has(f.checkId)).map(f => ({ ...f }));
   const score = f => {
     const sev = { critical:100, high:60, medium:30, low:10, none:0, info:5 }[f.severity];
     const eff = { small:3, medium:2, large:1 }[f.effort];
@@ -1465,7 +1524,7 @@ function Roadmap({ onViewFinding }) {
     return 'later';
   };
 
-  const getEffectiveLane = t => overrides[t.checkId] || getNaturalLane(t);
+  const getEffectiveLane = t => roadmapOverrides[t.checkId] || getNaturalLane(t);
   const LANE_LABEL = { now: 'Now', soon: 'Next', later: 'Later' };
 
   const now   = tasks.filter(t => getEffectiveLane(t) === 'now');
@@ -1473,7 +1532,7 @@ function Roadmap({ onViewFinding }) {
   const later = tasks.filter(t => getEffectiveLane(t) === 'later');
 
   const priorityReason = (t, lane) => {
-    if (overrides[t.checkId]) {
+    if (roadmapOverrides[t.checkId]) {
       const natural = LANE_LABEL[getNaturalLane(t)];
       return `Manually moved to ${LANE_LABEL[lane]}. Default lane was ${natural}. Click Reset to restore.`;
     }
@@ -1492,7 +1551,7 @@ function Roadmap({ onViewFinding }) {
   const renderTask = (t, lane) => {
     const key = t.checkId;
     const isOpen = open === key;
-    const isCustom = !!overrides[key];
+    const isCustom = !!roadmapOverrides[key];
     return (
       <div className={'task'+(isOpen?' task-open':'')+(isCustom?' task-custom':'')} key={key}>
         <button className="task-head-btn" onClick={()=>setOpen(isOpen?null:key)} aria-expanded={isOpen}>
@@ -1565,7 +1624,7 @@ function Roadmap({ onViewFinding }) {
   };
 
   const LaneReset = ({ laneItems }) => {
-    const hasCustom = laneItems.some(t => overrides[t.checkId]);
+    const hasCustom = laneItems.some(t => roadmapOverrides[t.checkId]);
     if (!hasCustom) return null;
     return (
       <button className="lane-reset-btn" onClick={() => resetLane(laneItems)}>Reset lane</button>
@@ -1584,7 +1643,7 @@ function Roadmap({ onViewFinding }) {
         <div className="roadmap-intro-head">How we prioritized</div>
         <div className="roadmap-intro-body">
           Findings are bucketed by severity. Critical findings — identity takeover, data exfiltration, privilege escalation paths — always go in <b>Now</b>. High-severity findings land in <b>Next</b>: risk is real but remediation typically requires coordination or scheduling. Medium-severity items also join <b>Next</b> when tractable, or <b>Later</b> for larger hardening work. <br/>
-          <span style={{color:'var(--muted)'}}>Click any task to expand it, or use the move buttons on each card to reprioritize. Overrides persist across page refreshes.</span>
+          <span style={{color:'var(--muted)'}}>Click any task to expand it, or use the move buttons on each card to reprioritize. Use Finalize (✎) to bake lane changes into the report.</span>
         </div>
       </div>
       <div className="roadmap">
@@ -1815,6 +1874,24 @@ function App() {
   const [showTweaks, setShowTweaks] = useState(false);
   const [navOpen, setNavOpen] = useState(false);
   const [focusFinding, setFocusFinding] = useState(null);
+  const [editMode, setEditMode] = useState(false);
+  const [hiddenFindings, setHiddenFindings] = useState(() => new Set(RO?.hiddenFindings || []));
+  const [roadmapOverrides, setRoadmapOverrides] = useState(() => RO?.roadmapOverrides || {});
+
+  const toggleHideFinding = id => setHiddenFindings(prev => {
+    const s = new Set(prev); s.has(id) ? s.delete(id) : s.add(id); return s;
+  });
+  const restoreAllFindings = () => setHiddenFindings(new Set());
+
+  const handleFinalize = () => finalizeReport({
+    hiddenFindings: [...hiddenFindings],
+    roadmapOverrides,
+  });
+
+  const handleResetAll = () => {
+    setHiddenFindings(new Set());
+    setRoadmapOverrides({});
+  };
 
   useEffect(() => {
     document.documentElement.dataset.theme = theme;
@@ -1905,6 +1982,11 @@ function App() {
           onPrint={()=>window.print()}
           onTweaks={()=>setShowTweaks(s=>!s)}
           onHamburger={()=>setNavOpen(o=>!o)}
+          editMode={editMode}
+          onEditToggle={()=>setEditMode(e=>!e)}
+          onFinalize={handleFinalize}
+          onReset={handleResetAll}
+          hiddenCount={hiddenFindings.size}
         />
         <Overview/>
         <Posture/>
@@ -1913,14 +1995,16 @@ function App() {
         <div id="findings-anchor"/>
         <div style={{marginTop:20}}/>
         <FilterBar filters={filters} setFilters={setFilters} counts={counts} total={FINDINGS.length} search={search} setSearch={setSearch}/>
-        <FindingsTable filters={filters} search={search} focusFinding={focusFinding} onFocusClear={() => setFocusFinding(null)}/>
-        <Roadmap onViewFinding={onViewFinding}/>
+        <FindingsTable filters={filters} search={search} focusFinding={focusFinding} onFocusClear={() => setFocusFinding(null)}
+          editMode={editMode} hiddenFindings={hiddenFindings} onHide={toggleHideFinding} onRestoreAll={restoreAllFindings}/>
+        <Roadmap onViewFinding={onViewFinding} editMode={editMode} hiddenFindings={hiddenFindings} roadmapOverrides={roadmapOverrides} onRoadmapChange={setRoadmapOverrides}/>
         <Appendix/>
         {!D.whiteLabel && (
-          <div style={{textAlign:'center',padding:'30px 0 10px',fontSize:12,color:'var(--muted)',fontFamily:'var(--font-mono)',letterSpacing:'.06em'}}>
+          <div style={{textAlign:'center',padding:'30px 0 10px',fontSize:12,color:'var(--muted)',fontFamily:'var(--font-mono)',letterSpacing:'.06em',display:'flex',alignItems:'center',justifyContent:'center',gap:16}}>
             <a href="https://github.com/Galvnyz/M365-Assess" target="_blank" rel="noreferrer" style={{color:'inherit',textDecoration:'underline',textUnderlineOffset:3}}>M365 ASSESS</a>
             {' · READ-ONLY SECURITY ASSESSMENT · '}
             <a href="https://galvnyz.com" target="_blank" rel="noreferrer" style={{color:'inherit',textDecoration:'underline',textUnderlineOffset:3}}>GALVNYZ</a>
+            <button className={'edit-mode-toggle'+(editMode?' active':'')} onClick={()=>setEditMode(e=>!e)} title="Toggle edit mode">✎</button>
           </div>
         )}
       </main>
@@ -1928,14 +2012,6 @@ function App() {
     </div>
   );
 }
-
-// ---- Edit-mode protocol (Tweaks toolbar) ----
-window.addEventListener('message', (e) => {
-  if (e.data?.type === '__activate_edit_mode') {
-    // No-op: the in-page Tweaks button already provides the UI
-  }
-});
-window.parent?.postMessage({type:'__edit_mode_available'}, '*');
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(<App/>);

--- a/src/M365-Assess/assets/report-shell.css
+++ b/src/M365-Assess/assets/report-shell.css
@@ -516,6 +516,14 @@ section.block { margin-bottom: 52px; scroll-margin-top: 20px; }
 }
 .finding-row.highlight-focus { animation: focus-flash 2.5s ease-out forwards; }
 
+mark.search-hl {
+  background: var(--accent-soft);
+  color: var(--accent-text);
+  border-radius: 2px;
+  padding: 0 1px;
+  font-style: inherit;
+}
+
 .finding-dom {
   font-size: 12px;
   font-weight: 500;
@@ -1432,3 +1440,23 @@ section.block { margin-bottom: 52px; scroll-margin-top: 20px; }
 .spo-top-fails-label { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .08em; color: var(--muted); margin-bottom: 6px; }
 .spo-fail-row { display: flex; align-items: center; gap: 8px; padding: 5px 0; border-bottom: 1px solid var(--border); font-size: 12px; }
 .spo-fail-name { color: var(--text-soft, var(--muted)); }
+
+/* Edit mode */
+.edit-toolbar { position: sticky; top: 0; z-index: 200; display: flex; align-items: center; gap: 10px; padding: 8px 16px; background: color-mix(in srgb, var(--accent) 12%, var(--bg-elev)); border-bottom: 1px solid color-mix(in srgb, var(--accent) 30%, var(--border)); flex-wrap: wrap; }
+.edit-toolbar-badge { font-size: 11px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; color: var(--accent); }
+.edit-toolbar-info { font-size: 12px; color: var(--muted); }
+.edit-toolbar-finalize { font-size: 12px; padding: 5px 14px; border-radius: 6px; border: 1px solid var(--accent); background: transparent; color: var(--accent); cursor: pointer; font-weight: 600; }
+.edit-toolbar-finalize:hover { background: color-mix(in srgb, var(--accent) 15%, transparent); }
+.edit-toolbar-exit { font-size: 12px; padding: 5px 12px; border-radius: 6px; border: 1px solid var(--border); background: transparent; color: var(--muted); cursor: pointer; }
+.edit-toolbar-exit:hover { color: var(--text); border-color: var(--border-strong); }
+.edit-mode-toggle { font-size: 14px; background: none; border: 1px solid var(--border); border-radius: 5px; color: var(--muted); cursor: pointer; padding: 3px 7px; transition: color .15s, border-color .15s; }
+.edit-mode-toggle.active, .edit-mode-toggle:hover { color: var(--accent); border-color: var(--accent); }
+.hide-finding-btn { font-size: 13px; width: 26px; height: 26px; border-radius: 5px; border: 1px solid var(--border); background: transparent; color: var(--muted); cursor: pointer; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+.hide-finding-btn:hover { background: color-mix(in srgb, var(--danger) 15%, transparent); border-color: var(--danger); color: var(--danger); }
+.hide-finding-btn.restore { border-color: var(--accent); color: var(--accent); }
+.hide-finding-btn.restore:hover { background: color-mix(in srgb, var(--accent) 15%, transparent); }
+.finding-hidden { opacity: .45; }
+.restore-all-btn { font-size: 12px; padding: 4px 10px; border-radius: 5px; border: 1px solid var(--accent); background: transparent; color: var(--accent); cursor: pointer; margin-left: auto; }
+.restore-all-btn:hover { background: color-mix(in srgb, var(--accent) 10%, transparent); }
+.edit-toolbar-reset { font-size: 12px; padding: 5px 12px; border-radius: 6px; border: 1px solid var(--border); background: transparent; color: var(--muted); cursor: pointer; }
+.edit-toolbar-reset:hover { border-color: var(--warn, #f59e0b); color: var(--warn, #f59e0b); }

--- a/tests/Common/Build-ReportData.Tests.ps1
+++ b/tests/Common/Build-ReportData.Tests.ps1
@@ -166,15 +166,15 @@ Describe 'Build-ReportData' {
             $d.findings[0].effort | Should -Be 'medium'
         }
 
-        It 'should propagate learnMore URL from registry entry' {
+        It 'should propagate learnMore URL from registry references[0].url' {
             $f = New-Finding -CheckId 'CA-LEGACYAUTH-001.1'
             $url = 'https://learn.microsoft.com/en-us/entra/identity/conditional-access/block-legacy-authentication'
-            $registry = @{ 'CA-LEGACYAUTH-001' = @{ riskSeverity = 'Critical'; frameworks = @{}; learnMore = $url } }
+            $registry = @{ 'CA-LEGACYAUTH-001' = @{ riskSeverity = 'Critical'; frameworks = @{}; references = @(@{ url = $url; title = 'Docs' }) } }
             $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @($f) -RegistryData $registry)
             $d.findings[0].learnMore | Should -Be $url
         }
 
-        It 'should set learnMore to null when not in registry' {
+        It 'should set learnMore to null when references array is absent' {
             $f = New-Finding -CheckId 'CA-LEGACYAUTH-001.1'
             $registry = @{ 'CA-LEGACYAUTH-001' = @{ riskSeverity = 'Critical'; frameworks = @{} } }
             $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @($f) -RegistryData $registry)


### PR DESCRIPTION
…iverable (#651)

* fix(report): surface learnMore URLs from registry references[0].url (#637)



* feat(report): evidence Phase 1 — structured evidence for CA, EntApp, AdminRole checks (#640)



* feat(report): port edit mode from Corporate SaaS v3

Adds consultant edit mode to the main HTML report:

- ✎ toggle in the report footer; toolbar appears at the top of the page
- Hide/restore individual findings per row (✕ / ↩ buttons, greyed-out row)
- "Restore N hidden" bulk restore in the findings section header
- Roadmap lane overrides (→ Now / → Next / → Later / Reset) — existing feature, now tenant-scoped and accepts state as props instead of reading localStorage
- ↓ Finalize report: DOM-clone approach bakes hidden findings + roadmap overrides into a self-contained deliverable HTML file
- REPORT_OVERRIDES sentinel added to Get-ReportTemplate.ps1 so finalized reports re-open with their baked-in state

No localStorage for structural state — each report open starts fresh. Finalize is the only persistence path for edit-mode choices.



* feat(report): highlight search match text in findings results (#636)



* feat(edit-mode): add Reset all button to revert all edits

Clears hidden findings and roadmap lane overrides in one click. Button appears in the edit toolbar (↺ Reset all); styled with a warning hover colour to signal destructive intent.



---------

## Summary

Brief description of what this PR does.

## Related Issues

Closes #

## Changes

-

## Test Plan

- [ ] PSScriptAnalyzer passes on changed `.ps1` files
- [ ] Pester tests pass (`Invoke-Pester ./tests/` or N/A)
- [ ] Ran against test tenant (or N/A for docs-only)
- [ ] HTML report renders correctly (or N/A)
- [ ] No secrets or tenant PII in committed files

## Breaking Changes

None / Describe any breaking changes.
