### PR TITLE
chore(release): bump version to v2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to M365 Assess are documented here. This project uses [Conve
 
 ## [Unreleased]
 
+## [2.3.1] - 2026-04-21
+
+### Fixed
+- Power BI collector now skips gracefully on non-Windows platforms (Linux/macOS) when no service principal is configured; emits an actionable warning instead of hanging on device-code auth (#664)
+- Password Hash Sync status corrected to amber "Verify" (instead of red "Disabled") when `OnPremisesLastPasswordSyncDateTime` is absent on an active hybrid tenant — this is normal for Entra Cloud Sync or PHS enabled before any password changes (#665)
+- Secure Score panel no longer shows 0 earned points when the tenant has a non-zero score; mapping from `currentScore` now applied correctly (#663)
+- Assessment CSV output files now use the correct base filename (was incorrectly including the full script path in some environments) (#666)
+
+### Changed
+- "Microsoft Entra Connect" replaces "Azure AD Connect" in all remediation strings and collector output; "Microsoft Entra Cloud Sync" replaces "Azure AD Connect Cloud Sync" (#667, #662)
+
+## [2.3.0] - 2026-04-21
+
+### Added
+- Filter state persistence — active section/severity/status/framework filters saved to `localStorage` (scoped per tenant) and restored on report reload (#634)
+- `-ReportDensity` parameter (`Compact` | `Comfort`) added to `Export-AssessmentReport` and threaded through to `Get-ReportTemplate`; default `Compact` (no behaviour change) (#646)
+- Vibe theme (`-ReportTheme Light`) — repurposed from the prior flat-light palette to a warm rose-gold dark aesthetic; Neon theme hue and contrast boosted (#649, #650)
+- Anti-FOUC theme allowlist now derived from the PowerShell `ValidateSet` via reflection — a single source of truth; adding a new theme to the `ValidateSet` automatically protects it from flash (#645)
+- N-of-M findings counter displayed in the All Findings table header (#638)
+- Search match text highlighted in yellow in the findings results list (#636)
+- `learnMore` URLs surfaced in the finding detail panel with a direct link (#637)
+- Evidence block (collapsible `<details>`) added to finding detail panel for findings that carry structured evidence data (#640)
+- CMMC L1 / L2 / L3 compliance scoring filters added to the compliance overview (#641)
+
+### Fixed
+- Print / PDF output quality improvements — dedicated print CSS media query, page-break rules, and hidden interactive controls (#635)
+
 ## [2.2.0] - 2026-04-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [![Coverage](https://img.shields.io/badge/coverage-check%20CI-informational)](https://github.com/Galvnyz/M365-Assess/actions/workflows/ci.yml)
 [![PowerShell 7.x](https://img.shields.io/badge/PowerShell-7.x-blue?logo=powershell&logoColor=white)](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows)
 [![Read-Only](https://img.shields.io/badge/Operations-Read--Only-brightgreen)](.)
-[![Version](https://img.shields.io/badge/version-2.2.0-blue)](.)
+[![Version](https://img.shields.io/badge/version-2.3.1-blue)](.)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 </div>

--- a/src/M365-Assess/M365-Assess.psd1
+++ b/src/M365-Assess/M365-Assess.psd1
@@ -3,7 +3,7 @@
     # Generated: 2026-03-08
 
     RootModule        = 'M365-Assess.psm1'
-    ModuleVersion     = '2.2.0'
+    ModuleVersion     = '2.3.1'
     GUID              = 'f7e3b2a1-4c5d-6e8f-9a0b-1c2d3e4f5a6b'
     Author            = 'Galvnyz'
     CompanyName       = 'Community'
@@ -232,7 +232,7 @@
             IconUri      = 'https://raw.githubusercontent.com/Galvnyz/M365-Assess/main/src/M365-Assess/assets/m365-assess-logo.png'
             LicenseUri   = 'https://github.com/Galvnyz/M365-Assess/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/Galvnyz/M365-Assess'
-            ReleaseNotes = 'v2.2.0 - Roadmap CSV export; Evidence field Phase 1 (5 collectors); AD/Hybrid dashboard panel; ISO 27001+27002 label clarification; AI disclosure; CheckID v2.17.0 sync'
+            ReleaseNotes = 'v2.3.1 - Filter state persistence; print/PDF CSS; Vibe theme + Neon boost; -ReportDensity param; anti-FOUC ValidateSet reflection; PowerBI Linux skip; PHS false-disabled fix; Secure Score 0pts fix; Entra Connect terminology'
         }
     }
 }


### PR DESCRIPTION
## Summary

- Bumps `ModuleVersion` to `2.3.1` in the manifest
- Updates `ReleaseNotes` in manifest and version badge in README
- Adds `[2.3.0]` and `[2.3.1]` sections to CHANGELOG

## v2.3.0 — UX & Polish
- Filter state persistence (localStorage, tenant-scoped) (#634)
- Print / PDF CSS quality improvements (#635)
- Search match text highlighting (#636)
- `learnMore` URLs in finding detail panel (#637)
- N-of-M findings counter in All Findings table (#638)
- Evidence block in finding detail panel (#640)
- CMMC L1/L2/L3 compliance scoring filters (#641)
- `-ReportDensity` parameter (`Compact` | `Comfort`) (#646)
- Anti-FOUC allowlist derived from `ValidateSet` reflection (#645)
- Vibe theme + Neon hue/contrast boost (#649, #650)

## v2.3.1 — Bug Fixes
- PowerBI collector graceful skip on Linux/macOS without service principal (#664)
- PHS false-disabled: amber "Verify" tri-state when timestamp absent on hybrid tenant (#665)
- Secure Score 0-earned-points panel mapping fix (#663)
- Assessment CSV output filename fix (#666)
- "Azure AD Connect" → "Microsoft Entra Connect / Cloud Sync" terminology (#667, #662)

## Test plan
- [ ] CI passes (Pester matrix PS 7.4/7.6 + coverage gate)
- [ ] `ModuleVersion` reads `2.3.1` via `Import-PowerShellDataFile`
- [ ] README version badge shows 2.3.1
- [ ] CHANGELOG has `[2.3.0]` and `[2.3.1]` sections with correct dates

🤖 Generated with [Claude Code](https://claude.com/claude-code)