### PR TITLE
feat(sprint3 + #646): tenant age, hygiene counts, intent-by-design, ReportDensity param

### DIFF
--- a/src/M365-Assess/Common/Build-ReportData.ps1
+++ b/src/M365-Assess/Common/Build-ReportData.ps1
@@ -160,7 +160,8 @@ function Build-ReportDataJson {
             effort       = if ($regEntry) { $e = if ($regEntry -is [hashtable]) { $regEntry['effort'] } else { $regEntry.effort }; if ($e) { $e } else { 'medium' } } else { 'medium' }
             frameworks   = $frameworks
             fwMeta       = $fwMeta
-            intentDesign = [bool]($f.PSObject.Properties['IntentDesign'] -and $f.IntentDesign)
+            intentDesign    = [bool]($f.PSObject.Properties['IntentDesign'] -and $f.IntentDesign)
+            intentRationale = if ($f.PSObject.Properties['ImpactRationale'] -and $f.ImpactRationale) { [string]$f.ImpactRationale } else { $null }
             learnMore    = $learnMore
             evidence     = $evidence
         })

--- a/src/M365-Assess/Common/Export-AssessmentReport.ps1
+++ b/src/M365-Assess/Common/Export-AssessmentReport.ps1
@@ -55,6 +55,10 @@ param(
     [string]$ReportTheme = 'Neon',
 
     [Parameter()]
+    [ValidateSet('Compact', 'Comfort')]
+    [string]$ReportDensity = 'Compact',
+
+    [Parameter()]
     [switch]$WhiteLabel,
 
     [Parameter()]
@@ -180,10 +184,11 @@ $themeDefaults = @{
 }
 $htmlTheme = $themeDefaults[$ReportTheme]
 $html = Get-ReportTemplate `
-    -ReportDataJson $reportJson `
-    -ReportTitle    $reportTitle `
-    -DefaultTheme   $htmlTheme.Theme `
-    -DefaultMode    $htmlTheme.Mode
+    -ReportDataJson  $reportJson `
+    -ReportTitle     $reportTitle `
+    -DefaultTheme    $htmlTheme.Theme `
+    -DefaultMode     $htmlTheme.Mode `
+    -DefaultDensity  ($ReportDensity.ToLower())
 
 Set-Content -Path $OutputPath -Value $html -Encoding UTF8
 Write-Output "HTML report generated: $OutputPath"

--- a/src/M365-Assess/Common/Get-ReportTemplate.ps1
+++ b/src/M365-Assess/Common/Get-ReportTemplate.ps1
@@ -30,7 +30,11 @@ function Get-ReportTemplate {
 
         [Parameter()]
         [ValidateSet('dark', 'light')]
-        [string]$DefaultMode = 'dark'
+        [string]$DefaultMode = 'dark',
+
+        [Parameter()]
+        [ValidateSet('compact', 'comfort')]
+        [string]$DefaultDensity = 'compact'
     )
 
     $assetsDir = Join-Path -Path $PSScriptRoot -ChildPath '../assets'
@@ -56,7 +60,7 @@ function Get-ReportTemplate {
                 "var d=localStorage.getItem('m365-density');" +
                 "if(v.indexOf(t)<0)t='$DefaultTheme';" +
                 "if(m!=='dark'&&m!=='light')m='$DefaultMode';" +
-                "if(d!=='compact'&&d!=='comfort')d='compact';" +
+                "if(d!=='compact'&&d!=='comfort')d='$DefaultDensity';" +
                 "e.dataset.theme=t;e.dataset.mode=m;e.dataset.density=d;" +
                 "}catch(err){}})();"
 
@@ -64,7 +68,7 @@ function Get-ReportTemplate {
     $sb = [System.Text.StringBuilder]::new(2097152) # 2 MB initial capacity
 
     $null = $sb.AppendLine('<!DOCTYPE html>')
-    $null = $sb.AppendLine("<html data-theme=`"$DefaultTheme`" data-mode=`"$DefaultMode`" data-density=`"compact`">")
+    $null = $sb.AppendLine("<html data-theme=`"$DefaultTheme`" data-mode=`"$DefaultMode`" data-density=`"$DefaultDensity`">")
     $null = $sb.AppendLine('<head>')
     $null = $sb.AppendLine('<meta charset="UTF-8">')
     $null = $sb.AppendLine('<meta name="viewport" content="width=device-width,initial-scale=1.0">')

--- a/src/M365-Assess/Invoke-M365Assessment.ps1
+++ b/src/M365-Assess/Invoke-M365Assessment.ps1
@@ -213,6 +213,10 @@ param(
     [string]$ReportTheme = 'Neon',
 
     [Parameter()]
+    [ValidateSet('Compact', 'Comfort')]
+    [string]$ReportDensity = 'Compact',
+
+    [Parameter()]
     [switch]$WhiteLabel,
 
     [Parameter()]
@@ -1278,7 +1282,8 @@ if (Test-Path -Path $reportScriptPath) {
         }
         if ($script:domainPrefix) { $reportParams['TenantName'] = $script:domainPrefix }
         elseif ($TenantId)        { $reportParams['TenantName'] = $TenantId }
-        $reportParams['ReportTheme'] = $ReportTheme
+        $reportParams['ReportTheme']   = $ReportTheme
+        $reportParams['ReportDensity'] = $ReportDensity
         if ($WhiteLabel)        { $reportParams['WhiteLabel']        = $true }
         if ($CompactReport)     { $reportParams['CompactReport']     = $true }
         if ($OpenReport)        { $reportParams['OpenReport']        = $true }

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -468,7 +468,9 @@ function Sidebar({
     className: "sc-row"
   }, /*#__PURE__*/React.createElement("span", null, "org"), /*#__PURE__*/React.createElement("span", null, TENANT.DefaultDomain || TENANT.OrgDisplayName)), /*#__PURE__*/React.createElement("div", {
     className: "sc-row"
-  }, /*#__PURE__*/React.createElement("span", null, "tenant"), /*#__PURE__*/React.createElement("span", null, (TENANT.TenantId || '').slice(0, 8) + '…')), /*#__PURE__*/React.createElement("div", {
+  }, /*#__PURE__*/React.createElement("span", null, "tenant"), /*#__PURE__*/React.createElement("span", null, (TENANT.TenantId || '').slice(0, 8) + '…')), TENANT.tenantAgeYears != null && /*#__PURE__*/React.createElement("div", {
+    className: "sc-row"
+  }, /*#__PURE__*/React.createElement("span", null, "age"), /*#__PURE__*/React.createElement("span", null, TENANT.tenantAgeYears, " yrs")), /*#__PURE__*/React.createElement("div", {
     className: "sc-row"
   }, /*#__PURE__*/React.createElement("span", null, "users"), /*#__PURE__*/React.createElement("span", null, fmt(USERS.TotalUsers))), /*#__PURE__*/React.createElement("div", {
     className: "sc-row"
@@ -476,7 +478,19 @@ function Sidebar({
     className: "sc-row"
   }, /*#__PURE__*/React.createElement("span", null, "guests"), /*#__PURE__*/React.createElement("span", null, fmt(USERS.GuestUsers))), USERS.SyncedFromOnPrem > 0 && /*#__PURE__*/React.createElement("div", {
     className: "sc-row"
-  }, /*#__PURE__*/React.createElement("span", null, "synced"), /*#__PURE__*/React.createElement("span", null, fmt(USERS.SyncedFromOnPrem)))), /*#__PURE__*/React.createElement("div", {
+  }, /*#__PURE__*/React.createElement("span", null, "synced"), /*#__PURE__*/React.createElement("span", null, fmt(USERS.SyncedFromOnPrem))), USERS.DisabledUsers > 0 && /*#__PURE__*/React.createElement("div", {
+    className: "sc-row"
+  }, /*#__PURE__*/React.createElement("span", null, "disabled"), /*#__PURE__*/React.createElement("span", {
+    className: "sc-warn"
+  }, fmt(USERS.DisabledUsers))), USERS.NeverSignedIn > 0 && /*#__PURE__*/React.createElement("div", {
+    className: "sc-row"
+  }, /*#__PURE__*/React.createElement("span", null, "never signed in"), /*#__PURE__*/React.createElement("span", {
+    className: "sc-warn"
+  }, fmt(USERS.NeverSignedIn))), USERS.StaleMember > 0 && /*#__PURE__*/React.createElement("div", {
+    className: "sc-row"
+  }, /*#__PURE__*/React.createElement("span", null, "stale"), /*#__PURE__*/React.createElement("span", {
+    className: "sc-warn"
+  }, fmt(USERS.StaleMember)))), /*#__PURE__*/React.createElement("div", {
     className: "sc-card"
   }, /*#__PURE__*/React.createElement("div", {
     className: "sc-header"
@@ -2227,12 +2241,19 @@ function FindingsTable({
     switch (colId) {
       case 'status':
         return /*#__PURE__*/React.createElement("div", {
-          key: "status"
+          key: "status",
+          style: {
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 3
+          }
         }, /*#__PURE__*/React.createElement("span", {
           className: 'status-badge ' + STATUS_COLORS[f.status]
         }, /*#__PURE__*/React.createElement("span", {
           className: "dot"
-        }), f.status));
+        }), f.status), f.intentDesign && /*#__PURE__*/React.createElement("span", {
+          className: "badge-intent"
+        }, "By Design"));
       case 'finding':
         return /*#__PURE__*/React.createElement("div", {
           key: "finding",
@@ -2445,7 +2466,9 @@ function FindingsTable({
       className: "caret"
     }, /*#__PURE__*/React.createElement(Icon.chevron, null))), isOpen && /*#__PURE__*/React.createElement("div", {
       className: "finding-detail"
-    }, /*#__PURE__*/React.createElement("div", {
+    }, f.intentDesign && /*#__PURE__*/React.createElement("div", {
+      className: "intent-callout"
+    }, /*#__PURE__*/React.createElement("strong", null, "Intentional by design."), f.intentRationale && /*#__PURE__*/React.createElement("span", null, " ", f.intentRationale)), /*#__PURE__*/React.createElement("div", {
       className: "why"
     }, /*#__PURE__*/React.createElement("div", {
       className: "why-label"

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -200,10 +200,14 @@ function Sidebar({ active, counts, domainCounts, activeDomain, onDomainJump, onO
             </div>
             <div className="sc-row"><span>org</span><span>{TENANT.DefaultDomain || TENANT.OrgDisplayName}</span></div>
             <div className="sc-row"><span>tenant</span><span>{(TENANT.TenantId||'').slice(0,8)+'…'}</span></div>
+            {TENANT.tenantAgeYears != null && <div className="sc-row"><span>age</span><span>{TENANT.tenantAgeYears} yrs</span></div>}
             <div className="sc-row"><span>users</span><span>{fmt(USERS.TotalUsers)}</span></div>
             <div className="sc-row"><span>licensed</span><span>{fmt(USERS.Licensed)}</span></div>
             <div className="sc-row"><span>guests</span><span>{fmt(USERS.GuestUsers)}</span></div>
             {USERS.SyncedFromOnPrem > 0 && <div className="sc-row"><span>synced</span><span>{fmt(USERS.SyncedFromOnPrem)}</span></div>}
+            {USERS.DisabledUsers  > 0 && <div className="sc-row"><span>disabled</span><span className="sc-warn">{fmt(USERS.DisabledUsers)}</span></div>}
+            {USERS.NeverSignedIn  > 0 && <div className="sc-row"><span>never signed in</span><span className="sc-warn">{fmt(USERS.NeverSignedIn)}</span></div>}
+            {USERS.StaleMember    > 0 && <div className="sc-row"><span>stale</span><span className="sc-warn">{fmt(USERS.StaleMember)}</span></div>}
           </div>
           <div className="sc-card">
             <div className="sc-header">
@@ -1284,10 +1288,11 @@ function FindingsTable({ filters, search, focusFinding, onFocusClear, editMode, 
   const renderCell = (colId, f) => {
     switch (colId) {
       case 'status': return (
-        <div key="status">
+        <div key="status" style={{display:'flex',flexDirection:'column',gap:3}}>
           <span className={'status-badge ' + STATUS_COLORS[f.status]}>
             <span className="dot"/>{f.status}
           </span>
+          {f.intentDesign && <span className="badge-intent">By Design</span>}
         </div>
       );
       case 'finding': return (
@@ -1408,6 +1413,12 @@ function FindingsTable({ filters, search, focusFinding, onFocusClear, editMode, 
               </div>
               {isOpen && (
                 <div className="finding-detail">
+                  {f.intentDesign && (
+                    <div className="intent-callout">
+                      <strong>Intentional by design.</strong>
+                      {f.intentRationale && <span> {f.intentRationale}</span>}
+                    </div>
+                  )}
                   <div className="why">
                     <div className="why-label">Why it matters</div>
                     <div className="why-text">{whyItMatters(f)}</div>

--- a/src/M365-Assess/assets/report-shell.css
+++ b/src/M365-Assess/assets/report-shell.css
@@ -1507,3 +1507,5 @@ mark.search-hl {
 .restore-all-btn:hover { background: color-mix(in srgb, var(--accent) 10%, transparent); }
 .edit-toolbar-reset { font-size: 12px; padding: 5px 12px; border-radius: 6px; border: 1px solid var(--border); background: transparent; color: var(--muted); cursor: pointer; }
 .edit-toolbar-reset:hover { border-color: var(--warn, #f59e0b); color: var(--warn, #f59e0b); }
+.badge-intent { font-size: 10px; font-weight: 600; letter-spacing: .4px; padding: 2px 6px; border-radius: 4px; background: var(--accent-soft); color: var(--accent-text); width: fit-content; }
+.intent-callout { font-size: 13px; background: var(--accent-soft); color: var(--accent-text); border-left: 3px solid var(--accent); border-radius: 4px; padding: 8px 12px; margin-bottom: 10px; line-height: 1.5; }

--- a/tests/Common/Get-ReportTemplate.Tests.ps1
+++ b/tests/Common/Get-ReportTemplate.Tests.ps1
@@ -81,6 +81,11 @@ Describe 'Get-ReportTemplate — function contract' {
         # Must NOT contain the old hardcoded array literal
         $script:content | Should -Not -Match "v=\['neon','console','saas','high-contrast'\]"
     }
+
+    It 'declares DefaultDensity parameter with compact/comfort ValidateSet' {
+        $script:content | Should -Match '\[ValidateSet\(''compact'',\s*''comfort''\)\]'
+        $script:content | Should -Match '\[string\]\$DefaultDensity'
+    }
 }
 
 Describe 'Get-ReportTemplate — output validation' {
@@ -151,6 +156,17 @@ Describe 'Get-ReportTemplate — output validation' {
     It 'uses default title when ReportTitle omitted' {
         $result = Get-ReportTemplate -ReportDataJson 'window.REPORT_DATA = {};'
         $result | Should -Match 'M365 Security Assessment'
+    }
+
+    It 'default output uses data-density compact' {
+        $result = Get-ReportTemplate -ReportDataJson 'window.REPORT_DATA = {};'
+        $result | Should -Match 'data-density="compact"'
+    }
+
+    It 'output uses comfort density when DefaultDensity is comfort' {
+        $result = Get-ReportTemplate -ReportDataJson 'window.REPORT_DATA = {};' -DefaultDensity comfort
+        $result | Should -Match 'data-density="comfort"'
+        $result | Should -Not -Match "d='compact'"
     }
 
     It 'anti-FOUC JS contains every theme from the DefaultTheme ValidateSet' {


### PR DESCRIPTION
## Summary

Combines Sprint 3 data enrichment with the `#646` ReportDensity parameter.

## Related Issues

Closes Mods#20, Closes Mods#22, Closes #646
Mods#21 (tenantAgeYears) — PS side already done; this wires the UI
Mods#23 (Secure Score split) — already wired in a prior commit, closing separately

## Changes

**Sprint 3 — data enrichment:**
- `Build-ReportData.ps1`: add `intentRationale` field (from `ImpactRationale` / registry `impactRating.rationale`)
- `report-app.jsx`: tenantAgeYears in sidebar tenant card; DisabledUsers / NeverSignedIn / StaleMember counts (amber, conditional); "By Design" badge in status cell; `intent-callout` panel in finding detail
- `report-shell.css`: `.badge-intent`, `.intent-callout` styles

**#646 — ReportDensity param:**
- `Get-ReportTemplate.ps1`: `$DefaultDensity` param wired into anti-FOUC and `<html data-density>`
- `Export-AssessmentReport.ps1`: `$ReportDensity` param forwarded to `Get-ReportTemplate`
- `Invoke-M365Assessment.ps1`: `-ReportDensity` param exposed to end users
- `tests/Common/Get-ReportTemplate.Tests.ps1`: 3 new density tests

## Test Plan

- [x] PSScriptAnalyzer clean on all changed `.ps1` files
- [x] Babel build succeeds
- [x] All 424 tests pass locally (393 smoke + 31 Get-ReportTemplate)
- [x] No breaking changes — ReportDensity defaults to Compact; all new JSX fields render conditionally

🤖 Generated with [Claude Code](https://claude.com/claude-code)