### PR TITLE
fix: PowerBI skip on non-Windows + PHS false-disabled detection

### DIFF
--- a/src/M365-Assess/ActiveDirectory/Get-HybridSyncReport.ps1
+++ b/src/M365-Assess/ActiveDirectory/Get-HybridSyncReport.ps1
@@ -117,8 +117,12 @@ $report = foreach ($org in $organizations) {
         'Cloud-only (no hybrid sync)'
     }
 
-    # Determine if password hash sync is enabled based on last sync timestamp
-    $passwordHashSyncEnabled = if ($lastPasswordSyncTime) { $true } else { $false }
+    # Determine PHS state: True = confirmed, Unknown = sync active but no timestamp yet
+    # (onPremisesLastPasswordSyncDateTime can be null when PHS is enabled but no password
+    # changes have occurred, or when Cloud Sync is used instead of Entra Connect)
+    $passwordHashSyncEnabled = if ($lastPasswordSyncTime) { $true }
+                               elseif ($onPremSyncEnabled -eq $true) { 'Unknown' }
+                               else { $false }
 
     # Determine if directory sync is configured (distinct from enabled)
     $dirSyncConfigured = if ($null -ne $onPremSyncEnabled) { $onPremSyncEnabled } else { $false }

--- a/src/M365-Assess/Common/Build-ReportData.ps1
+++ b/src/M365-Assess/Common/Build-ReportData.ps1
@@ -245,7 +245,7 @@ function Build-ReportDataJson {
             syncEnabled      = [bool]($row.OnPremisesSyncEnabled -eq 'True')
             lastSyncTime     = if ($row.LastDirSyncTime) { [string]$row.LastDirSyncTime } else { $null }
             syncType         = if ($row.SyncType) { [string]$row.SyncType } else { $null }
-            pwHashSync       = [bool]($row.PasswordHashSyncEnabled -eq 'True')
+            pwHashSync       = if ($row.PasswordHashSyncEnabled -eq 'True') { $true } elseif ($row.PasswordHashSyncEnabled -eq 'Unknown') { $null } else { $false }
             securityFindings = $adSecurityRows.Count
             highRiskFindings = $highRiskCount
             syncErrorCount   = 0
@@ -266,7 +266,7 @@ function Build-ReportDataJson {
                 syncEnabled      = $true
                 lastSyncTime     = if ($lastSync) { [string]$lastSync } else { $null }
                 syncType         = $null
-                pwHashSync       = ($null -ne $phsDate -and $phsDate -ne '')
+                pwHashSync       = if ($null -ne $phsDate -and $phsDate -ne '') { $true } else { $null }
                 securityFindings = 0
                 highRiskFindings = 0
                 syncErrorCount   = $errCount

--- a/src/M365-Assess/Entra/EntraPasswordAuthChecks.ps1
+++ b/src/M365-Assess/Entra/EntraPasswordAuthChecks.ps1
@@ -618,14 +618,17 @@ try {
                 Add-Setting @settingParams
             }
             else {
+                # No PHS timestamp found — directory sync is active but password hashes may not be
+                # syncing. This is Warning (not Fail) because: Cloud Sync may not populate this field,
+                # or PHS was recently enabled and no passwords have changed since.
                 $settingParams = @{
                     Category         = 'Hybrid Identity'
                     Setting          = 'Password Hash Sync'
-                    CurrentValue     = 'Directory sync enabled but no password sync detected'
+                    CurrentValue     = 'Directory sync active — no PHS timestamp found; verify in Azure AD Connect'
                     RecommendedValue = 'Enabled'
-                    Status           = 'Fail'
+                    Status           = 'Warning'
                     CheckId          = 'ENTRA-HYBRID-001'
-                    Remediation      = 'Enable Password Hash Sync in Azure AD Connect > Optional Features. This provides leaked credential detection and backup authentication.'
+                    Remediation      = 'Verify Password Hash Sync is enabled in Azure AD Connect > Optional Features (or Entra Cloud Sync settings). PHS provides leaked credential detection and backup authentication.'
                 }
                 Add-Setting @settingParams
             }

--- a/src/M365-Assess/Invoke-M365Assessment.ps1
+++ b/src/M365-Assess/Invoke-M365Assessment.ps1
@@ -907,6 +907,25 @@ foreach ($sectionName in $Section) {
             # ships Microsoft.Identity.Client 4.64 while Microsoft.Graph loads 4.78;
             # a child process gets its own AppDomain and avoids the clash.
             if ($collector.ContainsKey('IsChildProcess') -and $collector.IsChildProcess) {
+                # MicrosoftPowerBIMgmt device code auth hangs on Linux/macOS.
+                # Service principal auth works cross-platform; interactive auth requires Windows.
+                $hasSp = $ClientId -and ($CertificateThumbprint -or $ClientSecret)
+                if (-not $IsWindows -and -not $hasSp) {
+                    $skipMsg = 'Power BI collector skipped: MicrosoftPowerBIMgmt interactive auth is not supported on non-Windows platforms. Re-run on Windows, or supply -ClientId with -ClientSecret / -CertificateThumbprint to use service principal auth.'
+                    Write-Warning $skipMsg
+                    Write-AssessmentLog -Level WARN -Message $skipMsg -Section $sectionName -Collector $collector.Label
+                    $summaryResults.Add([PSCustomObject]@{
+                        Section   = $sectionName
+                        Collector = $collector.Label
+                        FileName  = "$($collector.Name).csv"
+                        Status    = 'Skipped'
+                        Items     = 0
+                        Duration  = '00:00'
+                        Error     = 'Platform not supported for interactive auth'
+                    })
+                    Show-CollectorResult -Label $collector.Label -Status 'Skipped' -Items 0 -DurationSeconds 0 -ErrorMessage 'Platform not supported for interactive auth'
+                    continue
+                }
                 Write-Host "    Connecting to Power BI..." -ForegroundColor Yellow
                 Write-Host "    Running in isolated process (assembly compatibility)..." -ForegroundColor Gray
                 Write-AssessmentLog -Level INFO -Message "Running $($collector.Label) in child process to avoid MSAL assembly conflict" -Section $sectionName -Collector $collector.Label

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -1307,8 +1307,9 @@ function AdHybridPanel() {
   const fail = adFindings.filter(f => f.status === 'Fail').length;
   const syncOk = ad.syncEnabled;
   const phsOk = ad.pwHashSync;
+  const phsUnknown = phsOk === null || phsOk === undefined;
   const syncColor = syncOk ? 'var(--success-text)' : 'var(--danger-text)';
-  const phsColor = phsOk ? 'var(--success-text)' : 'var(--danger-text)';
+  const phsColor = phsUnknown ? 'var(--warn-text)' : phsOk ? 'var(--success-text)' : 'var(--danger-text)';
   const fmtDate = d => {
     if (!d) return 'Unknown';
     try {
@@ -1366,7 +1367,7 @@ function AdHybridPanel() {
       lineHeight: 1.3
     }
   }, fmtDate(ad.lastSyncTime))), /*#__PURE__*/React.createElement("div", {
-    className: 'spo-stat-card' + (!phsOk ? ' spo-stat-bad' : '')
+    className: 'spo-stat-card' + (phsOk === false ? ' spo-stat-bad' : '')
   }, /*#__PURE__*/React.createElement("div", {
     className: "kpi-label"
   }, "Password hash sync"), /*#__PURE__*/React.createElement("div", {
@@ -1376,12 +1377,17 @@ function AdHybridPanel() {
       color: phsColor,
       marginTop: 6
     }
-  }, phsOk ? 'Enabled' : 'Disabled'), !phsOk && /*#__PURE__*/React.createElement("div", {
+  }, phsOk ? 'Enabled' : phsUnknown ? 'Verify' : 'Disabled'), phsOk === false && /*#__PURE__*/React.createElement("div", {
     className: "kpi-hint",
     style: {
       color: 'var(--danger-text)'
     }
-  }, "Users cannot reset passwords from Entra")), ad.syncErrorCount > 0 && /*#__PURE__*/React.createElement("div", {
+  }, "Leaked credential detection and fallback auth may be impacted"), phsUnknown && /*#__PURE__*/React.createElement("div", {
+    className: "kpi-hint",
+    style: {
+      color: 'var(--warn-text)'
+    }
+  }, "No PHS timestamp \u2014 verify in Azure AD Connect")), ad.syncErrorCount > 0 && /*#__PURE__*/React.createElement("div", {
     className: "spo-stat-card spo-stat-bad"
   }, /*#__PURE__*/React.createElement("div", {
     className: "kpi-label"

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -683,10 +683,11 @@ function AdHybridPanel() {
   const adFindings = FINDINGS.filter(f => f.domain === 'Active Directory');
   const pass = adFindings.filter(f => f.status==='Pass').length;
   const fail = adFindings.filter(f => f.status==='Fail').length;
-  const syncOk    = ad.syncEnabled;
-  const phsOk     = ad.pwHashSync;
-  const syncColor = syncOk ? 'var(--success-text)' : 'var(--danger-text)';
-  const phsColor  = phsOk  ? 'var(--success-text)' : 'var(--danger-text)';
+  const syncOk      = ad.syncEnabled;
+  const phsOk       = ad.pwHashSync;
+  const phsUnknown  = phsOk === null || phsOk === undefined;
+  const syncColor   = syncOk    ? 'var(--success-text)' : 'var(--danger-text)';
+  const phsColor    = phsUnknown ? 'var(--warn-text)'   : phsOk ? 'var(--success-text)' : 'var(--danger-text)';
   const fmtDate   = d => {
     if (!d) return 'Unknown';
     try { return new Date(d).toLocaleDateString(undefined, { year:'numeric', month:'short', day:'numeric' }); }
@@ -711,10 +712,11 @@ function AdHybridPanel() {
           <div className="kpi-label">Last sync</div>
           <div style={{fontSize:12, fontWeight:600, color:'var(--text-soft)', marginTop:6, lineHeight:1.3}}>{fmtDate(ad.lastSyncTime)}</div>
         </div>
-        <div className={'spo-stat-card' + (!phsOk ? ' spo-stat-bad' : '')}>
+        <div className={'spo-stat-card' + (phsOk === false ? ' spo-stat-bad' : '')}>
           <div className="kpi-label">Password hash sync</div>
-          <div style={{fontSize:13, fontWeight:700, color: phsColor, marginTop:6}}>{phsOk ? 'Enabled' : 'Disabled'}</div>
-          {!phsOk && <div className="kpi-hint" style={{color:'var(--danger-text)'}}>Users cannot reset passwords from Entra</div>}
+          <div style={{fontSize:13, fontWeight:700, color: phsColor, marginTop:6}}>{phsOk ? 'Enabled' : phsUnknown ? 'Verify' : 'Disabled'}</div>
+          {phsOk === false && <div className="kpi-hint" style={{color:'var(--danger-text)'}}>Leaked credential detection and fallback auth may be impacted</div>}
+          {phsUnknown && <div className="kpi-hint" style={{color:'var(--warn-text)'}}>No PHS timestamp — verify in Azure AD Connect</div>}
         </div>
         {ad.syncErrorCount > 0 && (
           <div className="spo-stat-card spo-stat-bad">

--- a/tests/Common/Build-ReportData.Tests.ps1
+++ b/tests/Common/Build-ReportData.Tests.ps1
@@ -602,7 +602,9 @@ Describe 'Build-ReportData' {
             $d.adHybrid | Should -BeNullOrEmpty
         }
 
-        It 'should detect PHS disabled when LastPasswordSyncDateTime is absent' {
+        It 'should return null pwHashSync when sync is enabled but LastPasswordSyncDateTime is absent' {
+            # Cloud Sync or recently-enabled PHS may not populate this timestamp;
+            # null signals the UI to show amber "Verify" rather than red "Disabled"
             $tenant = [PSCustomObject]@{
                 OrgDisplayName                     = 'Contoso'
                 TenantId                           = 'test-tenant-id'
@@ -612,7 +614,7 @@ Describe 'Build-ReportData' {
                 OnPremisesProvisioningErrorCount   = '0'
             }
             $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -SectionData @{ 'tenant' = @($tenant) })
-            $d.adHybrid.pwHashSync | Should -Be $false
+            $d.adHybrid.pwHashSync | Should -BeNullOrEmpty
         }
     }
 }


### PR DESCRIPTION
## Summary

- **PowerBI hang on Linux/macOS** — `MicrosoftPowerBIMgmt` interactive/device-code auth hangs on non-Windows platforms. The collector now exits immediately with a clear `Warning` on Linux/macOS when no service principal is configured, rather than spawning a child process that hangs indefinitely. Service principal auth (`-ClientId` + `-ClientSecret` / `-CertificateThumbprint`) continues to work cross-platform.
- **Password Hash Sync falsely reported as "Disabled"** — `onPremisesLastPasswordSyncDateTime` can be `null` even when PHS is configured (Cloud Sync users, no password changes since PHS was enabled). Changed from binary True/False to tri-state: confirmed (`True`), unverifiable (`Unknown`/amber), confirmed off (`False`). The Entra check is now `Warning` instead of `Fail` when the timestamp is absent on a hybrid tenant.
- **Incorrect panel hint** — "Users cannot reset passwords from Entra" is factually wrong (PHS ≠ SSPR). Changed to "Leaked credential detection and fallback auth may be impacted" for the confirmed-off state, and "No PHS timestamp — verify in Azure AD Connect" for the unverifiable state.

## Files changed

| File | Change |
|------|--------|
| `Invoke-M365Assessment.ps1` | Skip PowerBI on non-Windows + no SP; log warning + summaryResults entry |
| `ActiveDirectory/Get-HybridSyncReport.ps1` | Tri-state `PasswordHashSyncEnabled`: `True` / `Unknown` / `False` |
| `Common/Build-ReportData.ps1` | Map `Unknown` PHS → `null` for React panel |
| `Entra/EntraPasswordAuthChecks.ps1` | `Warning` (not `Fail`) when PHS timestamp absent on hybrid tenant |
| `assets/report-app.jsx` + `report-app.js` | Tri-state panel display; corrected hint text |

## Test plan

- [ ] On Linux/macOS without `-ClientId`: run assessment with PowerBI section — verify `○ Power BI Security Config — Skipped` appears and assessment continues
- [ ] On Linux/macOS with service principal: verify PowerBI child process still runs normally
- [ ] On Windows: verify no behaviour change for PowerBI
- [ ] Hybrid tenant with PHS confirmed via timestamp: panel shows green "Enabled"
- [ ] Hybrid tenant with sync enabled but no timestamp (e.g. Cloud Sync): panel shows amber "Verify" with "No PHS timestamp — verify in Azure AD Connect"
- [ ] Cloud-only tenant: panel shows gray "Disabled" (syncEnabled = false path, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)