### PR TITLE
fix: correct CSV filenames for mailbox and SharePoint config

### DIFF
--- a/src/M365-Assess/Common/Build-SectionHtml.ps1
+++ b/src/M365-Assess/Common/Build-SectionHtml.ps1
@@ -44,9 +44,9 @@ $sectionData = @{
     'licenses'    = & $loadCsv '08-License-Summary.csv'
     'score'            = & $loadCsv '16-Secure-Score.csv'
     'dns'              = @($dnsCsvRaw | Where-Object { $_.Domain -notmatch '\.onmicrosoft\.com$' })
-    'mailbox-summary'  = & $loadCsv 'Get-MailboxSummary.csv'
+    'mailbox-summary'  = & $loadCsv '09-Mailbox-Summary.csv'
     'mailflow'         = & $loadCsv 'Get-MailFlowReport.csv'
-    'sharepoint-config'= & $loadCsv 'Get-SharePointSecurityConfig.csv'
+    'sharepoint-config'= & $loadCsv '20b-SharePoint-Security-Config.csv'
     'ad-hybrid'        = & $loadCsv '23-Hybrid-Sync.csv'
     'ad-security'      = & $loadCsv '26-AD-Security.csv'
 }


### PR DESCRIPTION
## Summary
- `Get-MailboxSummary.csv` → `09-Mailbox-Summary.csv`
- `Get-SharePointSecurityConfig.csv` → `20b-SharePoint-Security-Config.csv`

Collector outputs use the numbered prefix scheme defined in `AssessmentMaps.ps1`, but `Build-SectionHtml.ps1` was still using the old verb-noun names. This caused `D.mailboxSummary` and `D.sharepointConfig` to always be null in `REPORT_DATA`, preventing MailboxSummaryPanel and SharePointSummaryPanel from rendering.

## Test plan
- [ ] Run a full assessment and confirm `09-Mailbox-Summary.csv` and `20b-SharePoint-Security-Config.csv` are picked up
- [ ] Open the generated HTML report — MailboxSummaryPanel and SharePointSummaryPanel should render in Section 04 Domain Breakdown
- [ ] `pwsh -NoProfile -Command "Invoke-Pester -Path './tests' -Output Detailed"`

Resolves Galvnyz/M365-Assess-Mods#32 / Galvnyz/M365-Assess#657

🤖 Generated with [Claude Code](https://claude.com/claude-code)