### PR TITLE
feat(report): v2.4.0 UX — section reorder, expandable domain posture, nav persistence, appendix enrichment

### DIFF
--- a/docs/superpowers/plans/2026-04-21-v2.4.0-report-ux.md
+++ b/docs/superpowers/plans/2026-04-21-v2.4.0-report-ux.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Four targeted report UI improvements — reorder sections, make Domain Posture expandable with subheadings, persist nav state, and enrich the tenant appendix.
+**Goal:** Four targeted report UI improvements — reorder sections, make Domain Posture expandable with subheadings, persist nav state within a session, and enrich the tenant appendix.
 
-**Architecture:** All changes are in the React report engine (`report-app.jsx` → mirrored to `report-app.js`) and CSS (`report-shell.css`). No PowerShell or data-layer changes required — all data is already in `REPORT_DATA`. The `LS()` helper (line 14 of report-app.jsx) namespaces localStorage keys per tenant.
+**Architecture:** All changes are in the React report engine (`report-app.jsx` → mirrored to `report-app.js`) and CSS (`report-shell.css`). No PowerShell or data-layer changes required — all data is already in `REPORT_DATA`. Nav/section expansion state uses plain React `useState` (no storage) because the Sidebar and DomainRollup components never unmount — state survives navigation within a session naturally. localStorage is intentionally avoided for new features: the report is a transferable file and storage is origin-tied, so moving or sharing the file would silently discard any persisted state.
 
 **Tech Stack:** React 18 UMD (no build step), inline CSS in `report-shell.css`, PowerShell wraps it all in `Get-ReportTemplate.ps1`
 
@@ -127,16 +127,11 @@ Replace the entire `DomainRollup` function (lines 759-804) with:
 ```jsx
 // ======================== Domain rollup ========================
 function DomainRollup({ onJump }) {
-  const [open, setOpen] = useState(() => {
-    try { return localStorage.getItem(LS('m365-domain-posture-open')) !== 'false'; }
-    catch { return true; }
-  });
+  const [open, setOpen] = useState(true);  // default expanded; in-memory only (no storage)
 
   function toggleOpen(e) {
     e.stopPropagation();
-    const next = !open;
-    setOpen(next);
-    try { localStorage.setItem(LS('m365-domain-posture-open'), String(next)); } catch {}
+    setOpen(o => !o);
   }
 
   return (
@@ -224,8 +219,9 @@ Apply the identical DomainRollup replacement to `report-app.js`. The Unicode esc
 Confirm in a browser:
 - Section header shows ▾ when expanded, ▸ when collapsed
 - Clicking header toggles collapse/expand
-- State persists after page refresh (localStorage key `m365-domain-posture-open-<tenantId>`)
+- Navigating to Findings and back to Domain Posture — chevron state is preserved (in-memory)
 - Collapse hides all domain cards and sub-panels
+- Refreshing the page resets to expanded (correct — fresh session default)
 
 - [ ] **Step 5: Commit**
 
@@ -364,9 +360,11 @@ The Sidebar component currently:
 - Has no sub-nav for Domain posture
 
 Changes needed:
-1. Add `roadmapOpen` state (localStorage-persisted) — sub-nav visible when `roadmapOpen` OR `active==='roadmap'`
-2. Add `domainNavOpen` state (localStorage-persisted) — controls Domain posture sub-items in sidebar
-3. Clicking the expand icon on either nav item toggles + persists state
+1. Add `roadmapOpen` state (in-memory only) — sub-nav visible when `roadmapOpen` OR `active==='roadmap'`
+2. Add `domainNavOpen` state (in-memory only) — controls Domain posture sub-items in sidebar
+3. Clicking the expand icon on either nav item toggles state; Sidebar never unmounts so state survives navigation within the session
+
+No localStorage needed: the Sidebar component stays mounted for the entire report session. Clicking to another section doesn't unmount it — `roadmapOpen` and `domainNavOpen` are preserved in React's component state naturally.
 
 - [ ] **Step 1: Add state to Sidebar and update roadmap sub-nav**
 
@@ -380,25 +378,15 @@ Add two state declarations right after the opening brace (before the DOM_ORDER c
 
 ```javascript
 function Sidebar({ active, counts, domainCounts, activeDomain, onDomainJump, onOverviewClick, navOpen, onClose }) {
-  const [roadmapOpen, setRoadmapOpen] = useState(() => {
-    try { return localStorage.getItem(LS('m365-nav-roadmap')) === 'true'; }
-    catch { return false; }
-  });
-  const [domainNavOpen, setDomainNavOpen] = useState(() => {
-    try { return localStorage.getItem(LS('m365-nav-domain')) === 'true'; }
-    catch { return false; }
-  });
+  const [roadmapOpen, setRoadmapOpen] = useState(false);
+  const [domainNavOpen, setDomainNavOpen] = useState(false);
   function toggleRoadmap(e) {
     e.preventDefault(); e.stopPropagation();
-    const next = !roadmapOpen;
-    setRoadmapOpen(next);
-    try { localStorage.setItem(LS('m365-nav-roadmap'), String(next)); } catch {}
+    setRoadmapOpen(o => !o);
   }
   function toggleDomainNav(e) {
     e.preventDefault(); e.stopPropagation();
-    const next = !domainNavOpen;
-    setDomainNavOpen(next);
-    try { localStorage.setItem(LS('m365-nav-domain'), String(next)); } catch {}
+    setDomainNavOpen(o => !o);
   }
   const DOM_ORDER = ['Entra ID','Conditional Access','Enterprise Apps','Exchange Online','Intune','Defender','Purview / Compliance','SharePoint & OneDrive','Teams','Forms','Power BI','Active Directory','SOC 2','Value Opportunity'];
   // ... rest unchanged
@@ -498,10 +486,10 @@ Apply the identical Sidebar changes to `report-app.js`.
 - [ ] **Step 5: Verify visually**
 
 Confirm in a browser:
-- Clicking '+' next to Remediation roadmap opens the sub-nav and keeps it open when scrolling away
-- Clicking '+' next to Domain posture opens sub-items (Intune coverage, SharePoint & OneDrive, AD & hybrid, Email auth — each only if data is present)
-- Both states persist after a hard refresh
+- Clicking '+' next to Remediation roadmap opens the sub-nav; navigating to Findings and back — sub-nav stays open
+- Clicking '+' next to Domain posture opens sub-items (Intune coverage, SharePoint & OneDrive, AD & hybrid, Email auth — each only if data is present); survives navigation within the session
 - Both items' '+' becomes '−' when open
+- Hard refresh resets both to collapsed (correct — fresh session default)
 
 - [ ] **Step 6: Commit**
 
@@ -812,7 +800,7 @@ gh pr create \
 **Placeholder scan:** None — all code blocks are complete implementations.
 
 **Type consistency:**
-- `LS()` helper used consistently for all new localStorage keys
+- No new localStorage keys — nav/section expansion state uses plain `useState` only
 - `D.adHybrid.pwHashSync` tri-state check matches the pattern established in report-app.jsx (null = Verify, true = Enabled, false = Disabled)
 - `D.dns` array used consistently with `.length > 0` guard in both Task 3 and Task 5
 - `FINDINGS.some(f => f.domain === 'Intune')` guard in Task 3 matches domain strings used in Task 4 sidebar sub-items

--- a/docs/superpowers/plans/2026-04-21-v2.4.0-report-ux.md
+++ b/docs/superpowers/plans/2026-04-21-v2.4.0-report-ux.md
@@ -1,0 +1,819 @@
+# v2.4.0 Report UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Four targeted report UI improvements — reorder sections, make Domain Posture expandable with subheadings, persist nav state, and enrich the tenant appendix.
+
+**Architecture:** All changes are in the React report engine (`report-app.jsx` → mirrored to `report-app.js`) and CSS (`report-shell.css`). No PowerShell or data-layer changes required — all data is already in `REPORT_DATA`. The `LS()` helper (line 14 of report-app.jsx) namespaces localStorage keys per tenant.
+
+**Tech Stack:** React 18 UMD (no build step), inline CSS in `report-shell.css`, PowerShell wraps it all in `Get-ReportTemplate.ps1`
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `src/M365-Assess/assets/report-app.jsx` | All React changes (canonical source) |
+| `src/M365-Assess/assets/report-app.js` | Mirror of jsx — must be kept identical |
+| `src/M365-Assess/assets/report-shell.css` | Add `.posture-sub-label` class |
+
+---
+
+## Task 1: Reorder — Frameworks above Domain Posture (#669)
+
+**Files:**
+- Modify: `src/M365-Assess/assets/report-app.jsx:125-130` (exec nav array)
+- Modify: `src/M365-Assess/assets/report-app.jsx:762-766` (DomainRollup eyebrow)
+- Modify: `src/M365-Assess/assets/report-app.jsx:882-885` (FrameworkQuilt eyebrow)
+- Modify: `src/M365-Assess/assets/report-app.jsx:2044-2054` (App render order)
+- Modify: `src/M365-Assess/assets/report-app.js` (mirror all above)
+
+- [ ] **Step 1: Swap sidebar exec nav order**
+
+In `report-app.jsx` at lines 125-130, change:
+
+```javascript
+  const exec = [
+    { id: 'overview', label: 'Overview' },
+    { id: 'posture',  label: 'Posture score' },
+    { id: 'identity', label: 'Domain posture' },
+    { id: 'frameworks', label: 'Frameworks' },
+  ];
+```
+
+to:
+
+```javascript
+  const exec = [
+    { id: 'overview', label: 'Overview' },
+    { id: 'posture',  label: 'Posture score' },
+    { id: 'frameworks', label: 'Frameworks' },
+    { id: 'identity', label: 'Domain posture' },
+  ];
+```
+
+- [ ] **Step 2: Update eyebrow numbers**
+
+In `report-app.jsx` at line 884, change FrameworkQuilt eyebrow from:
+
+```jsx
+        <span className="eyebrow">02 · Compliance</span>
+```
+
+to:
+
+```jsx
+        <span className="eyebrow">01 · Compliance</span>
+```
+
+In `report-app.jsx` at line 764, change DomainRollup eyebrow from:
+
+```jsx
+        <span className="eyebrow">01 · Domains</span>
+```
+
+to:
+
+```jsx
+        <span className="eyebrow">02 · Domains</span>
+```
+
+- [ ] **Step 3: Swap render order in App**
+
+In `report-app.jsx` at lines 2046-2047, change:
+
+```jsx
+        <DomainRollup onJump={onDomainJump}/>
+        <FrameworkQuilt onSelect={onFrameworkSelect} selected={filters.framework[0]}/>
+```
+
+to:
+
+```jsx
+        <FrameworkQuilt onSelect={onFrameworkSelect} selected={filters.framework[0]}/>
+        <DomainRollup onJump={onDomainJump}/>
+```
+
+- [ ] **Step 4: Mirror changes to report-app.js**
+
+Apply the identical three changes (exec array, eyebrows, render order) to `src/M365-Assess/assets/report-app.js`. The two files must remain identical in logic.
+
+- [ ] **Step 5: Verify visually**
+
+Open any generated HTML report in a browser (or generate a test report). Confirm:
+- Sidebar shows "Frameworks" above "Domain posture" in the Executive section
+- Main content renders Framework Coverage section above Security posture by domain
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/M365-Assess/assets/report-app.jsx src/M365-Assess/assets/report-app.js
+git commit -m "feat(report): move Frameworks panel above Domain Posture (#669)"
+```
+
+---
+
+## Task 2: Domain Posture — expandable section with chevron (#670 part A)
+
+**Files:**
+- Modify: `src/M365-Assess/assets/report-app.jsx:759-804` (DomainRollup component)
+- Modify: `src/M365-Assess/assets/report-app.js` (mirror)
+
+- [ ] **Step 1: Replace DomainRollup with expandable version**
+
+Replace the entire `DomainRollup` function (lines 759-804) with:
+
+```jsx
+// ======================== Domain rollup ========================
+function DomainRollup({ onJump }) {
+  const [open, setOpen] = useState(() => {
+    try { return localStorage.getItem(LS('m365-domain-posture-open')) !== 'false'; }
+    catch { return true; }
+  });
+
+  function toggleOpen(e) {
+    e.stopPropagation();
+    const next = !open;
+    setOpen(next);
+    try { localStorage.setItem(LS('m365-domain-posture-open'), String(next)); } catch {}
+  }
+
+  return (
+    <section className="block" id="identity">
+      <div className="section-head" style={{cursor:'pointer'}} onClick={toggleOpen}>
+        <span className="eyebrow">02 · Domains</span>
+        <h2>Security posture by domain <span className="section-chevron" aria-hidden="true">{open ? '\u25be' : '\u25b8'}</span></h2>
+        <div className="hr"/>
+      </div>
+      {open && (
+        <>
+          <div className="domain-grid">
+            {DOMAIN_ORDER.map(name => {
+              const d = DOMAIN_STATS[name];
+              if (!d) return null;
+              const total = d.total;
+              const score = Math.round(((d.pass + d.info*0.5) / total) * 100);
+              return (
+                <div key={name} className="domain-card" onClick={()=>onJump(name)}>
+                  <div className="dc-head">
+                    <div className="dc-name">{name}</div>
+                    <div className="dc-score">{score}%</div>
+                  </div>
+                  <div className="dc-bar">
+                    {d.pass>0 && <i className="pass-seg" style={{flex: d.pass}}/>}
+                    {d.warn>0 && <i className="warn-seg" style={{flex: d.warn}}/>}
+                    {d.fail>0 && <i className="fail-seg" style={{flex: d.fail}}/>}
+                    {d.review>0 && <i className="review-seg" style={{flex: d.review}}/>}
+                    {d.info>0 && <i className="info-seg" style={{flex: d.info}}/>}
+                  </div>
+                  <div className="dc-meta">
+                    <span><b>{d.pass}</b> pass</span>
+                    <span><b>{d.warn}</b> warn</span>
+                    <span><b>{d.fail}</b> fail</span>
+                    {d.review>0 && <span><b>{d.review}</b> review</span>}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          <div id="identity-intune">
+            <IntuneCategoryGrid />
+          </div>
+          <div id="identity-mailbox">
+            <MailboxSummaryPanel />
+          </div>
+          <div id="identity-sharepoint">
+            <SharePointSummaryPanel />
+          </div>
+          <div id="identity-ad">
+            <AdHybridPanel />
+          </div>
+          <div id="identity-email">
+            <DnsAuthPanel />
+          </div>
+        </>
+      )}
+    </section>
+  );
+}
+```
+
+Note: `\u25be` = ▾ (down-pointing small triangle), `\u25b8` = ▸ (right-pointing small triangle). Use Unicode escapes in the .js file to avoid encoding issues.
+
+- [ ] **Step 2: Add section-chevron CSS**
+
+In `src/M365-Assess/assets/report-shell.css`, find line 235:
+
+```css
+.section-head h2 { margin: 0; font-size: 17px; font-weight: 700; letter-spacing: -0.01em; }
+```
+
+Add after it:
+
+```css
+.section-chevron { font-size: 13px; opacity: .6; margin-left: 6px; font-weight: 400; vertical-align: middle; }
+```
+
+- [ ] **Step 3: Mirror to report-app.js**
+
+Apply the identical DomainRollup replacement to `report-app.js`. The Unicode escapes (`\u25be`, `\u25b8`) should already be correct since this is a .js file.
+
+- [ ] **Step 4: Verify visually**
+
+Confirm in a browser:
+- Section header shows ▾ when expanded, ▸ when collapsed
+- Clicking header toggles collapse/expand
+- State persists after page refresh (localStorage key `m365-domain-posture-open-<tenantId>`)
+- Collapse hides all domain cards and sub-panels
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/M365-Assess/assets/report-app.jsx src/M365-Assess/assets/report-app.js src/M365-Assess/assets/report-shell.css
+git commit -m "feat(report): make Domain Posture section expandable with chevron (#670)"
+```
+
+---
+
+## Task 3: Domain Posture — subheading labels on sub-panels (#670 part B)
+
+**Files:**
+- Modify: `src/M365-Assess/assets/report-app.jsx:759-815` (DomainRollup, inside open block)
+- Modify: `src/M365-Assess/assets/report-shell.css` (add .posture-sub-label)
+- Modify: `src/M365-Assess/assets/report-app.js` (mirror)
+
+- [ ] **Step 1: Add posture-sub-label CSS class**
+
+In `report-shell.css`, after the `.section-chevron` rule you added in Task 2, add:
+
+```css
+.posture-sub-label {
+  font-size: 11px; font-weight: 600; letter-spacing: .08em;
+  text-transform: uppercase; color: var(--muted);
+  margin: 28px 0 10px; padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+}
+```
+
+- [ ] **Step 2: Add subheading labels to sub-panel wrappers in DomainRollup**
+
+Inside the `{open && ...}` block of DomainRollup (added in Task 2), replace the sub-panel wrappers with labeled versions:
+
+```jsx
+          <div id="identity-intune">
+            <div className="posture-sub-label">Intune coverage by category</div>
+            <IntuneCategoryGrid />
+          </div>
+          <div id="identity-mailbox">
+            <MailboxSummaryPanel />
+          </div>
+          <div id="identity-sharepoint">
+            <div className="posture-sub-label">SharePoint &amp; OneDrive posture</div>
+            <SharePointSummaryPanel />
+          </div>
+          <div id="identity-ad">
+            <div className="posture-sub-label">Active Directory &amp; hybrid posture</div>
+            <AdHybridPanel />
+          </div>
+          <div id="identity-email">
+            <div className="posture-sub-label">Email authentication posture</div>
+            <DnsAuthPanel />
+          </div>
+```
+
+Note: In JSX, `&` inside JSX attribute values is fine but inside JSX text nodes use `&amp;` OR just use `& ` with a space (JSX handles it). Use `{'SharePoint & OneDrive posture'}` inside curly braces if the `&amp;` approach feels wrong — both render correctly.
+
+- [ ] **Step 3: Mirror to report-app.js**
+
+Apply the identical sub-panel changes to `report-app.js`.
+
+- [ ] **Step 4: Verify visually**
+
+Confirm in a browser with the Domain Posture section expanded:
+- "Intune coverage by category" label appears above the Intune grid (if Intune data is present)
+- "SharePoint & OneDrive posture" label appears above the SPO panel (if SPO data is present)
+- "Active Directory & hybrid posture" label appears above the AD/hybrid panel (if AD data present)
+- "Email authentication posture" label appears above the DNS auth panel (if DNS data present)
+- Panels with no data render nothing (component returns null internally — no orphan labels needed)
+
+Note on empty panels: IntuneCategoryGrid, MailboxSummaryPanel, SharePointSummaryPanel, AdHybridPanel, and DnsAuthPanel all already guard against empty data and return null. The posture-sub-label sits in the same wrapper div and will still render even when the panel below it is empty. To avoid orphan labels, conditionally render the wrapper:
+
+- For IntuneCategoryGrid: check `FINDINGS.filter(f => f.domain === 'Intune').length > 0`
+- For MailboxSummaryPanel: check `D.mailboxSummary` is truthy (already done inside component)
+- For SharePointSummaryPanel: check `FINDINGS.filter(f => f.domain === 'SharePoint & OneDrive').length > 0`
+- For AdHybridPanel: check `D.adHybrid` is truthy
+- For DnsAuthPanel: check `(D.dns || []).length > 0`
+
+Replace the wrappers with guarded versions:
+
+```jsx
+          {FINDINGS.some(f => f.domain === 'Intune') && (
+            <div id="identity-intune">
+              <div className="posture-sub-label">Intune coverage by category</div>
+              <IntuneCategoryGrid />
+            </div>
+          )}
+          {D.mailboxSummary && (
+            <div id="identity-mailbox">
+              <MailboxSummaryPanel />
+            </div>
+          )}
+          {FINDINGS.some(f => f.domain === 'SharePoint & OneDrive') && (
+            <div id="identity-sharepoint">
+              <div className="posture-sub-label">SharePoint &amp; OneDrive posture</div>
+              <SharePointSummaryPanel />
+            </div>
+          )}
+          {D.adHybrid && (
+            <div id="identity-ad">
+              <div className="posture-sub-label">Active Directory &amp; hybrid posture</div>
+              <AdHybridPanel />
+            </div>
+          )}
+          {(D.dns || []).length > 0 && (
+            <div id="identity-email">
+              <div className="posture-sub-label">Email authentication posture</div>
+              <DnsAuthPanel />
+            </div>
+          )}
+```
+
+- [ ] **Step 5: Mirror to report-app.js**
+
+Apply the guarded wrapper version to `report-app.js`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/M365-Assess/assets/report-app.jsx src/M365-Assess/assets/report-app.js src/M365-Assess/assets/report-shell.css
+git commit -m "feat(report): add posture subheadings to Domain Posture sub-panels (#670)"
+```
+
+---
+
+## Task 4: Persist nav open state — Roadmap and Domain Posture sidebar (#671)
+
+**Files:**
+- Modify: `src/M365-Assess/assets/report-app.jsx:119-228` (Sidebar component)
+- Modify: `src/M365-Assess/assets/report-app.js` (mirror)
+
+The Sidebar component currently:
+- Shows roadmap sub-nav only when `active === 'roadmap'` (line 184)
+- Shows roadmap expand icon reflecting `active === 'roadmap'` (line 180)
+- Has no sub-nav for Domain posture
+
+Changes needed:
+1. Add `roadmapOpen` state (localStorage-persisted) — sub-nav visible when `roadmapOpen` OR `active==='roadmap'`
+2. Add `domainNavOpen` state (localStorage-persisted) — controls Domain posture sub-items in sidebar
+3. Clicking the expand icon on either nav item toggles + persists state
+
+- [ ] **Step 1: Add state to Sidebar and update roadmap sub-nav**
+
+Replace the Sidebar function signature and add state declarations. The current signature at line 120 is:
+
+```javascript
+function Sidebar({ active, counts, domainCounts, activeDomain, onDomainJump, onOverviewClick, navOpen, onClose }) {
+```
+
+Add two state declarations right after the opening brace (before the DOM_ORDER const):
+
+```javascript
+function Sidebar({ active, counts, domainCounts, activeDomain, onDomainJump, onOverviewClick, navOpen, onClose }) {
+  const [roadmapOpen, setRoadmapOpen] = useState(() => {
+    try { return localStorage.getItem(LS('m365-nav-roadmap')) === 'true'; }
+    catch { return false; }
+  });
+  const [domainNavOpen, setDomainNavOpen] = useState(() => {
+    try { return localStorage.getItem(LS('m365-nav-domain')) === 'true'; }
+    catch { return false; }
+  });
+  function toggleRoadmap(e) {
+    e.preventDefault(); e.stopPropagation();
+    const next = !roadmapOpen;
+    setRoadmapOpen(next);
+    try { localStorage.setItem(LS('m365-nav-roadmap'), String(next)); } catch {}
+  }
+  function toggleDomainNav(e) {
+    e.preventDefault(); e.stopPropagation();
+    const next = !domainNavOpen;
+    setDomainNavOpen(next);
+    try { localStorage.setItem(LS('m365-nav-domain'), String(next)); } catch {}
+  }
+  const DOM_ORDER = ['Entra ID','Conditional Access','Enterprise Apps','Exchange Online','Intune','Defender','Purview / Compliance','SharePoint & OneDrive','Teams','Forms','Power BI','Active Directory','SOC 2','Value Opportunity'];
+  // ... rest unchanged
+```
+
+- [ ] **Step 2: Update roadmap expand icon and sub-nav condition**
+
+At line 179-190, find the roadmap expand icon and sub-nav block:
+
+```jsx
+                {it.id === 'roadmap'
+                  ? <span className="nav-expand-icon">{active === 'roadmap' ? '−' : '+'}</span>
+                  : it.count !== undefined && <span className="count">{it.count}</span>
+                }
+              </a>
+              {it.id === 'roadmap' && active === 'roadmap' && (
+                <div className="nav-subitems">
+                  <a href="#roadmap-now"   className="nav-subitem">Now   <span className="count">{ROADMAP_COUNTS.now}</span></a>
+                  <a href="#roadmap-next"  className="nav-subitem">Next  <span className="count">{ROADMAP_COUNTS.soon}</span></a>
+                  <a href="#roadmap-later" className="nav-subitem">Later <span className="count">{ROADMAP_COUNTS.later}</span></a>
+                </div>
+              )}
+```
+
+Replace with:
+
+```jsx
+                {it.id === 'roadmap'
+                  ? <span className="nav-expand-icon" onClick={toggleRoadmap}>{(roadmapOpen || active === 'roadmap') ? '\u2212' : '+'}</span>
+                  : it.count !== undefined && <span className="count">{it.count}</span>
+                }
+              </a>
+              {it.id === 'roadmap' && (roadmapOpen || active === 'roadmap') && (
+                <div className="nav-subitems">
+                  <a href="#roadmap-now"   className="nav-subitem">Now   <span className="count">{ROADMAP_COUNTS.now}</span></a>
+                  <a href="#roadmap-next"  className="nav-subitem">Next  <span className="count">{ROADMAP_COUNTS.soon}</span></a>
+                  <a href="#roadmap-later" className="nav-subitem">Later <span className="count">{ROADMAP_COUNTS.later}</span></a>
+                </div>
+              )}
+```
+
+Note: `\u2212` = − (minus sign, same as what was there before as literal `−`).
+
+- [ ] **Step 3: Add Domain posture expand icon and sub-items in exec loop**
+
+Find the exec.map block (lines 152-158):
+
+```jsx
+          {exec.map(it => (
+            <a href={`#${it.id}`} key={it.id}
+               onClick={e => { if (it.id === 'overview') { e.preventDefault(); onOverviewClick(); } closeIfMobile(); }}
+               className={'nav-item' + (active===it.id?' active':'')}>
+              <span>{it.label}</span>
+            </a>
+          ))}
+```
+
+Replace with a version that special-cases `identity`:
+
+```jsx
+          {exec.map(it => (
+            <React.Fragment key={it.id}>
+              <a href={`#${it.id}`}
+                 onClick={e => { if (it.id === 'overview') { e.preventDefault(); onOverviewClick(); } closeIfMobile(); }}
+                 className={'nav-item' + (active===it.id?' active':'')}>
+                <span>{it.label}</span>
+                {it.id === 'identity' && (
+                  <span className="nav-expand-icon" onClick={toggleDomainNav}>
+                    {domainNavOpen ? '\u2212' : '+'}
+                  </span>
+                )}
+              </a>
+              {it.id === 'identity' && domainNavOpen && (
+                <div className="nav-subitems">
+                  {FINDINGS.some(f => f.domain === 'Intune') && (
+                    <a href="#identity-intune" className="nav-subitem" onClick={closeIfMobile}>Intune coverage</a>
+                  )}
+                  {FINDINGS.some(f => f.domain === 'SharePoint & OneDrive') && (
+                    <a href="#identity-sharepoint" className="nav-subitem" onClick={closeIfMobile}>SharePoint &amp; OneDrive</a>
+                  )}
+                  {D.adHybrid && (
+                    <a href="#identity-ad" className="nav-subitem" onClick={closeIfMobile}>AD &amp; hybrid</a>
+                  )}
+                  {(D.dns || []).length > 0 && (
+                    <a href="#identity-email" className="nav-subitem" onClick={closeIfMobile}>Email auth</a>
+                  )}
+                </div>
+              )}
+            </React.Fragment>
+          ))}
+```
+
+- [ ] **Step 4: Mirror to report-app.js**
+
+Apply the identical Sidebar changes to `report-app.js`.
+
+- [ ] **Step 5: Verify visually**
+
+Confirm in a browser:
+- Clicking '+' next to Remediation roadmap opens the sub-nav and keeps it open when scrolling away
+- Clicking '+' next to Domain posture opens sub-items (Intune coverage, SharePoint & OneDrive, AD & hybrid, Email auth — each only if data is present)
+- Both states persist after a hard refresh
+- Both items' '+' becomes '−' when open
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/M365-Assess/assets/report-app.jsx src/M365-Assess/assets/report-app.js
+git commit -m "feat(report): persist sidebar nav open state for Roadmap and Domain Posture (#671)"
+```
+
+---
+
+## Task 5: Enrich tenant appendix (#672)
+
+**Files:**
+- Modify: `src/M365-Assess/assets/report-app.jsx:1794-1849` (Appendix component)
+- Modify: `src/M365-Assess/assets/report-app.js` (mirror)
+
+All data is already in `REPORT_DATA`. No PowerShell changes needed:
+- `TENANT` (line 6): OrgDisplayName, TenantId, DefaultDomain, CreatedDateTime, tenantAgeYears
+- `MFA_STATS` (line 10): phishResistant, standard, weak, none, adminsWithoutMfa, total
+- `D.adHybrid`: syncType, lastSync, pwHashSync, onPremSyncEnabled
+- `D.dns`: Domain, SPF, DMARC, DMARCPolicy, DKIM per domain
+- `D['admin-roles']`: RoleName, MemberDisplayName (all privileged roles, not just Global Admin)
+
+- [ ] **Step 1: Replace Appendix component**
+
+Replace the entire `Appendix` function (lines 1794-1849) with:
+
+```jsx
+// ======================== Appendix ========================
+function Appendix() {
+  // MFA coverage percentages
+  const mfaTotal = MFA_STATS.total || 1;
+  const mfaPct = n => Math.round((n / mfaTotal) * 100);
+
+  // DNS summary: count domains passing SPF, DKIM, DMARC
+  const dns = D.dns || [];
+  const dnsTotal = dns.length;
+  const spfPass  = dns.filter(r => r.SPF === 'Pass').length;
+  const dkimPass = dns.filter(r => r.DKIMStatus === 'Pass' || r.DKIM === 'Pass').length;
+  const dmarcEnf = dns.filter(r => r.DMARCPolicy === 'reject' || r.DMARCPolicy === 'quarantine').length;
+
+  // Admin roles: all unique privileged roles with member counts
+  const allRoles = D['admin-roles'] || [];
+  const roleCounts = allRoles.reduce((acc, r) => {
+    acc[r.RoleName] = (acc[r.RoleName] || 0) + 1;
+    return acc;
+  }, {});
+  const roleEntries = Object.entries(roleCounts).sort((a,b) => b[1] - a[1]);
+
+  // Hybrid sync
+  const ad = D.adHybrid;
+  const phsLabel = ad
+    ? (ad.pwHashSync === true ? 'Enabled' : ad.pwHashSync === null || ad.pwHashSync === undefined ? 'Verify' : 'Disabled')
+    : null;
+  const phsColor = ad
+    ? (ad.pwHashSync === true ? 'var(--success-text)' : ad.pwHashSync === null || ad.pwHashSync === undefined ? 'var(--warn-text)' : 'var(--danger-text)')
+    : 'var(--muted)';
+
+  const labelStyle = {fontSize:12,color:'var(--muted)',textTransform:'uppercase',letterSpacing:'.08em',fontWeight:600,marginBottom:10};
+  const rowStyle   = {borderTop:'1px solid var(--border)'};
+  const cellStyle  = {padding:'6px 0', fontSize:12};
+  const monoRight  = {textAlign:'right',fontFamily:'var(--font-mono)',fontVariantNumeric:'tabular-nums'};
+
+  return (
+    <section className="block" id="appendix">
+      <div className="section-head">
+        <span className="eyebrow">05 \xb7 Reference</span>
+        <h2>Tenant appendix</h2>
+        <div className="hr"/>
+      </div>
+
+      {/* Tenant info strip */}
+      <div className="card" style={{marginBottom:14}}>
+        <div style={labelStyle}>Tenant</div>
+        <div style={{display:'flex',flexWrap:'wrap',gap:'6px 24px',fontSize:12}}>
+          <span><span style={{color:'var(--muted)'}}>org</span> <b>{TENANT.OrgDisplayName}</b></span>
+          <span><span style={{color:'var(--muted)'}}>domain</span> <b>{TENANT.DefaultDomain}</b></span>
+          <span><span style={{color:'var(--muted)'}}>id</span> <span style={{fontFamily:'var(--font-mono)'}}>{TENANT.TenantId}</span></span>
+          {TENANT.tenantAgeYears != null && (
+            <span><span style={{color:'var(--muted)'}}>age</span> <b>{TENANT.tenantAgeYears} yrs</b></span>
+          )}
+          {TENANT.CreatedDateTime && (
+            <span><span style={{color:'var(--muted)'}}>created</span> <b>{TENANT.CreatedDateTime.slice(0,10)}</b></span>
+          )}
+        </div>
+      </div>
+
+      <div style={{display:'grid',gridTemplateColumns:'1fr 1fr',gap:14}}>
+
+        {/* Licenses */}
+        <div className="card">
+          <div style={labelStyle}>Licenses</div>
+          <table style={{width:'100%',fontSize:12,borderCollapse:'collapse'}}>
+            <thead><tr style={{textAlign:'left',color:'var(--muted)'}}><th style={{padding:'6px 0'}}>SKU</th><th style={{textAlign:'right'}}>Assigned</th><th style={{textAlign:'right'}}>Total</th></tr></thead>
+            <tbody>
+              {D.licenses.filter(l => parseInt(l.Assigned) > 0).map((l,i)=>(
+                <tr key={i} style={rowStyle}>
+                  <td style={cellStyle}>{l.License}</td>
+                  <td style={{...cellStyle,...monoRight}}>{l.Assigned}</td>
+                  <td style={{...cellStyle,...monoRight,color:'var(--muted)'}}>{l.Total}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* MFA coverage */}
+        <div className="card">
+          <div style={labelStyle}>MFA coverage ({fmt(mfaTotal)} users)</div>
+          <table style={{width:'100%',fontSize:12,borderCollapse:'collapse'}}>
+            <tbody>
+              {MFA_STATS.phishResistant > 0 && (
+                <tr style={rowStyle}>
+                  <td style={cellStyle}>Phish-resistant</td>
+                  <td style={{...cellStyle,...monoRight}}>{fmt(MFA_STATS.phishResistant)}</td>
+                  <td style={{...cellStyle,...monoRight,color:'var(--success-text)'}}>{mfaPct(MFA_STATS.phishResistant)}%</td>
+                </tr>
+              )}
+              {MFA_STATS.standard > 0 && (
+                <tr style={rowStyle}>
+                  <td style={cellStyle}>Standard MFA</td>
+                  <td style={{...cellStyle,...monoRight}}>{fmt(MFA_STATS.standard)}</td>
+                  <td style={{...cellStyle,...monoRight,color:'var(--text-soft)'}}>{mfaPct(MFA_STATS.standard)}%</td>
+                </tr>
+              )}
+              {MFA_STATS.weak > 0 && (
+                <tr style={rowStyle}>
+                  <td style={cellStyle}>Weak (SMS/voice)</td>
+                  <td style={{...cellStyle,...monoRight}}>{fmt(MFA_STATS.weak)}</td>
+                  <td style={{...cellStyle,...monoRight,color:'var(--warn-text)'}}>{mfaPct(MFA_STATS.weak)}%</td>
+                </tr>
+              )}
+              <tr style={rowStyle}>
+                <td style={cellStyle}>No MFA</td>
+                <td style={{...cellStyle,...monoRight}}>{fmt(MFA_STATS.none)}</td>
+                <td style={{...cellStyle,...monoRight,color:MFA_STATS.none>0?'var(--danger-text)':'var(--muted)'}}>{mfaPct(MFA_STATS.none)}%</td>
+              </tr>
+              {MFA_STATS.adminsWithoutMfa > 0 && (
+                <tr style={rowStyle}>
+                  <td style={{...cellStyle,color:'var(--danger-text)',fontWeight:600}}>Admins without MFA</td>
+                  <td style={{...cellStyle,...monoRight,color:'var(--danger-text)',fontWeight:600}}>{fmt(MFA_STATS.adminsWithoutMfa)}</td>
+                  <td style={cellStyle}/>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Conditional Access */}
+        <div className="card">
+          <div style={labelStyle}>Conditional Access policies ({D.ca.length})</div>
+          <table style={{width:'100%',fontSize:12,borderCollapse:'collapse'}}>
+            <tbody>
+              {D.ca.map((r,i)=>(
+                <tr key={i} style={rowStyle}>
+                  <td style={cellStyle}>{r.DisplayName}</td>
+                  <td style={{textAlign:'right',paddingRight:6}}><StatusDot ok={r.State==='enabled'} warn={r.State?.includes('Report')}/></td>
+                  <td style={{...cellStyle,textAlign:'right',color:'var(--muted)'}}>{r.State}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Privileged roles */}
+        <div className="card">
+          <div style={labelStyle}>Privileged roles ({allRoles.length} assignments)</div>
+          <table style={{width:'100%',fontSize:12,borderCollapse:'collapse'}}>
+            <tbody>
+              {roleEntries.map(([role, count], i) => (
+                <tr key={i} style={rowStyle}>
+                  <td style={cellStyle}>{role}</td>
+                  <td style={{...cellStyle,...monoRight,color:'var(--muted)'}}>{count}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Email authentication */}
+        {dnsTotal > 0 && (
+          <div className="card">
+            <div style={labelStyle}>Email authentication ({dnsTotal} domain{dnsTotal!==1?'s':''})</div>
+            <table style={{width:'100%',fontSize:12,borderCollapse:'collapse'}}>
+              <tbody>
+                <tr style={rowStyle}>
+                  <td style={cellStyle}>SPF passing</td>
+                  <td style={{...cellStyle,...monoRight,color:spfPass===dnsTotal?'var(--success-text)':spfPass>0?'var(--warn-text)':'var(--danger-text)'}}>{spfPass}/{dnsTotal}</td>
+                </tr>
+                <tr style={rowStyle}>
+                  <td style={cellStyle}>DKIM passing</td>
+                  <td style={{...cellStyle,...monoRight,color:dkimPass===dnsTotal?'var(--success-text)':dkimPass>0?'var(--warn-text)':'var(--danger-text)'}}>{dkimPass}/{dnsTotal}</td>
+                </tr>
+                <tr style={rowStyle}>
+                  <td style={cellStyle}>DMARC enforced</td>
+                  <td style={{...cellStyle,...monoRight,color:dmarcEnf===dnsTotal?'var(--success-text)':dmarcEnf>0?'var(--warn-text)':'var(--danger-text)'}}>{dmarcEnf}/{dnsTotal}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* Hybrid sync */}
+        {ad && (
+          <div className="card">
+            <div style={labelStyle}>Hybrid sync</div>
+            <table style={{width:'100%',fontSize:12,borderCollapse:'collapse'}}>
+              <tbody>
+                <tr style={rowStyle}>
+                  <td style={cellStyle}>Sync type</td>
+                  <td style={{...cellStyle,textAlign:'right'}}>{ad.syncType || 'Cloud-only'}</td>
+                </tr>
+                <tr style={rowStyle}>
+                  <td style={cellStyle}>Password hash sync</td>
+                  <td style={{...cellStyle,textAlign:'right',color:phsColor,fontWeight:600}}>{phsLabel}</td>
+                </tr>
+                {ad.lastSync && (
+                  <tr style={rowStyle}>
+                    <td style={cellStyle}>Last sync</td>
+                    <td style={{...cellStyle,textAlign:'right',fontFamily:'var(--font-mono)'}}>{String(ad.lastSync).slice(0,19).replace('T',' ')}</td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+      </div>
+    </section>
+  );
+}
+```
+
+Note on `\xb7`: the eyebrow uses `·` (middle dot U+00B7) as a JS escape. If the file uses literal `·` elsewhere, use the literal character consistently.
+
+- [ ] **Step 2: Mirror to report-app.js**
+
+Apply the identical Appendix replacement to `report-app.js`.
+
+- [ ] **Step 3: Verify visually**
+
+Open a generated report and confirm the appendix shows:
+- Tenant info strip (org name, domain, tenant ID, age, creation date)
+- Licenses table (unchanged from before)
+- MFA coverage table with percentages
+- CA policies table with count in header
+- Privileged roles table (all roles, not just Global Admin)
+- Email authentication summary card (if DNS data present)
+- Hybrid sync card (if adHybrid data present)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/M365-Assess/assets/report-app.jsx src/M365-Assess/assets/report-app.js
+git commit -m "feat(report): enrich tenant appendix with MFA, email auth, hybrid sync, privileged roles (#672)"
+```
+
+---
+
+## Task 6: Open PR
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin feat/v2.4.0-report-ux
+```
+
+- [ ] **Step 2: Create PR**
+
+```bash
+gh pr create \
+  --title "feat(report): v2.4.0 UX — section reorder, expandable domain posture, nav persistence, appendix enrichment" \
+  --body "Closes #669, closes #670, closes #671, closes #672
+
+## Changes
+- Frameworks panel moved above Domain Posture in home view and sidebar nav (#669)
+- Domain Posture section is now expandable/collapsible with a chevron; state persists to localStorage (#670)
+- Four posture subheadings added inside Domain Posture: Intune, SharePoint & OneDrive, AD & hybrid, Email auth (#670)
+- Remediation Roadmap and Domain Posture sidebar nav open state persists via localStorage (#671)
+- Domain Posture sidebar item now has expand sub-items linking to subheadings (#671)
+- Tenant appendix enriched with MFA coverage, privileged roles, email auth summary, hybrid sync card, full tenant info strip (#672)
+
+## Test plan
+- [ ] CI passes (no PS changes, CI runs Pester which shouldn't be affected)
+- [ ] Framework Coverage appears above Security posture by domain in report
+- [ ] Domain Posture chevron toggles section; refresh restores state
+- [ ] Subheadings render only when data is present for that domain
+- [ ] Roadmap nav stays open after scrolling away when manually toggled
+- [ ] Appendix shows new cards for MFA, roles, email auth, hybrid sync
+"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Requirement | Task |
+|-------------|------|
+| Move frameworks above domain posture (#669) | Task 1 ✓ |
+| Domain posture expandable with chevron (#670) | Task 2 ✓ |
+| Intune, SPO, AD/hybrid, Email auth subheadings (#670) | Task 3 ✓ |
+| Roadmap nav state persists (#671) | Task 4 ✓ |
+| Domain posture nav state persists (#671) | Task 4 ✓ |
+| Enrich tenant appendix (#672) | Task 5 ✓ |
+
+**Placeholder scan:** None — all code blocks are complete implementations.
+
+**Type consistency:**
+- `LS()` helper used consistently for all new localStorage keys
+- `D.adHybrid.pwHashSync` tri-state check matches the pattern established in report-app.jsx (null = Verify, true = Enabled, false = Disabled)
+- `D.dns` array used consistently with `.length > 0` guard in both Task 3 and Task 5
+- `FINDINGS.some(f => f.domain === 'Intune')` guard in Task 3 matches domain strings used in Task 4 sidebar sub-items
+- `ad.syncType`, `ad.lastSync`, `ad.pwHashSync` property names match the adHybridData shape from `Build-ReportData.ps1` (lines 296-314)

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -1485,21 +1485,35 @@ function DomainRollup({ onJump }) {
               );
             })}
           </div>
-          <div id="identity-intune">
-            <IntuneCategoryGrid />
-          </div>
-          <div id="identity-mailbox">
-            <MailboxSummaryPanel />
-          </div>
-          <div id="identity-sharepoint">
-            <SharePointSummaryPanel />
-          </div>
-          <div id="identity-ad">
-            <AdHybridPanel />
-          </div>
-          <div id="identity-email">
-            <DnsAuthPanel />
-          </div>
+          {FINDINGS.some(f => f.domain === 'Intune') && (
+            <div id="identity-intune">
+              <div className="posture-sub-label">Intune coverage by category</div>
+              <IntuneCategoryGrid />
+            </div>
+          )}
+          {D.mailboxSummary && (
+            <div id="identity-mailbox">
+              <MailboxSummaryPanel />
+            </div>
+          )}
+          {FINDINGS.some(f => f.domain === 'SharePoint & OneDrive') && (
+            <div id="identity-sharepoint">
+              <div className="posture-sub-label">SharePoint & OneDrive posture</div>
+              <SharePointSummaryPanel />
+            </div>
+          )}
+          {D.adHybrid && (
+            <div id="identity-ad">
+              <div className="posture-sub-label">Active Directory & hybrid posture</div>
+              <AdHybridPanel />
+            </div>
+          )}
+          {(D.dns || []).length > 0 && (
+            <div id="identity-email">
+              <div className="posture-sub-label">Email authentication posture</div>
+              <DnsAuthPanel />
+            </div>
+          )}
         </>
       )}
     </section>

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -3093,6 +3093,8 @@ function Overview() {
 function Appendix() {
   const mfaTotal = MFA_STATS.total || 1;
   const mfaPct = n => Math.round(n / mfaTotal * 100);
+  const ca = D.ca || [];
+  const licenses = D.licenses || [];
   const dns = D.dns || [];
   const dnsTotal = dns.length;
   const spfPass = dns.filter(r => r.SPF === 'Pass').length;
@@ -3207,7 +3209,7 @@ function Appendix() {
     style: {
       textAlign: 'right'
     }
-  }, "Total"))), /*#__PURE__*/React.createElement("tbody", null, D.licenses.filter(l => parseInt(l.Assigned) > 0).map((l, i) => /*#__PURE__*/React.createElement("tr", {
+  }, "Total"))), /*#__PURE__*/React.createElement("tbody", null, licenses.filter(l => parseInt(l.Assigned) > 0).map((l, i) => /*#__PURE__*/React.createElement("tr", {
     key: i,
     style: rowStyle
   }, /*#__PURE__*/React.createElement("td", {
@@ -3302,13 +3304,13 @@ function Appendix() {
     className: "card"
   }, /*#__PURE__*/React.createElement("div", {
     style: labelStyle
-  }, "Conditional Access policies (", D.ca.length, ")"), /*#__PURE__*/React.createElement("table", {
+  }, "Conditional Access policies (", ca.length, ")"), /*#__PURE__*/React.createElement("table", {
     style: {
       width: '100%',
       fontSize: 12,
       borderCollapse: 'collapse'
     }
-  }, /*#__PURE__*/React.createElement("tbody", null, D.ca.map((r, i) => /*#__PURE__*/React.createElement("tr", {
+  }, /*#__PURE__*/React.createElement("tbody", null, ca.map((r, i) => /*#__PURE__*/React.createElement("tr", {
     key: i,
     style: rowStyle
   }, /*#__PURE__*/React.createElement("td", {

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -1439,66 +1439,71 @@ function AdHybridPanel() {
 }
 
 // ======================== Domain rollup ========================
-function DomainRollup({
-  onJump
-}) {
-  return /*#__PURE__*/React.createElement("section", {
-    className: "block",
-    id: "identity"
-  }, /*#__PURE__*/React.createElement("div", {
-    className: "section-head"
-  }, /*#__PURE__*/React.createElement("span", {
-    className: "eyebrow"
-  }, "02 \xB7 Domains"), /*#__PURE__*/React.createElement("h2", null, "Security posture by domain"), /*#__PURE__*/React.createElement("div", {
-    className: "hr"
-  })), /*#__PURE__*/React.createElement("div", {
-    className: "domain-grid"
-  }, DOMAIN_ORDER.map(name => {
-    const d = DOMAIN_STATS[name];
-    if (!d) return null;
-    const total = d.total;
-    const score = Math.round((d.pass + d.info * 0.5) / total * 100);
-    return /*#__PURE__*/React.createElement("div", {
-      key: name,
-      className: "domain-card",
-      onClick: () => onJump(name)
-    }, /*#__PURE__*/React.createElement("div", {
-      className: "dc-head"
-    }, /*#__PURE__*/React.createElement("div", {
-      className: "dc-name"
-    }, name), /*#__PURE__*/React.createElement("div", {
-      className: "dc-score"
-    }, score, "%")), /*#__PURE__*/React.createElement("div", {
-      className: "dc-bar"
-    }, d.pass > 0 && /*#__PURE__*/React.createElement("i", {
-      className: "pass-seg",
-      style: {
-        flex: d.pass
-      }
-    }), d.warn > 0 && /*#__PURE__*/React.createElement("i", {
-      className: "warn-seg",
-      style: {
-        flex: d.warn
-      }
-    }), d.fail > 0 && /*#__PURE__*/React.createElement("i", {
-      className: "fail-seg",
-      style: {
-        flex: d.fail
-      }
-    }), d.review > 0 && /*#__PURE__*/React.createElement("i", {
-      className: "review-seg",
-      style: {
-        flex: d.review
-      }
-    }), d.info > 0 && /*#__PURE__*/React.createElement("i", {
-      className: "info-seg",
-      style: {
-        flex: d.info
-      }
-    })), /*#__PURE__*/React.createElement("div", {
-      className: "dc-meta"
-    }, /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, d.pass), " pass"), /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, d.warn), " warn"), /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, d.fail), " fail"), d.review > 0 && /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, d.review), " review")));
-  })), /*#__PURE__*/React.createElement(IntuneCategoryGrid, null), /*#__PURE__*/React.createElement(MailboxSummaryPanel, null), /*#__PURE__*/React.createElement(SharePointSummaryPanel, null), /*#__PURE__*/React.createElement(AdHybridPanel, null), /*#__PURE__*/React.createElement(DnsAuthPanel, null));
+function DomainRollup({ onJump }) {
+  const [open, setOpen] = useState(true);
+
+  function toggleOpen(e) {
+    e.stopPropagation();
+    setOpen(o => !o);
+  }
+
+  return (
+    <section className="block" id="identity">
+      <div className="section-head" style={{cursor:'pointer'}} onClick={toggleOpen}>
+        <span className="eyebrow">02 · Domains</span>
+        <h2>Security posture by domain <span className="section-chevron" aria-hidden="true">{open ? '\u25be' : '\u25b8'}</span></h2>
+        <div className="hr"/>
+      </div>
+      {open && (
+        <>
+          <div className="domain-grid">
+            {DOMAIN_ORDER.map(name => {
+              const d = DOMAIN_STATS[name];
+              if (!d) return null;
+              const total = d.total;
+              const score = Math.round(((d.pass + d.info*0.5) / total) * 100);
+              return (
+                <div key={name} className="domain-card" onClick={()=>onJump(name)}>
+                  <div className="dc-head">
+                    <div className="dc-name">{name}</div>
+                    <div className="dc-score">{score}%</div>
+                  </div>
+                  <div className="dc-bar">
+                    {d.pass>0 && <i className="pass-seg" style={{flex: d.pass}}/>}
+                    {d.warn>0 && <i className="warn-seg" style={{flex: d.warn}}/>}
+                    {d.fail>0 && <i className="fail-seg" style={{flex: d.fail}}/>}
+                    {d.review>0 && <i className="review-seg" style={{flex: d.review}}/>}
+                    {d.info>0 && <i className="info-seg" style={{flex: d.info}}/>}
+                  </div>
+                  <div className="dc-meta">
+                    <span><b>{d.pass}</b> pass</span>
+                    <span><b>{d.warn}</b> warn</span>
+                    <span><b>{d.fail}</b> fail</span>
+                    {d.review>0 && <span><b>{d.review}</b> review</span>}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          <div id="identity-intune">
+            <IntuneCategoryGrid />
+          </div>
+          <div id="identity-mailbox">
+            <MailboxSummaryPanel />
+          </div>
+          <div id="identity-sharepoint">
+            <SharePointSummaryPanel />
+          </div>
+          <div id="identity-ad">
+            <AdHybridPanel />
+          </div>
+          <div id="identity-email">
+            <DnsAuthPanel />
+          </div>
+        </>
+      )}
+    </section>
+  );
 }
 
 // ======================== Framework quilt ========================

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -1472,85 +1472,96 @@ function AdHybridPanel() {
 }
 
 // ======================== Domain rollup ========================
-function DomainRollup({ onJump }) {
+function DomainRollup({
+  onJump
+}) {
   const [open, setOpen] = useState(true);
-
   function toggleOpen(e) {
     e.stopPropagation();
     setOpen(o => !o);
   }
-
-  return (
-    <section className="block" id="identity">
-      <div className="section-head" style={{cursor:'pointer'}} onClick={toggleOpen}>
-        <span className="eyebrow">02 · Domains</span>
-        <h2>Security posture by domain <span className="section-chevron" aria-hidden="true">{open ? '\u25be' : '\u25b8'}</span></h2>
-        <div className="hr"/>
-      </div>
-      {open && (
-        <>
-          <div className="domain-grid">
-            {DOMAIN_ORDER.map(name => {
-              const d = DOMAIN_STATS[name];
-              if (!d) return null;
-              const total = d.total;
-              const score = Math.round(((d.pass + d.info*0.5) / total) * 100);
-              return (
-                <div key={name} className="domain-card" onClick={()=>onJump(name)}>
-                  <div className="dc-head">
-                    <div className="dc-name">{name}</div>
-                    <div className="dc-score">{score}%</div>
-                  </div>
-                  <div className="dc-bar">
-                    {d.pass>0 && <i className="pass-seg" style={{flex: d.pass}}/>}
-                    {d.warn>0 && <i className="warn-seg" style={{flex: d.warn}}/>}
-                    {d.fail>0 && <i className="fail-seg" style={{flex: d.fail}}/>}
-                    {d.review>0 && <i className="review-seg" style={{flex: d.review}}/>}
-                    {d.info>0 && <i className="info-seg" style={{flex: d.info}}/>}
-                  </div>
-                  <div className="dc-meta">
-                    <span><b>{d.pass}</b> pass</span>
-                    <span><b>{d.warn}</b> warn</span>
-                    <span><b>{d.fail}</b> fail</span>
-                    {d.review>0 && <span><b>{d.review}</b> review</span>}
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-          {FINDINGS.some(f => f.domain === 'Intune') && (
-            <div id="identity-intune">
-              <div className="posture-sub-label">Intune coverage by category</div>
-              <IntuneCategoryGrid />
-            </div>
-          )}
-          {D.mailboxSummary && (
-            <div id="identity-mailbox">
-              <MailboxSummaryPanel />
-            </div>
-          )}
-          {FINDINGS.some(f => f.domain === 'SharePoint & OneDrive') && (
-            <div id="identity-sharepoint">
-              <div className="posture-sub-label">SharePoint & OneDrive posture</div>
-              <SharePointSummaryPanel />
-            </div>
-          )}
-          {D.adHybrid && (
-            <div id="identity-ad">
-              <div className="posture-sub-label">Active Directory & hybrid posture</div>
-              <AdHybridPanel />
-            </div>
-          )}
-          {(D.dns || []).length > 0 && (
-            <div id="identity-email">
-              <div className="posture-sub-label">Email authentication posture</div>
-              <DnsAuthPanel />
-            </div>
-          )}
-        </>
-      )}
-    </section>
-  );
+  return /*#__PURE__*/React.createElement("section", {
+    className: "block",
+    id: "identity"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "section-head",
+    style: {
+      cursor: 'pointer'
+    },
+    onClick: toggleOpen
+  }, /*#__PURE__*/React.createElement("span", {
+    className: "eyebrow"
+  }, "02 \xB7 Domains"), /*#__PURE__*/React.createElement("h2", null, "Security posture by domain ", /*#__PURE__*/React.createElement("span", {
+    className: "section-chevron",
+    "aria-hidden": "true"
+  }, open ? '\u25be' : '\u25b8')), /*#__PURE__*/React.createElement("div", {
+    className: "hr"
+  })), open && /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement("div", {
+    className: "domain-grid"
+  }, DOMAIN_ORDER.map(name => {
+    const d = DOMAIN_STATS[name];
+    if (!d) return null;
+    const total = d.total;
+    const score = Math.round((d.pass + d.info * 0.5) / total * 100);
+    return /*#__PURE__*/React.createElement("div", {
+      key: name,
+      className: "domain-card",
+      onClick: () => onJump(name)
+    }, /*#__PURE__*/React.createElement("div", {
+      className: "dc-head"
+    }, /*#__PURE__*/React.createElement("div", {
+      className: "dc-name"
+    }, name), /*#__PURE__*/React.createElement("div", {
+      className: "dc-score"
+    }, score, "%")), /*#__PURE__*/React.createElement("div", {
+      className: "dc-bar"
+    }, d.pass > 0 && /*#__PURE__*/React.createElement("i", {
+      className: "pass-seg",
+      style: {
+        flex: d.pass
+      }
+    }), d.warn > 0 && /*#__PURE__*/React.createElement("i", {
+      className: "warn-seg",
+      style: {
+        flex: d.warn
+      }
+    }), d.fail > 0 && /*#__PURE__*/React.createElement("i", {
+      className: "fail-seg",
+      style: {
+        flex: d.fail
+      }
+    }), d.review > 0 && /*#__PURE__*/React.createElement("i", {
+      className: "review-seg",
+      style: {
+        flex: d.review
+      }
+    }), d.info > 0 && /*#__PURE__*/React.createElement("i", {
+      className: "info-seg",
+      style: {
+        flex: d.info
+      }
+    })), /*#__PURE__*/React.createElement("div", {
+      className: "dc-meta"
+    }, /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, d.pass), " pass"), /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, d.warn), " warn"), /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, d.fail), " fail"), d.review > 0 && /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, d.review), " review")));
+  })), FINDINGS.some(f => f.domain === 'Intune') && /*#__PURE__*/React.createElement("div", {
+    id: "identity-intune"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "posture-sub-label"
+  }, "Intune coverage by category"), /*#__PURE__*/React.createElement(IntuneCategoryGrid, null)), D.mailboxSummary && /*#__PURE__*/React.createElement("div", {
+    id: "identity-mailbox"
+  }, /*#__PURE__*/React.createElement(MailboxSummaryPanel, null)), FINDINGS.some(f => f.domain === 'SharePoint & OneDrive') && /*#__PURE__*/React.createElement("div", {
+    id: "identity-sharepoint"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "posture-sub-label"
+  }, "SharePoint & OneDrive posture"), /*#__PURE__*/React.createElement(SharePointSummaryPanel, null)), D.adHybrid && /*#__PURE__*/React.createElement("div", {
+    id: "identity-ad"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "posture-sub-label"
+  }, "Active Directory & hybrid posture"), /*#__PURE__*/React.createElement(AdHybridPanel, null)), (D.dns || []).length > 0 && /*#__PURE__*/React.createElement("div", {
+    id: "identity-email"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "posture-sub-label"
+  }, "Email authentication posture"), /*#__PURE__*/React.createElement(DnsAuthPanel, null))));
 }
 
 // ======================== Framework quilt ========================

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -330,6 +330,16 @@ function Sidebar({
   navOpen,
   onClose
 }) {
+  const [roadmapOpen, setRoadmapOpen] = useState(false);
+  const [domainNavOpen, setDomainNavOpen] = useState(false);
+  function toggleRoadmap(e) {
+    e.preventDefault(); e.stopPropagation();
+    setRoadmapOpen(o => !o);
+  }
+  function toggleDomainNav(e) {
+    e.preventDefault(); e.stopPropagation();
+    setDomainNavOpen(o => !o);
+  }
   const DOM_ORDER = ['Entra ID', 'Conditional Access', 'Enterprise Apps', 'Exchange Online', 'Intune', 'Defender', 'Purview / Compliance', 'SharePoint & OneDrive', 'Teams', 'Forms', 'Power BI', 'Active Directory', 'SOC 2', 'Value Opportunity'];
   const domains = DOM_ORDER.filter(d => domainCounts.total[d]).concat(Object.keys(domainCounts.total).filter(d => !DOM_ORDER.includes(d)).sort());
   const exec = [{
@@ -383,9 +393,10 @@ function Sidebar({
     }
   }, /*#__PURE__*/React.createElement("div", {
     className: "nav-label"
-  }, "Executive"), exec.map(it => /*#__PURE__*/React.createElement("a", {
+  }, "Executive"), exec.map(it => /*#__PURE__*/React.createElement(React.Fragment, {
+    key: it.id
+  }, /*#__PURE__*/React.createElement("a", {
     href: `#${it.id}`,
-    key: it.id,
     onClick: e => {
       if (it.id === 'overview') {
         e.preventDefault();
@@ -394,7 +405,28 @@ function Sidebar({
       closeIfMobile();
     },
     className: 'nav-item' + (active === it.id ? ' active' : '')
-  }, /*#__PURE__*/React.createElement("span", null, it.label))), /*#__PURE__*/React.createElement("div", {
+  }, /*#__PURE__*/React.createElement("span", null, it.label), it.id === 'identity' && /*#__PURE__*/React.createElement("span", {
+    className: "nav-expand-icon",
+    onClick: toggleDomainNav
+  }, domainNavOpen ? '\u2212' : '+')), it.id === 'identity' && domainNavOpen && /*#__PURE__*/React.createElement("div", {
+    className: "nav-subitems"
+  }, FINDINGS.some(f => f.domain === 'Intune') && /*#__PURE__*/React.createElement("a", {
+    href: "#identity-intune",
+    className: "nav-subitem",
+    onClick: closeIfMobile
+  }, "Intune coverage"), FINDINGS.some(f => f.domain === 'SharePoint & OneDrive') && /*#__PURE__*/React.createElement("a", {
+    href: "#identity-sharepoint",
+    className: "nav-subitem",
+    onClick: closeIfMobile
+  }, "SharePoint & OneDrive"), D.adHybrid && /*#__PURE__*/React.createElement("a", {
+    href: "#identity-ad",
+    className: "nav-subitem",
+    onClick: closeIfMobile
+  }, "AD & hybrid"), (D.dns || []).length > 0 && /*#__PURE__*/React.createElement("a", {
+    href: "#identity-email",
+    className: "nav-subitem",
+    onClick: closeIfMobile
+  }, "Email auth")))), /*#__PURE__*/React.createElement("div", {
     className: "nav-label",
     style: {
       marginTop: 14
@@ -429,10 +461,11 @@ function Sidebar({
     },
     className: 'nav-item' + (active === it.id && !(it.id === 'findings' && activeDomain) ? ' active' : '')
   }, /*#__PURE__*/React.createElement("span", null, it.label), it.id === 'roadmap' ? /*#__PURE__*/React.createElement("span", {
-    className: "nav-expand-icon"
-  }, active === 'roadmap' ? '−' : '+') : it.count !== undefined && /*#__PURE__*/React.createElement("span", {
+    className: "nav-expand-icon",
+    onClick: toggleRoadmap
+  }, (roadmapOpen || active === 'roadmap') ? '\u2212' : '+') : it.count !== undefined && /*#__PURE__*/React.createElement("span", {
     className: "count"
-  }, it.count)), it.id === 'roadmap' && active === 'roadmap' && /*#__PURE__*/React.createElement("div", {
+  }, it.count)), it.id === 'roadmap' && (roadmapOpen || active === 'roadmap') && /*#__PURE__*/React.createElement("div", {
     className: "nav-subitems"
   }, /*#__PURE__*/React.createElement("a", {
     href: "#roadmap-now",

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -339,11 +339,11 @@ function Sidebar({
     id: 'posture',
     label: 'Posture score'
   }, {
-    id: 'identity',
-    label: 'Domain posture'
-  }, {
     id: 'frameworks',
     label: 'Frameworks'
+  }, {
+    id: 'identity',
+    label: 'Domain posture'
   }];
   const details = [{
     id: 'findings',
@@ -1449,7 +1449,7 @@ function DomainRollup({
     className: "section-head"
   }, /*#__PURE__*/React.createElement("span", {
     className: "eyebrow"
-  }, "01 \xB7 Domains"), /*#__PURE__*/React.createElement("h2", null, "Security posture by domain"), /*#__PURE__*/React.createElement("div", {
+  }, "02 \xB7 Domains"), /*#__PURE__*/React.createElement("h2", null, "Security posture by domain"), /*#__PURE__*/React.createElement("div", {
     className: "hr"
   })), /*#__PURE__*/React.createElement("div", {
     className: "domain-grid"
@@ -1603,7 +1603,7 @@ function FrameworkQuilt({
     className: "section-head"
   }, /*#__PURE__*/React.createElement("span", {
     className: "eyebrow"
-  }, "02 \xB7 Compliance"), /*#__PURE__*/React.createElement("h2", null, "Framework coverage"), /*#__PURE__*/React.createElement("div", {
+  }, "01 \xB7 Compliance"), /*#__PURE__*/React.createElement("h2", null, "Framework coverage"), /*#__PURE__*/React.createElement("div", {
     ref: pickerRef,
     style: {
       position: 'relative',
@@ -3488,11 +3488,11 @@ function App() {
     onFinalize: handleFinalize,
     onReset: handleResetAll,
     hiddenCount: hiddenFindings.size
-  }), /*#__PURE__*/React.createElement(Overview, null), /*#__PURE__*/React.createElement(Posture, null), /*#__PURE__*/React.createElement(DomainRollup, {
-    onJump: onDomainJump
-  }), /*#__PURE__*/React.createElement(FrameworkQuilt, {
+  }), /*#__PURE__*/React.createElement(Overview, null), /*#__PURE__*/React.createElement(Posture, null), /*#__PURE__*/React.createElement(FrameworkQuilt, {
     onSelect: onFrameworkSelect,
     selected: filters.framework[0]
+  }), /*#__PURE__*/React.createElement(DomainRollup, {
+    onJump: onDomainJump
   }), /*#__PURE__*/React.createElement("div", {
     id: "findings-anchor"
   }), /*#__PURE__*/React.createElement("div", {

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -3091,6 +3091,42 @@ function Overview() {
 
 // ======================== Appendix ========================
 function Appendix() {
+  const mfaTotal = MFA_STATS.total || 1;
+  const mfaPct = n => Math.round(n / mfaTotal * 100);
+  const dns = D.dns || [];
+  const dnsTotal = dns.length;
+  const spfPass = dns.filter(r => r.SPF === 'Pass').length;
+  const dkimPass = dns.filter(r => r.DKIMStatus === 'Pass' || r.DKIM === 'Pass').length;
+  const dmarcEnf = dns.filter(r => r.DMARCPolicy === 'reject' || r.DMARCPolicy === 'quarantine').length;
+  const allRoles = D['admin-roles'] || [];
+  const roleCounts = allRoles.reduce((acc, r) => {
+    acc[r.RoleName] = (acc[r.RoleName] || 0) + 1;
+    return acc;
+  }, {});
+  const roleEntries = Object.entries(roleCounts).sort((a, b) => b[1] - a[1]);
+  const ad = D.adHybrid;
+  const phsLabel = ad ? ad.pwHashSync === true ? 'Enabled' : ad.pwHashSync === null || ad.pwHashSync === undefined ? 'Verify' : 'Disabled' : null;
+  const phsColor = ad ? ad.pwHashSync === true ? 'var(--success-text)' : ad.pwHashSync === null || ad.pwHashSync === undefined ? 'var(--warn-text)' : 'var(--danger-text)' : 'var(--muted)';
+  const labelStyle = {
+    fontSize: 12,
+    color: 'var(--muted)',
+    textTransform: 'uppercase',
+    letterSpacing: '.08em',
+    fontWeight: 600,
+    marginBottom: 10
+  };
+  const rowStyle = {
+    borderTop: '1px solid var(--border)'
+  };
+  const cellStyle = {
+    padding: '6px 0',
+    fontSize: 12
+  };
+  const monoRight = {
+    textAlign: 'right',
+    fontFamily: 'var(--font-mono)',
+    fontVariantNumeric: 'tabular-nums'
+  };
   return /*#__PURE__*/React.createElement("section", {
     className: "block",
     id: "appendix"
@@ -3101,6 +3137,44 @@ function Appendix() {
   }, "05 \xB7 Reference"), /*#__PURE__*/React.createElement("h2", null, "Tenant appendix"), /*#__PURE__*/React.createElement("div", {
     className: "hr"
   })), /*#__PURE__*/React.createElement("div", {
+    className: "card",
+    style: {
+      marginBottom: 14
+    }
+  }, /*#__PURE__*/React.createElement("div", {
+    style: labelStyle
+  }, "Tenant"), /*#__PURE__*/React.createElement("div", {
+    style: {
+      display: 'flex',
+      flexWrap: 'wrap',
+      gap: '6px 24px',
+      fontSize: 12
+    }
+  }, /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("span", {
+    style: {
+      color: 'var(--muted)'
+    }
+  }, "org"), " ", /*#__PURE__*/React.createElement("b", null, TENANT.OrgDisplayName)), /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("span", {
+    style: {
+      color: 'var(--muted)'
+    }
+  }, "domain"), " ", /*#__PURE__*/React.createElement("b", null, TENANT.DefaultDomain)), /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("span", {
+    style: {
+      color: 'var(--muted)'
+    }
+  }, "id"), " ", /*#__PURE__*/React.createElement("span", {
+    style: {
+      fontFamily: 'var(--font-mono)'
+    }
+  }, TENANT.TenantId)), TENANT.tenantAgeYears != null && /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("span", {
+    style: {
+      color: 'var(--muted)'
+    }
+  }, "age"), " ", /*#__PURE__*/React.createElement("b", null, TENANT.tenantAgeYears, " yrs")), TENANT.CreatedDateTime && /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("span", {
+    style: {
+      color: 'var(--muted)'
+    }
+  }, "created"), " ", /*#__PURE__*/React.createElement("b", null, TENANT.CreatedDateTime.slice(0, 10))))), /*#__PURE__*/React.createElement("div", {
     style: {
       display: 'grid',
       gridTemplateColumns: '1fr 1fr',
@@ -3109,14 +3183,7 @@ function Appendix() {
   }, /*#__PURE__*/React.createElement("div", {
     className: "card"
   }, /*#__PURE__*/React.createElement("div", {
-    style: {
-      fontSize: 12,
-      color: 'var(--muted)',
-      textTransform: 'uppercase',
-      letterSpacing: '.08em',
-      fontWeight: 600,
-      marginBottom: 10
-    }
+    style: labelStyle
   }, "Licenses"), /*#__PURE__*/React.createElement("table", {
     style: {
       width: '100%',
@@ -3142,38 +3209,100 @@ function Appendix() {
     }
   }, "Total"))), /*#__PURE__*/React.createElement("tbody", null, D.licenses.filter(l => parseInt(l.Assigned) > 0).map((l, i) => /*#__PURE__*/React.createElement("tr", {
     key: i,
-    style: {
-      borderTop: '1px solid var(--border)'
-    }
+    style: rowStyle
   }, /*#__PURE__*/React.createElement("td", {
-    style: {
-      padding: '6px 0'
-    }
+    style: cellStyle
   }, l.License), /*#__PURE__*/React.createElement("td", {
-    style: {
-      textAlign: 'right',
-      fontFamily: 'var(--font-mono)',
-      fontVariantNumeric: 'tabular-nums'
+    style: { ...cellStyle,
+      ...monoRight
     }
   }, l.Assigned), /*#__PURE__*/React.createElement("td", {
-    style: {
-      textAlign: 'right',
-      fontFamily: 'var(--font-mono)',
-      fontVariantNumeric: 'tabular-nums',
+    style: { ...cellStyle,
+      ...monoRight,
       color: 'var(--muted)'
     }
   }, l.Total)))))), /*#__PURE__*/React.createElement("div", {
     className: "card"
   }, /*#__PURE__*/React.createElement("div", {
+    style: labelStyle
+  }, "MFA coverage (", fmt(mfaTotal), " users)"), /*#__PURE__*/React.createElement("table", {
     style: {
+      width: '100%',
       fontSize: 12,
-      color: 'var(--muted)',
-      textTransform: 'uppercase',
-      letterSpacing: '.08em',
-      fontWeight: 600,
-      marginBottom: 10
+      borderCollapse: 'collapse'
     }
-  }, "Conditional Access policies"), /*#__PURE__*/React.createElement("table", {
+  }, /*#__PURE__*/React.createElement("tbody", null, MFA_STATS.phishResistant > 0 && /*#__PURE__*/React.createElement("tr", {
+    style: rowStyle
+  }, /*#__PURE__*/React.createElement("td", {
+    style: cellStyle
+  }, "Phish-resistant"), /*#__PURE__*/React.createElement("td", {
+    style: { ...cellStyle,
+      ...monoRight
+    }
+  }, fmt(MFA_STATS.phishResistant)), /*#__PURE__*/React.createElement("td", {
+    style: { ...cellStyle,
+      ...monoRight,
+      color: 'var(--success-text)'
+    }
+  }, mfaPct(MFA_STATS.phishResistant), "%")), MFA_STATS.standard > 0 && /*#__PURE__*/React.createElement("tr", {
+    style: rowStyle
+  }, /*#__PURE__*/React.createElement("td", {
+    style: cellStyle
+  }, "Standard MFA"), /*#__PURE__*/React.createElement("td", {
+    style: { ...cellStyle,
+      ...monoRight
+    }
+  }, fmt(MFA_STATS.standard)), /*#__PURE__*/React.createElement("td", {
+    style: { ...cellStyle,
+      ...monoRight,
+      color: 'var(--text-soft)'
+    }
+  }, mfaPct(MFA_STATS.standard), "%")), MFA_STATS.weak > 0 && /*#__PURE__*/React.createElement("tr", {
+    style: rowStyle
+  }, /*#__PURE__*/React.createElement("td", {
+    style: cellStyle
+  }, "Weak (SMS/voice)"), /*#__PURE__*/React.createElement("td", {
+    style: { ...cellStyle,
+      ...monoRight
+    }
+  }, fmt(MFA_STATS.weak)), /*#__PURE__*/React.createElement("td", {
+    style: { ...cellStyle,
+      ...monoRight,
+      color: 'var(--warn-text)'
+    }
+  }, mfaPct(MFA_STATS.weak), "%")), /*#__PURE__*/React.createElement("tr", {
+    style: rowStyle
+  }, /*#__PURE__*/React.createElement("td", {
+    style: cellStyle
+  }, "No MFA"), /*#__PURE__*/React.createElement("td", {
+    style: { ...cellStyle,
+      ...monoRight
+    }
+  }, fmt(MFA_STATS.none)), /*#__PURE__*/React.createElement("td", {
+    style: { ...cellStyle,
+      ...monoRight,
+      color: MFA_STATS.none > 0 ? 'var(--danger-text)' : 'var(--muted)'
+    }
+  }, mfaPct(MFA_STATS.none), "%")), MFA_STATS.adminsWithoutMfa > 0 && /*#__PURE__*/React.createElement("tr", {
+    style: rowStyle
+  }, /*#__PURE__*/React.createElement("td", {
+    style: { ...cellStyle,
+      color: 'var(--danger-text)',
+      fontWeight: 600
+    }
+  }, "Admins without MFA"), /*#__PURE__*/React.createElement("td", {
+    style: { ...cellStyle,
+      ...monoRight,
+      color: 'var(--danger-text)',
+      fontWeight: 600
+    }
+  }, fmt(MFA_STATS.adminsWithoutMfa)), /*#__PURE__*/React.createElement("td", {
+    style: cellStyle
+  }))))), /*#__PURE__*/React.createElement("div", {
+    className: "card"
+  }, /*#__PURE__*/React.createElement("div", {
+    style: labelStyle
+  }, "Conditional Access policies (", D.ca.length, ")"), /*#__PURE__*/React.createElement("table", {
     style: {
       width: '100%',
       fontSize: 12,
@@ -3181,57 +3310,117 @@ function Appendix() {
     }
   }, /*#__PURE__*/React.createElement("tbody", null, D.ca.map((r, i) => /*#__PURE__*/React.createElement("tr", {
     key: i,
-    style: {
-      borderTop: '1px solid var(--border)'
-    }
+    style: rowStyle
   }, /*#__PURE__*/React.createElement("td", {
-    style: {
-      padding: '6px 0'
-    }
+    style: cellStyle
   }, r.DisplayName), /*#__PURE__*/React.createElement("td", {
     style: {
-      textAlign: 'right'
+      textAlign: 'right',
+      paddingRight: 6
     }
   }, /*#__PURE__*/React.createElement(StatusDot, {
     ok: r.State === 'enabled',
     warn: r.State?.includes('Report')
   })), /*#__PURE__*/React.createElement("td", {
-    style: {
+    style: { ...cellStyle,
       textAlign: 'right',
-      fontSize: 12,
       color: 'var(--muted)'
     }
   }, r.State)))))), /*#__PURE__*/React.createElement("div", {
     className: "card"
   }, /*#__PURE__*/React.createElement("div", {
+    style: labelStyle
+  }, "Privileged roles (", allRoles.length, " assignments)"), /*#__PURE__*/React.createElement("table", {
     style: {
+      width: '100%',
       fontSize: 12,
-      color: 'var(--muted)',
-      textTransform: 'uppercase',
-      letterSpacing: '.08em',
-      fontWeight: 600,
-      marginBottom: 10
+      borderCollapse: 'collapse'
     }
-  }, "Global administrators"), /*#__PURE__*/React.createElement("div", {
-    style: {
-      display: 'flex',
-      flexWrap: 'wrap',
-      gap: 6
-    }
-  }, D['admin-roles'].filter(r => r.RoleName === 'Global Administrator').map((r, i) => /*#__PURE__*/React.createElement("span", {
+  }, /*#__PURE__*/React.createElement("tbody", null, roleEntries.map(([role, count], i) => /*#__PURE__*/React.createElement("tr", {
     key: i,
-    className: "fw-pill",
-    style: {
-      fontSize: 12,
-      padding: '4px 8px'
+    style: rowStyle
+  }, /*#__PURE__*/React.createElement("td", {
+    style: cellStyle
+  }, role), /*#__PURE__*/React.createElement("td", {
+    style: { ...cellStyle,
+      ...monoRight,
+      color: 'var(--muted)'
     }
-  }, r.MemberDisplayName))), /*#__PURE__*/React.createElement("div", {
+  }, count))))), dnsTotal > 0 && /*#__PURE__*/React.createElement("div", {
+    className: "card"
+  }, /*#__PURE__*/React.createElement("div", {
+    style: labelStyle
+  }, "Email authentication (", dnsTotal, " domain", dnsTotal !== 1 ? 's' : '', ")"), /*#__PURE__*/React.createElement("table", {
     style: {
+      width: '100%',
       fontSize: 12,
-      color: 'var(--muted)',
-      marginTop: 8
+      borderCollapse: 'collapse'
     }
-  }, D['admin-roles'].filter(r => r.RoleName === 'Global Administrator').length, " Global Administrators detected (including break-glass)."))));
+  }, /*#__PURE__*/React.createElement("tbody", null, /*#__PURE__*/React.createElement("tr", {
+    style: rowStyle
+  }, /*#__PURE__*/React.createElement("td", {
+    style: cellStyle
+  }, "SPF passing"), /*#__PURE__*/React.createElement("td", {
+    style: { ...cellStyle,
+      ...monoRight,
+      color: spfPass === dnsTotal ? 'var(--success-text)' : spfPass > 0 ? 'var(--warn-text)' : 'var(--danger-text)'
+    }
+  }, spfPass, "/", dnsTotal)), /*#__PURE__*/React.createElement("tr", {
+    style: rowStyle
+  }, /*#__PURE__*/React.createElement("td", {
+    style: cellStyle
+  }, "DKIM passing"), /*#__PURE__*/React.createElement("td", {
+    style: { ...cellStyle,
+      ...monoRight,
+      color: dkimPass === dnsTotal ? 'var(--success-text)' : dkimPass > 0 ? 'var(--warn-text)' : 'var(--danger-text)'
+    }
+  }, dkimPass, "/", dnsTotal)), /*#__PURE__*/React.createElement("tr", {
+    style: rowStyle
+  }, /*#__PURE__*/React.createElement("td", {
+    style: cellStyle
+  }, "DMARC enforced"), /*#__PURE__*/React.createElement("td", {
+    style: { ...cellStyle,
+      ...monoRight,
+      color: dmarcEnf === dnsTotal ? 'var(--success-text)' : dmarcEnf > 0 ? 'var(--warn-text)' : 'var(--danger-text)'
+    }
+  }, dmarcEnf, "/", dnsTotal))))), ad && /*#__PURE__*/React.createElement("div", {
+    className: "card"
+  }, /*#__PURE__*/React.createElement("div", {
+    style: labelStyle
+  }, "Hybrid sync"), /*#__PURE__*/React.createElement("table", {
+    style: {
+      width: '100%',
+      fontSize: 12,
+      borderCollapse: 'collapse'
+    }
+  }, /*#__PURE__*/React.createElement("tbody", null, /*#__PURE__*/React.createElement("tr", {
+    style: rowStyle
+  }, /*#__PURE__*/React.createElement("td", {
+    style: cellStyle
+  }, "Sync type"), /*#__PURE__*/React.createElement("td", {
+    style: { ...cellStyle,
+      textAlign: 'right'
+    }
+  }, ad.syncType || 'Cloud-only')), /*#__PURE__*/React.createElement("tr", {
+    style: rowStyle
+  }, /*#__PURE__*/React.createElement("td", {
+    style: cellStyle
+  }, "Password hash sync"), /*#__PURE__*/React.createElement("td", {
+    style: { ...cellStyle,
+      textAlign: 'right',
+      color: phsColor,
+      fontWeight: 600
+    }
+  }, phsLabel)), ad.lastSync && /*#__PURE__*/React.createElement("tr", {
+    style: rowStyle
+  }, /*#__PURE__*/React.createElement("td", {
+    style: cellStyle
+  }, "Last sync"), /*#__PURE__*/React.createElement("td", {
+    style: { ...cellStyle,
+      textAlign: 'right',
+      fontFamily: 'var(--font-mono)'
+    }
+  }, String(ad.lastSync).slice(0, 19).replace('T', ' '))))))));
 }
 function StatusDot({
   ok,

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -758,47 +758,68 @@ function AdHybridPanel() {
 
 // ======================== Domain rollup ========================
 function DomainRollup({ onJump }) {
+  const [open, setOpen] = useState(true);
+
+  function toggleOpen(e) {
+    e.stopPropagation();
+    setOpen(o => !o);
+  }
+
   return (
     <section className="block" id="identity">
-      <div className="section-head">
+      <div className="section-head" style={{cursor:'pointer'}} onClick={toggleOpen}>
         <span className="eyebrow">02 · Domains</span>
-        <h2>Security posture by domain</h2>
+        <h2>Security posture by domain <span className="section-chevron" aria-hidden="true">{open ? '\u25be' : '\u25b8'}</span></h2>
         <div className="hr"/>
       </div>
-      <div className="domain-grid">
-        {DOMAIN_ORDER.map(name => {
-          const d = DOMAIN_STATS[name];
-          if (!d) return null;
-          const total = d.total;
-          const score = Math.round(((d.pass + d.info*0.5) / total) * 100);
-          return (
-            <div key={name} className="domain-card" onClick={()=>onJump(name)}>
-              <div className="dc-head">
-                <div className="dc-name">{name}</div>
-                <div className="dc-score">{score}%</div>
-              </div>
-              <div className="dc-bar">
-                {d.pass>0 && <i className="pass-seg" style={{flex: d.pass}}/>}
-                {d.warn>0 && <i className="warn-seg" style={{flex: d.warn}}/>}
-                {d.fail>0 && <i className="fail-seg" style={{flex: d.fail}}/>}
-                {d.review>0 && <i className="review-seg" style={{flex: d.review}}/>}
-                {d.info>0 && <i className="info-seg" style={{flex: d.info}}/>}
-              </div>
-              <div className="dc-meta">
-                <span><b>{d.pass}</b> pass</span>
-                <span><b>{d.warn}</b> warn</span>
-                <span><b>{d.fail}</b> fail</span>
-                {d.review>0 && <span><b>{d.review}</b> review</span>}
-              </div>
-            </div>
-          );
-        })}
-      </div>
-      <IntuneCategoryGrid />
-      <MailboxSummaryPanel />
-      <SharePointSummaryPanel />
-      <AdHybridPanel />
-      <DnsAuthPanel />
+      {open && (
+        <>
+          <div className="domain-grid">
+            {DOMAIN_ORDER.map(name => {
+              const d = DOMAIN_STATS[name];
+              if (!d) return null;
+              const total = d.total;
+              const score = Math.round(((d.pass + d.info*0.5) / total) * 100);
+              return (
+                <div key={name} className="domain-card" onClick={()=>onJump(name)}>
+                  <div className="dc-head">
+                    <div className="dc-name">{name}</div>
+                    <div className="dc-score">{score}%</div>
+                  </div>
+                  <div className="dc-bar">
+                    {d.pass>0 && <i className="pass-seg" style={{flex: d.pass}}/>}
+                    {d.warn>0 && <i className="warn-seg" style={{flex: d.warn}}/>}
+                    {d.fail>0 && <i className="fail-seg" style={{flex: d.fail}}/>}
+                    {d.review>0 && <i className="review-seg" style={{flex: d.review}}/>}
+                    {d.info>0 && <i className="info-seg" style={{flex: d.info}}/>}
+                  </div>
+                  <div className="dc-meta">
+                    <span><b>{d.pass}</b> pass</span>
+                    <span><b>{d.warn}</b> warn</span>
+                    <span><b>{d.fail}</b> fail</span>
+                    {d.review>0 && <span><b>{d.review}</b> review</span>}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          <div id="identity-intune">
+            <IntuneCategoryGrid />
+          </div>
+          <div id="identity-mailbox">
+            <MailboxSummaryPanel />
+          </div>
+          <div id="identity-sharepoint">
+            <SharePointSummaryPanel />
+          </div>
+          <div id="identity-ad">
+            <AdHybridPanel />
+          </div>
+          <div id="identity-email">
+            <DnsAuthPanel />
+          </div>
+        </>
+      )}
     </section>
   );
 }

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -803,21 +803,35 @@ function DomainRollup({ onJump }) {
               );
             })}
           </div>
-          <div id="identity-intune">
-            <IntuneCategoryGrid />
-          </div>
-          <div id="identity-mailbox">
-            <MailboxSummaryPanel />
-          </div>
-          <div id="identity-sharepoint">
-            <SharePointSummaryPanel />
-          </div>
-          <div id="identity-ad">
-            <AdHybridPanel />
-          </div>
-          <div id="identity-email">
-            <DnsAuthPanel />
-          </div>
+          {FINDINGS.some(f => f.domain === 'Intune') && (
+            <div id="identity-intune">
+              <div className="posture-sub-label">Intune coverage by category</div>
+              <IntuneCategoryGrid />
+            </div>
+          )}
+          {D.mailboxSummary && (
+            <div id="identity-mailbox">
+              <MailboxSummaryPanel />
+            </div>
+          )}
+          {FINDINGS.some(f => f.domain === 'SharePoint & OneDrive') && (
+            <div id="identity-sharepoint">
+              <div className="posture-sub-label">SharePoint & OneDrive posture</div>
+              <SharePointSummaryPanel />
+            </div>
+          )}
+          {D.adHybrid && (
+            <div id="identity-ad">
+              <div className="posture-sub-label">Active Directory & hybrid posture</div>
+              <AdHybridPanel />
+            </div>
+          )}
+          {(D.dns || []).length > 0 && (
+            <div id="identity-email">
+              <div className="posture-sub-label">Email authentication posture</div>
+              <DnsAuthPanel />
+            </div>
+          )}
         </>
       )}
     </section>

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -1864,6 +1864,8 @@ function Appendix() {
   const mfaTotal = MFA_STATS.total || 1;
   const mfaPct = n => Math.round((n / mfaTotal) * 100);
 
+  const ca       = D.ca       || [];
+  const licenses = D.licenses || [];
   const dns = D.dns || [];
   const dnsTotal = dns.length;
   const spfPass  = dns.filter(r => r.SPF === 'Pass').length;
@@ -1919,7 +1921,7 @@ function Appendix() {
           <table style={{width:'100%',fontSize:12,borderCollapse:'collapse'}}>
             <thead><tr style={{textAlign:'left',color:'var(--muted)'}}><th style={{padding:'6px 0'}}>SKU</th><th style={{textAlign:'right'}}>Assigned</th><th style={{textAlign:'right'}}>Total</th></tr></thead>
             <tbody>
-              {D.licenses.filter(l => parseInt(l.Assigned) > 0).map((l,i)=>(
+              {licenses.filter(l => parseInt(l.Assigned) > 0).map((l,i)=>(
                 <tr key={i} style={rowStyle}>
                   <td style={cellStyle}>{l.License}</td>
                   <td style={{...cellStyle,...monoRight}}>{l.Assigned}</td>
@@ -1972,10 +1974,10 @@ function Appendix() {
         </div>
 
         <div className="card">
-          <div style={labelStyle}>Conditional Access policies ({D.ca.length})</div>
+          <div style={labelStyle}>Conditional Access policies ({ca.length})</div>
           <table style={{width:'100%',fontSize:12,borderCollapse:'collapse'}}>
             <tbody>
-              {D.ca.map((r,i)=>(
+              {ca.map((r,i)=>(
                 <tr key={i} style={rowStyle}>
                   <td style={cellStyle}>{r.DisplayName}</td>
                   <td style={{textAlign:'right',paddingRight:6}}><StatusDot ok={r.State==='enabled'} warn={r.State?.includes('Report')}/></td>

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -118,6 +118,16 @@ const fmt = n => Number(n).toLocaleString();
 
 // ======================== Sidebar ========================
 function Sidebar({ active, counts, domainCounts, activeDomain, onDomainJump, onOverviewClick, navOpen, onClose }) {
+  const [roadmapOpen, setRoadmapOpen] = useState(false);
+  const [domainNavOpen, setDomainNavOpen] = useState(false);
+  function toggleRoadmap(e) {
+    e.preventDefault(); e.stopPropagation();
+    setRoadmapOpen(o => !o);
+  }
+  function toggleDomainNav(e) {
+    e.preventDefault(); e.stopPropagation();
+    setDomainNavOpen(o => !o);
+  }
   const DOM_ORDER = ['Entra ID','Conditional Access','Enterprise Apps','Exchange Online','Intune','Defender','Purview / Compliance','SharePoint & OneDrive','Teams','Forms','Power BI','Active Directory','SOC 2','Value Opportunity'];
   const domains = DOM_ORDER.filter(d => domainCounts.total[d]).concat(
     Object.keys(domainCounts.total).filter(d => !DOM_ORDER.includes(d)).sort()
@@ -150,11 +160,34 @@ function Sidebar({ active, counts, domainCounts, activeDomain, onDomainJump, onO
         <nav style={{flex:1}}>
           <div className="nav-label">Executive</div>
           {exec.map(it => (
-            <a href={`#${it.id}`} key={it.id}
-               onClick={e => { if (it.id === 'overview') { e.preventDefault(); onOverviewClick(); } closeIfMobile(); }}
-               className={'nav-item' + (active===it.id?' active':'')}>
-              <span>{it.label}</span>
-            </a>
+            <React.Fragment key={it.id}>
+              <a href={`#${it.id}`}
+                 onClick={e => { if (it.id === 'overview') { e.preventDefault(); onOverviewClick(); } closeIfMobile(); }}
+                 className={'nav-item' + (active===it.id?' active':'')}>
+                <span>{it.label}</span>
+                {it.id === 'identity' && (
+                  <span className="nav-expand-icon" onClick={toggleDomainNav}>
+                    {domainNavOpen ? '\u2212' : '+'}
+                  </span>
+                )}
+              </a>
+              {it.id === 'identity' && domainNavOpen && (
+                <div className="nav-subitems">
+                  {FINDINGS.some(f => f.domain === 'Intune') && (
+                    <a href="#identity-intune" className="nav-subitem" onClick={closeIfMobile}>Intune coverage</a>
+                  )}
+                  {FINDINGS.some(f => f.domain === 'SharePoint & OneDrive') && (
+                    <a href="#identity-sharepoint" className="nav-subitem" onClick={closeIfMobile}>SharePoint &amp; OneDrive</a>
+                  )}
+                  {D.adHybrid && (
+                    <a href="#identity-ad" className="nav-subitem" onClick={closeIfMobile}>AD &amp; hybrid</a>
+                  )}
+                  {(D.dns || []).length > 0 && (
+                    <a href="#identity-email" className="nav-subitem" onClick={closeIfMobile}>Email auth</a>
+                  )}
+                </div>
+              )}
+            </React.Fragment>
           ))}
           <div className="nav-label" style={{marginTop:14}}>Domains</div>
           {domains.map(d => {
@@ -177,11 +210,11 @@ function Sidebar({ active, counts, domainCounts, activeDomain, onDomainJump, onO
                  className={'nav-item' + (active===it.id && !(it.id==='findings' && activeDomain)?' active':'')}>
                 <span>{it.label}</span>
                 {it.id === 'roadmap'
-                  ? <span className="nav-expand-icon">{active === 'roadmap' ? '−' : '+'}</span>
+                  ? <span className="nav-expand-icon" onClick={toggleRoadmap}>{(roadmapOpen || active === 'roadmap') ? '\u2212' : '+'}</span>
                   : it.count !== undefined && <span className="count">{it.count}</span>
                 }
               </a>
-              {it.id === 'roadmap' && active === 'roadmap' && (
+              {it.id === 'roadmap' && (roadmapOpen || active === 'roadmap') && (
                 <div className="nav-subitems">
                   <a href="#roadmap-now"   className="nav-subitem">Now   <span className="count">{ROADMAP_COUNTS.now}</span></a>
                   <a href="#roadmap-next"  className="nav-subitem">Next  <span className="count">{ROADMAP_COUNTS.soon}</span></a>

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -125,8 +125,8 @@ function Sidebar({ active, counts, domainCounts, activeDomain, onDomainJump, onO
   const exec = [
     { id: 'overview', label: 'Overview' },
     { id: 'posture',  label: 'Posture score' },
-    { id: 'identity', label: 'Domain posture' },
     { id: 'frameworks', label: 'Frameworks' },
+    { id: 'identity', label: 'Domain posture' },
   ];
   const details = [
     { id: 'findings', label: 'All findings', count: counts.total },
@@ -761,7 +761,7 @@ function DomainRollup({ onJump }) {
   return (
     <section className="block" id="identity">
       <div className="section-head">
-        <span className="eyebrow">01 · Domains</span>
+        <span className="eyebrow">02 · Domains</span>
         <h2>Security posture by domain</h2>
         <div className="hr"/>
       </div>
@@ -881,7 +881,7 @@ function FrameworkQuilt({ onSelect, selected }) {
   return (
     <section className="block" id="frameworks">
       <div className="section-head">
-        <span className="eyebrow">02 · Compliance</span>
+        <span className="eyebrow">01 · Compliance</span>
         <h2>Framework coverage</h2>
         <div ref={pickerRef} style={{position:'relative', marginLeft:12, flexShrink:0}}>
           <button className={'chip chip-more' + (visibleFws.length > 1 ? ' selected' : '')}
@@ -2043,8 +2043,8 @@ function App() {
         />
         <Overview/>
         <Posture/>
-        <DomainRollup onJump={onDomainJump}/>
         <FrameworkQuilt onSelect={onFrameworkSelect} selected={filters.framework[0]}/>
+        <DomainRollup onJump={onDomainJump}/>
         <div id="findings-anchor"/>
         <div style={{marginTop:20}}/>
         <FilterBar filters={filters} setFilters={setFilters} counts={counts} total={FINDINGS.length} search={search} setSearch={setSearch}/>

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -1861,6 +1861,35 @@ function Overview() {
 
 // ======================== Appendix ========================
 function Appendix() {
+  const mfaTotal = MFA_STATS.total || 1;
+  const mfaPct = n => Math.round((n / mfaTotal) * 100);
+
+  const dns = D.dns || [];
+  const dnsTotal = dns.length;
+  const spfPass  = dns.filter(r => r.SPF === 'Pass').length;
+  const dkimPass = dns.filter(r => r.DKIMStatus === 'Pass' || r.DKIM === 'Pass').length;
+  const dmarcEnf = dns.filter(r => r.DMARCPolicy === 'reject' || r.DMARCPolicy === 'quarantine').length;
+
+  const allRoles = D['admin-roles'] || [];
+  const roleCounts = allRoles.reduce((acc, r) => {
+    acc[r.RoleName] = (acc[r.RoleName] || 0) + 1;
+    return acc;
+  }, {});
+  const roleEntries = Object.entries(roleCounts).sort((a,b) => b[1] - a[1]);
+
+  const ad = D.adHybrid;
+  const phsLabel = ad
+    ? (ad.pwHashSync === true ? 'Enabled' : ad.pwHashSync === null || ad.pwHashSync === undefined ? 'Verify' : 'Disabled')
+    : null;
+  const phsColor = ad
+    ? (ad.pwHashSync === true ? 'var(--success-text)' : ad.pwHashSync === null || ad.pwHashSync === undefined ? 'var(--warn-text)' : 'var(--danger-text)')
+    : 'var(--muted)';
+
+  const labelStyle = {fontSize:12,color:'var(--muted)',textTransform:'uppercase',letterSpacing:'.08em',fontWeight:600,marginBottom:10};
+  const rowStyle   = {borderTop:'1px solid var(--border)'};
+  const cellStyle  = {padding:'6px 0', fontSize:12};
+  const monoRight  = {textAlign:'right',fontFamily:'var(--font-mono)',fontVariantNumeric:'tabular-nums'};
+
   return (
     <section className="block" id="appendix">
       <div className="section-head">
@@ -1868,49 +1897,154 @@ function Appendix() {
         <h2>Tenant appendix</h2>
         <div className="hr"/>
       </div>
-      <div style={{display:'grid', gridTemplateColumns:'1fr 1fr', gap:14}}>
+
+      <div className="card" style={{marginBottom:14}}>
+        <div style={labelStyle}>Tenant</div>
+        <div style={{display:'flex',flexWrap:'wrap',gap:'6px 24px',fontSize:12}}>
+          <span><span style={{color:'var(--muted)'}}>org</span> <b>{TENANT.OrgDisplayName}</b></span>
+          <span><span style={{color:'var(--muted)'}}>domain</span> <b>{TENANT.DefaultDomain}</b></span>
+          <span><span style={{color:'var(--muted)'}}>id</span> <span style={{fontFamily:'var(--font-mono)'}}>{TENANT.TenantId}</span></span>
+          {TENANT.tenantAgeYears != null && (
+            <span><span style={{color:'var(--muted)'}}>age</span> <b>{TENANT.tenantAgeYears} yrs</b></span>
+          )}
+          {TENANT.CreatedDateTime && (
+            <span><span style={{color:'var(--muted)'}}>created</span> <b>{TENANT.CreatedDateTime.slice(0,10)}</b></span>
+          )}
+        </div>
+      </div>
+
+      <div style={{display:'grid',gridTemplateColumns:'1fr 1fr',gap:14}}>
         <div className="card">
-          <div style={{fontSize:12,color:'var(--muted)',textTransform:'uppercase',letterSpacing:'.08em',fontWeight:600,marginBottom:10}}>Licenses</div>
+          <div style={labelStyle}>Licenses</div>
           <table style={{width:'100%',fontSize:12,borderCollapse:'collapse'}}>
             <thead><tr style={{textAlign:'left',color:'var(--muted)'}}><th style={{padding:'6px 0'}}>SKU</th><th style={{textAlign:'right'}}>Assigned</th><th style={{textAlign:'right'}}>Total</th></tr></thead>
             <tbody>
               {D.licenses.filter(l => parseInt(l.Assigned) > 0).map((l,i)=>(
-                <tr key={i} style={{borderTop:'1px solid var(--border)'}}>
-                  <td style={{padding:'6px 0'}}>{l.License}</td>
-                  <td style={{textAlign:'right',fontFamily:'var(--font-mono)',fontVariantNumeric:'tabular-nums'}}>{l.Assigned}</td>
-                  <td style={{textAlign:'right',fontFamily:'var(--font-mono)',fontVariantNumeric:'tabular-nums',color:'var(--muted)'}}>{l.Total}</td>
+                <tr key={i} style={rowStyle}>
+                  <td style={cellStyle}>{l.License}</td>
+                  <td style={{...cellStyle,...monoRight}}>{l.Assigned}</td>
+                  <td style={{...cellStyle,...monoRight,color:'var(--muted)'}}>{l.Total}</td>
                 </tr>
               ))}
             </tbody>
           </table>
         </div>
+
         <div className="card">
-          <div style={{fontSize:12,color:'var(--muted)',textTransform:'uppercase',letterSpacing:'.08em',fontWeight:600,marginBottom:10}}>Conditional Access policies</div>
+          <div style={labelStyle}>MFA coverage ({fmt(mfaTotal)} users)</div>
+          <table style={{width:'100%',fontSize:12,borderCollapse:'collapse'}}>
+            <tbody>
+              {MFA_STATS.phishResistant > 0 && (
+                <tr style={rowStyle}>
+                  <td style={cellStyle}>Phish-resistant</td>
+                  <td style={{...cellStyle,...monoRight}}>{fmt(MFA_STATS.phishResistant)}</td>
+                  <td style={{...cellStyle,...monoRight,color:'var(--success-text)'}}>{mfaPct(MFA_STATS.phishResistant)}%</td>
+                </tr>
+              )}
+              {MFA_STATS.standard > 0 && (
+                <tr style={rowStyle}>
+                  <td style={cellStyle}>Standard MFA</td>
+                  <td style={{...cellStyle,...monoRight}}>{fmt(MFA_STATS.standard)}</td>
+                  <td style={{...cellStyle,...monoRight,color:'var(--text-soft)'}}>{mfaPct(MFA_STATS.standard)}%</td>
+                </tr>
+              )}
+              {MFA_STATS.weak > 0 && (
+                <tr style={rowStyle}>
+                  <td style={cellStyle}>Weak (SMS/voice)</td>
+                  <td style={{...cellStyle,...monoRight}}>{fmt(MFA_STATS.weak)}</td>
+                  <td style={{...cellStyle,...monoRight,color:'var(--warn-text)'}}>{mfaPct(MFA_STATS.weak)}%</td>
+                </tr>
+              )}
+              <tr style={rowStyle}>
+                <td style={cellStyle}>No MFA</td>
+                <td style={{...cellStyle,...monoRight}}>{fmt(MFA_STATS.none)}</td>
+                <td style={{...cellStyle,...monoRight,color:MFA_STATS.none>0?'var(--danger-text)':'var(--muted)'}}>{mfaPct(MFA_STATS.none)}%</td>
+              </tr>
+              {MFA_STATS.adminsWithoutMfa > 0 && (
+                <tr style={rowStyle}>
+                  <td style={{...cellStyle,color:'var(--danger-text)',fontWeight:600}}>Admins without MFA</td>
+                  <td style={{...cellStyle,...monoRight,color:'var(--danger-text)',fontWeight:600}}>{fmt(MFA_STATS.adminsWithoutMfa)}</td>
+                  <td style={cellStyle}/>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="card">
+          <div style={labelStyle}>Conditional Access policies ({D.ca.length})</div>
           <table style={{width:'100%',fontSize:12,borderCollapse:'collapse'}}>
             <tbody>
               {D.ca.map((r,i)=>(
-                <tr key={i} style={{borderTop:'1px solid var(--border)'}}>
-                  <td style={{padding:'6px 0'}}>{r.DisplayName}</td>
-                  <td style={{textAlign:'right'}}><StatusDot ok={r.State === 'enabled'} warn={r.State?.includes('Report')}/></td>
-                  <td style={{textAlign:'right',fontSize:12,color:'var(--muted)'}}>{r.State}</td>
+                <tr key={i} style={rowStyle}>
+                  <td style={cellStyle}>{r.DisplayName}</td>
+                  <td style={{textAlign:'right',paddingRight:6}}><StatusDot ok={r.State==='enabled'} warn={r.State?.includes('Report')}/></td>
+                  <td style={{...cellStyle,textAlign:'right',color:'var(--muted)'}}>{r.State}</td>
                 </tr>
               ))}
             </tbody>
           </table>
         </div>
+
         <div className="card">
-          <div style={{fontSize:12,color:'var(--muted)',textTransform:'uppercase',letterSpacing:'.08em',fontWeight:600,marginBottom:10}}>Global administrators</div>
-          <div style={{display:'flex',flexWrap:'wrap',gap:6}}>
-            {D['admin-roles'].filter(r=>r.RoleName==='Global Administrator').map((r,i)=>(
-              <span key={i} className="fw-pill" style={{fontSize:12,padding:'4px 8px'}}>
-                {r.MemberDisplayName}
-              </span>
-            ))}
-          </div>
-          <div style={{fontSize:12,color:'var(--muted)',marginTop:8}}>
-            {D['admin-roles'].filter(r=>r.RoleName==='Global Administrator').length} Global Administrators detected (including break-glass).
-          </div>
+          <div style={labelStyle}>Privileged roles ({allRoles.length} assignments)</div>
+          <table style={{width:'100%',fontSize:12,borderCollapse:'collapse'}}>
+            <tbody>
+              {roleEntries.map(([role, count], i) => (
+                <tr key={i} style={rowStyle}>
+                  <td style={cellStyle}>{role}</td>
+                  <td style={{...cellStyle,...monoRight,color:'var(--muted)'}}>{count}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
+
+        {dnsTotal > 0 && (
+          <div className="card">
+            <div style={labelStyle}>Email authentication ({dnsTotal} domain{dnsTotal!==1?'s':''})</div>
+            <table style={{width:'100%',fontSize:12,borderCollapse:'collapse'}}>
+              <tbody>
+                <tr style={rowStyle}>
+                  <td style={cellStyle}>SPF passing</td>
+                  <td style={{...cellStyle,...monoRight,color:spfPass===dnsTotal?'var(--success-text)':spfPass>0?'var(--warn-text)':'var(--danger-text)'}}>{spfPass}/{dnsTotal}</td>
+                </tr>
+                <tr style={rowStyle}>
+                  <td style={cellStyle}>DKIM passing</td>
+                  <td style={{...cellStyle,...monoRight,color:dkimPass===dnsTotal?'var(--success-text)':dkimPass>0?'var(--warn-text)':'var(--danger-text)'}}>{dkimPass}/{dnsTotal}</td>
+                </tr>
+                <tr style={rowStyle}>
+                  <td style={cellStyle}>DMARC enforced</td>
+                  <td style={{...cellStyle,...monoRight,color:dmarcEnf===dnsTotal?'var(--success-text)':dmarcEnf>0?'var(--warn-text)':'var(--danger-text)'}}>{dmarcEnf}/{dnsTotal}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {ad && (
+          <div className="card">
+            <div style={labelStyle}>Hybrid sync</div>
+            <table style={{width:'100%',fontSize:12,borderCollapse:'collapse'}}>
+              <tbody>
+                <tr style={rowStyle}>
+                  <td style={cellStyle}>Sync type</td>
+                  <td style={{...cellStyle,textAlign:'right'}}>{ad.syncType || 'Cloud-only'}</td>
+                </tr>
+                <tr style={rowStyle}>
+                  <td style={cellStyle}>Password hash sync</td>
+                  <td style={{...cellStyle,textAlign:'right',color:phsColor,fontWeight:600}}>{phsLabel}</td>
+                </tr>
+                {ad.lastSync && (
+                  <tr style={rowStyle}>
+                    <td style={cellStyle}>Last sync</td>
+                    <td style={{...cellStyle,textAlign:'right',fontFamily:'var(--font-mono)'}}>{String(ad.lastSync).slice(0,19).replace('T',' ')}</td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
     </section>
   );

--- a/src/M365-Assess/assets/report-shell.css
+++ b/src/M365-Assess/assets/report-shell.css
@@ -233,6 +233,7 @@ section.block { margin-bottom: 52px; scroll-margin-top: 20px; }
   margin-bottom: 18px;
 }
 .section-head h2 { margin: 0; font-size: 17px; font-weight: 700; letter-spacing: -0.01em; }
+.section-chevron { font-size: 13px; opacity: .6; margin-left: 6px; font-weight: 400; vertical-align: middle; }
 .section-head .eyebrow {
   font-family: var(--font-mono); font-size: 13px;
   text-transform: uppercase; letter-spacing: 0.1em;

--- a/src/M365-Assess/assets/report-shell.css
+++ b/src/M365-Assess/assets/report-shell.css
@@ -234,6 +234,14 @@ section.block { margin-bottom: 52px; scroll-margin-top: 20px; }
 }
 .section-head h2 { margin: 0; font-size: 17px; font-weight: 700; letter-spacing: -0.01em; }
 .section-chevron { font-size: 13px; opacity: .6; margin-left: 6px; font-weight: 400; vertical-align: middle; }
+
+.posture-sub-label {
+  font-size: 11px; font-weight: 600; letter-spacing: .08em;
+  text-transform: uppercase; color: var(--muted);
+  margin: 28px 0 10px; padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+}
+
 .section-head .eyebrow {
   font-family: var(--font-mono); font-size: 13px;
   text-transform: uppercase; letter-spacing: 0.1em;

--- a/src/M365-Assess/assets/report-themes.css
+++ b/src/M365-Assess/assets/report-themes.css
@@ -416,6 +416,10 @@
 [data-theme="high-contrast"][data-mode="dark"] .brand-mark {
   color: #000000;
 }
+/* high-contrast dark: accent is #fff so active count pill needs dark text */
+[data-theme="high-contrast"][data-mode="dark"] .nav-item.active .count {
+  color: #000000;
+}
 
 /* =========================================================
    NEON DARK — CYBER GLOW LAYER


### PR DESCRIPTION
Closes #669, closes #670, closes #671, closes #672

## Summary
- Frameworks panel moved above Domain Posture in sidebar nav and main content (#669)
- Domain Posture section is now expandable/collapsible with a chevron toggle; four posture subheadings (Intune, SharePoint & OneDrive, AD & hybrid, Email auth) added inside, each guarded and only rendered when data is present (#670)
- Remediation Roadmap and Domain Posture sidebar nav open state persists within a session using plain `useState` — no localStorage (report is a transferable file; storage is origin-tied) (#671)
- Tenant appendix enriched: full tenant info strip, MFA coverage breakdown with percentages, CA policies list, all privileged roles (not just Global Admin), email auth summary, hybrid sync card — all data already in `REPORT_DATA`, no PS changes (#672)
- Bug fix: high-contrast dark mode count pill was white-on-white; fixed with a scoped CSS override in `report-themes.css`
- Bug fix: `D.ca` and `D.licenses` guarded with `|| []` in Appendix to prevent crash on partial assessment runs
- Bug fix: DomainRollup compiled from JSX to `React.createElement` in `report-app.js` (file is inlined into a plain `<script>` tag with no Babel)

## Test Plan
- [ ] CI passes (Pester 2075 tests — no PS changes on this branch)
- [ ] Framework Coverage appears above Security posture by domain in the report
- [ ] Domain Posture chevron toggles section; navigating away and back preserves state (in-memory)
- [ ] Subheadings (Intune, SharePoint & OneDrive, AD & hybrid, Email auth) render only when data is present
- [ ] Roadmap nav sub-items stay visible after manually toggling open and scrolling away
- [ ] Domain Posture sidebar expand shows sub-items linking to the correct anchors
- [ ] Appendix shows new cards: MFA breakdown, CA policies, all privileged roles, email auth summary, hybrid sync
- [ ] High-contrast dark mode: active nav count pill is readable (black text on white background)
- [ ] Report generated from a partial run (e.g. `-Section Entra`) does not crash the Appendix

🤖 Generated with [Claude Code](https://claude.com/claude-code)