### PR TITLE
feat(report): expose -ReportDensity param — Compact / Comfort (#646)

### DIFF
--- a/src/M365-Assess/Common/Export-AssessmentReport.ps1
+++ b/src/M365-Assess/Common/Export-AssessmentReport.ps1
@@ -55,6 +55,10 @@ param(
     [string]$ReportTheme = 'Neon',
 
     [Parameter()]
+    [ValidateSet('Compact', 'Comfort')]
+    [string]$ReportDensity = 'Compact',
+
+    [Parameter()]
     [switch]$WhiteLabel,
 
     [Parameter()]
@@ -180,10 +184,11 @@ $themeDefaults = @{
 }
 $htmlTheme = $themeDefaults[$ReportTheme]
 $html = Get-ReportTemplate `
-    -ReportDataJson $reportJson `
-    -ReportTitle    $reportTitle `
-    -DefaultTheme   $htmlTheme.Theme `
-    -DefaultMode    $htmlTheme.Mode
+    -ReportDataJson  $reportJson `
+    -ReportTitle     $reportTitle `
+    -DefaultTheme    $htmlTheme.Theme `
+    -DefaultMode     $htmlTheme.Mode `
+    -DefaultDensity  ($ReportDensity.ToLower())
 
 Set-Content -Path $OutputPath -Value $html -Encoding UTF8
 Write-Output "HTML report generated: $OutputPath"

--- a/src/M365-Assess/Common/Get-ReportTemplate.ps1
+++ b/src/M365-Assess/Common/Get-ReportTemplate.ps1
@@ -30,7 +30,11 @@ function Get-ReportTemplate {
 
         [Parameter()]
         [ValidateSet('dark', 'light')]
-        [string]$DefaultMode = 'dark'
+        [string]$DefaultMode = 'dark',
+
+        [Parameter()]
+        [ValidateSet('compact', 'comfort')]
+        [string]$DefaultDensity = 'compact'
     )
 
     $assetsDir = Join-Path -Path $PSScriptRoot -ChildPath '../assets'
@@ -56,7 +60,7 @@ function Get-ReportTemplate {
                 "var d=localStorage.getItem('m365-density');" +
                 "if(v.indexOf(t)<0)t='$DefaultTheme';" +
                 "if(m!=='dark'&&m!=='light')m='$DefaultMode';" +
-                "if(d!=='compact'&&d!=='comfort')d='compact';" +
+                "if(d!=='compact'&&d!=='comfort')d='$DefaultDensity';" +
                 "e.dataset.theme=t;e.dataset.mode=m;e.dataset.density=d;" +
                 "}catch(err){}})();"
 
@@ -64,7 +68,7 @@ function Get-ReportTemplate {
     $sb = [System.Text.StringBuilder]::new(2097152) # 2 MB initial capacity
 
     $null = $sb.AppendLine('<!DOCTYPE html>')
-    $null = $sb.AppendLine("<html data-theme=`"$DefaultTheme`" data-mode=`"$DefaultMode`" data-density=`"compact`">")
+    $null = $sb.AppendLine("<html data-theme=`"$DefaultTheme`" data-mode=`"$DefaultMode`" data-density=`"$DefaultDensity`">")
     $null = $sb.AppendLine('<head>')
     $null = $sb.AppendLine('<meta charset="UTF-8">')
     $null = $sb.AppendLine('<meta name="viewport" content="width=device-width,initial-scale=1.0">')

--- a/src/M365-Assess/Invoke-M365Assessment.ps1
+++ b/src/M365-Assess/Invoke-M365Assessment.ps1
@@ -213,6 +213,10 @@ param(
     [string]$ReportTheme = 'Neon',
 
     [Parameter()]
+    [ValidateSet('Compact', 'Comfort')]
+    [string]$ReportDensity = 'Compact',
+
+    [Parameter()]
     [switch]$WhiteLabel,
 
     [Parameter()]
@@ -1278,7 +1282,8 @@ if (Test-Path -Path $reportScriptPath) {
         }
         if ($script:domainPrefix) { $reportParams['TenantName'] = $script:domainPrefix }
         elseif ($TenantId)        { $reportParams['TenantName'] = $TenantId }
-        $reportParams['ReportTheme'] = $ReportTheme
+        $reportParams['ReportTheme']   = $ReportTheme
+        $reportParams['ReportDensity'] = $ReportDensity
         if ($WhiteLabel)        { $reportParams['WhiteLabel']        = $true }
         if ($CompactReport)     { $reportParams['CompactReport']     = $true }
         if ($OpenReport)        { $reportParams['OpenReport']        = $true }

--- a/tests/Common/Get-ReportTemplate.Tests.ps1
+++ b/tests/Common/Get-ReportTemplate.Tests.ps1
@@ -81,6 +81,11 @@ Describe 'Get-ReportTemplate — function contract' {
         # Must NOT contain the old hardcoded array literal
         $script:content | Should -Not -Match "v=\['neon','console','saas','high-contrast'\]"
     }
+
+    It 'declares DefaultDensity parameter with compact/comfort ValidateSet' {
+        $script:content | Should -Match '\[ValidateSet\(''compact'',\s*''comfort''\)\]'
+        $script:content | Should -Match '\[string\]\$DefaultDensity'
+    }
 }
 
 Describe 'Get-ReportTemplate — output validation' {
@@ -151,6 +156,17 @@ Describe 'Get-ReportTemplate — output validation' {
     It 'uses default title when ReportTitle omitted' {
         $result = Get-ReportTemplate -ReportDataJson 'window.REPORT_DATA = {};'
         $result | Should -Match 'M365 Security Assessment'
+    }
+
+    It 'default output uses data-density compact' {
+        $result = Get-ReportTemplate -ReportDataJson 'window.REPORT_DATA = {};'
+        $result | Should -Match 'data-density="compact"'
+    }
+
+    It 'output uses comfort density when DefaultDensity is comfort' {
+        $result = Get-ReportTemplate -ReportDataJson 'window.REPORT_DATA = {};' -DefaultDensity comfort
+        $result | Should -Match 'data-density="comfort"'
+        $result | Should -Not -Match "d='compact'"
     }
 
     It 'anti-FOUC JS contains every theme from the DefaultTheme ValidateSet' {


### PR DESCRIPTION
## Summary

Threads a `-ReportDensity` parameter from `Invoke-M365Assessment` through `Export-AssessmentReport` to `Get-ReportTemplate`, baking the chosen density into the anti-FOUC inline script and the opening `<html data-density>` attribute. Default is `Compact` — no behaviour change for existing callers.

## Related Issues

Closes #646

## Changes

- `Get-ReportTemplate.ps1`: new `[ValidateSet('compact','comfort')] $DefaultDensity = 'compact'` param; wired into anti-FOUC fallback and `<html>` tag
- `Export-AssessmentReport.ps1`: new `[ValidateSet('Compact','Comfort')] $ReportDensity = 'Compact'` param; passed to `Get-ReportTemplate`
- `Invoke-M365Assessment.ps1`: same param exposed to end users; forwarded to report params
- `tests/Common/Get-ReportTemplate.Tests.ps1`: 3 new tests (param declared, compact default, comfort wired)

Cherry-picked from `feat/v2.3.0` (commit 82e2ae3) onto current main.

## Test Plan

- [x] PSScriptAnalyzer clean
- [x] All 424 tests pass (393 smoke + 31 Get-ReportTemplate)
- [x] No breaking changes — default is Compact, same as current behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)