### PR TITLE
chore: update Azure AD Connect references to current Microsoft Entra branding

### DIFF
--- a/src/M365-Assess/Entra/EntraPasswordAuthChecks.ps1
+++ b/src/M365-Assess/Entra/EntraPasswordAuthChecks.ps1
@@ -582,7 +582,7 @@ try {
             RecommendedValue = 'Enabled (if hybrid)'
             Status           = 'Review'
             CheckId          = 'ENTRA-HYBRID-001'
-            Remediation      = 'Verify Password Hash Sync status in Azure AD Connect. Entra admin center > Identity > Hybrid management > Azure AD Connect.'
+            Remediation      = 'Verify Password Hash Sync status in Microsoft Entra Connect. Entra admin center > Identity > Hybrid management > Microsoft Entra Connect.'
         }
         Add-Setting @settingParams
     }
@@ -598,7 +598,7 @@ try {
                 RecommendedValue = 'Enabled (if hybrid)'
                 Status           = 'Info'
                 CheckId          = 'ENTRA-HYBRID-001'
-                Remediation      = 'Not applicable for cloud-only tenants. If you configure hybrid identity in the future, enable Password Hash Sync in Azure AD Connect.'
+                Remediation      = 'Not applicable for cloud-only tenants. If you configure hybrid identity in the future, enable Password Hash Sync in Microsoft Entra Connect or Microsoft Entra Cloud Sync.'
             }
             Add-Setting @settingParams
         }
@@ -613,7 +613,7 @@ try {
                     RecommendedValue = 'Enabled'
                     Status           = 'Pass'
                     CheckId          = 'ENTRA-HYBRID-001'
-                    Remediation      = 'Password Hash Sync is enabled. Verify it remains active in Azure AD Connect configuration.'
+                    Remediation      = 'Password Hash Sync is enabled. Verify it remains active in Microsoft Entra Connect or Microsoft Entra Cloud Sync.'
                 }
                 Add-Setting @settingParams
             }
@@ -624,11 +624,11 @@ try {
                 $settingParams = @{
                     Category         = 'Hybrid Identity'
                     Setting          = 'Password Hash Sync'
-                    CurrentValue     = 'Directory sync active — no PHS timestamp found; verify in Azure AD Connect'
+                    CurrentValue     = 'Directory sync active - no PHS timestamp found; verify in Microsoft Entra Connect or Entra Cloud Sync'
                     RecommendedValue = 'Enabled'
                     Status           = 'Warning'
                     CheckId          = 'ENTRA-HYBRID-001'
-                    Remediation      = 'Verify Password Hash Sync is enabled in Azure AD Connect > Optional Features (or Entra Cloud Sync settings). PHS provides leaked credential detection and backup authentication.'
+                    Remediation      = 'Verify Password Hash Sync is enabled in Microsoft Entra Connect (Optional Features) or Microsoft Entra Cloud Sync. PHS provides leaked credential detection and backup authentication.'
                 }
                 Add-Setting @settingParams
             }

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -1387,7 +1387,7 @@ function AdHybridPanel() {
     style: {
       color: 'var(--warn-text)'
     }
-  }, "No PHS timestamp \u2014 verify in Azure AD Connect")), ad.syncErrorCount > 0 && /*#__PURE__*/React.createElement("div", {
+  }, "No PHS timestamp - verify in Microsoft Entra Connect or Entra Cloud Sync")), ad.syncErrorCount > 0 && /*#__PURE__*/React.createElement("div", {
     className: "spo-stat-card spo-stat-bad"
   }, /*#__PURE__*/React.createElement("div", {
     className: "kpi-label"

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -716,7 +716,7 @@ function AdHybridPanel() {
           <div className="kpi-label">Password hash sync</div>
           <div style={{fontSize:13, fontWeight:700, color: phsColor, marginTop:6}}>{phsOk ? 'Enabled' : phsUnknown ? 'Verify' : 'Disabled'}</div>
           {phsOk === false && <div className="kpi-hint" style={{color:'var(--danger-text)'}}>Leaked credential detection and fallback auth may be impacted</div>}
-          {phsUnknown && <div className="kpi-hint" style={{color:'var(--warn-text)'}}>No PHS timestamp — verify in Azure AD Connect</div>}
+          {phsUnknown && <div className="kpi-hint" style={{color:'var(--warn-text)'}}>No PHS timestamp - verify in Microsoft Entra Connect or Entra Cloud Sync</div>}
         </div>
         {ad.syncErrorCount > 0 && (
           <div className="spo-stat-card spo-stat-bad">


### PR DESCRIPTION
## Summary

- Replace stale "Azure AD Connect" with "Microsoft Entra Connect" and "Microsoft Entra Cloud Sync" across all remediation text, registry.json, and the report panel hint
- No behaviour changes; text-only update

## Files changed

| File | Change |
|------|--------|
| `Entra/EntraPasswordAuthChecks.ps1` | 5 remediation/currentValue strings updated |
| `controls/registry.json` | ENTRA-HYBRID-001 remediation text updated |
| `assets/report-app.jsx` + `report-app.js` | Panel hint updated |

🤖 Generated with [Claude Code](https://claude.com/claude-code)