### PR TITLE
feat(report): surface remediation guidance and titled Learn links per finding

### DIFF
--- a/docs/superpowers/plans/2026-04-21-v2.4.0-report-ux.md
+++ b/docs/superpowers/plans/2026-04-21-v2.4.0-report-ux.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Four targeted report UI improvements — reorder sections, make Domain Posture expandable with subheadings, persist nav state, and enrich the tenant appendix.
+**Goal:** Four targeted report UI improvements — reorder sections, make Domain Posture expandable with subheadings, persist nav state within a session, and enrich the tenant appendix.
 
-**Architecture:** All changes are in the React report engine (`report-app.jsx` → mirrored to `report-app.js`) and CSS (`report-shell.css`). No PowerShell or data-layer changes required — all data is already in `REPORT_DATA`. The `LS()` helper (line 14 of report-app.jsx) namespaces localStorage keys per tenant.
+**Architecture:** All changes are in the React report engine (`report-app.jsx` → mirrored to `report-app.js`) and CSS (`report-shell.css`). No PowerShell or data-layer changes required — all data is already in `REPORT_DATA`. Nav/section expansion state uses plain React `useState` (no storage) because the Sidebar and DomainRollup components never unmount — state survives navigation within a session naturally. localStorage is intentionally avoided for new features: the report is a transferable file and storage is origin-tied, so moving or sharing the file would silently discard any persisted state.
 
 **Tech Stack:** React 18 UMD (no build step), inline CSS in `report-shell.css`, PowerShell wraps it all in `Get-ReportTemplate.ps1`
 
@@ -127,16 +127,11 @@ Replace the entire `DomainRollup` function (lines 759-804) with:
 ```jsx
 // ======================== Domain rollup ========================
 function DomainRollup({ onJump }) {
-  const [open, setOpen] = useState(() => {
-    try { return localStorage.getItem(LS('m365-domain-posture-open')) !== 'false'; }
-    catch { return true; }
-  });
+  const [open, setOpen] = useState(true);  // default expanded; in-memory only (no storage)
 
   function toggleOpen(e) {
     e.stopPropagation();
-    const next = !open;
-    setOpen(next);
-    try { localStorage.setItem(LS('m365-domain-posture-open'), String(next)); } catch {}
+    setOpen(o => !o);
   }
 
   return (
@@ -224,8 +219,9 @@ Apply the identical DomainRollup replacement to `report-app.js`. The Unicode esc
 Confirm in a browser:
 - Section header shows ▾ when expanded, ▸ when collapsed
 - Clicking header toggles collapse/expand
-- State persists after page refresh (localStorage key `m365-domain-posture-open-<tenantId>`)
+- Navigating to Findings and back to Domain Posture — chevron state is preserved (in-memory)
 - Collapse hides all domain cards and sub-panels
+- Refreshing the page resets to expanded (correct — fresh session default)
 
 - [ ] **Step 5: Commit**
 
@@ -364,9 +360,11 @@ The Sidebar component currently:
 - Has no sub-nav for Domain posture
 
 Changes needed:
-1. Add `roadmapOpen` state (localStorage-persisted) — sub-nav visible when `roadmapOpen` OR `active==='roadmap'`
-2. Add `domainNavOpen` state (localStorage-persisted) — controls Domain posture sub-items in sidebar
-3. Clicking the expand icon on either nav item toggles + persists state
+1. Add `roadmapOpen` state (in-memory only) — sub-nav visible when `roadmapOpen` OR `active==='roadmap'`
+2. Add `domainNavOpen` state (in-memory only) — controls Domain posture sub-items in sidebar
+3. Clicking the expand icon on either nav item toggles state; Sidebar never unmounts so state survives navigation within the session
+
+No localStorage needed: the Sidebar component stays mounted for the entire report session. Clicking to another section doesn't unmount it — `roadmapOpen` and `domainNavOpen` are preserved in React's component state naturally.
 
 - [ ] **Step 1: Add state to Sidebar and update roadmap sub-nav**
 
@@ -380,25 +378,15 @@ Add two state declarations right after the opening brace (before the DOM_ORDER c
 
 ```javascript
 function Sidebar({ active, counts, domainCounts, activeDomain, onDomainJump, onOverviewClick, navOpen, onClose }) {
-  const [roadmapOpen, setRoadmapOpen] = useState(() => {
-    try { return localStorage.getItem(LS('m365-nav-roadmap')) === 'true'; }
-    catch { return false; }
-  });
-  const [domainNavOpen, setDomainNavOpen] = useState(() => {
-    try { return localStorage.getItem(LS('m365-nav-domain')) === 'true'; }
-    catch { return false; }
-  });
+  const [roadmapOpen, setRoadmapOpen] = useState(false);
+  const [domainNavOpen, setDomainNavOpen] = useState(false);
   function toggleRoadmap(e) {
     e.preventDefault(); e.stopPropagation();
-    const next = !roadmapOpen;
-    setRoadmapOpen(next);
-    try { localStorage.setItem(LS('m365-nav-roadmap'), String(next)); } catch {}
+    setRoadmapOpen(o => !o);
   }
   function toggleDomainNav(e) {
     e.preventDefault(); e.stopPropagation();
-    const next = !domainNavOpen;
-    setDomainNavOpen(next);
-    try { localStorage.setItem(LS('m365-nav-domain'), String(next)); } catch {}
+    setDomainNavOpen(o => !o);
   }
   const DOM_ORDER = ['Entra ID','Conditional Access','Enterprise Apps','Exchange Online','Intune','Defender','Purview / Compliance','SharePoint & OneDrive','Teams','Forms','Power BI','Active Directory','SOC 2','Value Opportunity'];
   // ... rest unchanged
@@ -498,10 +486,10 @@ Apply the identical Sidebar changes to `report-app.js`.
 - [ ] **Step 5: Verify visually**
 
 Confirm in a browser:
-- Clicking '+' next to Remediation roadmap opens the sub-nav and keeps it open when scrolling away
-- Clicking '+' next to Domain posture opens sub-items (Intune coverage, SharePoint & OneDrive, AD & hybrid, Email auth — each only if data is present)
-- Both states persist after a hard refresh
+- Clicking '+' next to Remediation roadmap opens the sub-nav; navigating to Findings and back — sub-nav stays open
+- Clicking '+' next to Domain posture opens sub-items (Intune coverage, SharePoint & OneDrive, AD & hybrid, Email auth — each only if data is present); survives navigation within the session
 - Both items' '+' becomes '−' when open
+- Hard refresh resets both to collapsed (correct — fresh session default)
 
 - [ ] **Step 6: Commit**
 
@@ -812,7 +800,7 @@ gh pr create \
 **Placeholder scan:** None — all code blocks are complete implementations.
 
 **Type consistency:**
-- `LS()` helper used consistently for all new localStorage keys
+- No new localStorage keys — nav/section expansion state uses plain `useState` only
 - `D.adHybrid.pwHashSync` tri-state check matches the pattern established in report-app.jsx (null = Verify, true = Enabled, false = Disabled)
 - `D.dns` array used consistently with `.length > 0` guard in both Task 3 and Task 5
 - `FINDINGS.some(f => f.domain === 'Intune')` guard in Task 3 matches domain strings used in Task 4 sidebar sub-items

--- a/docs/superpowers/plans/2026-04-21-v2.4.0-report-ux.md
+++ b/docs/superpowers/plans/2026-04-21-v2.4.0-report-ux.md
@@ -1,0 +1,819 @@
+# v2.4.0 Report UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Four targeted report UI improvements — reorder sections, make Domain Posture expandable with subheadings, persist nav state, and enrich the tenant appendix.
+
+**Architecture:** All changes are in the React report engine (`report-app.jsx` → mirrored to `report-app.js`) and CSS (`report-shell.css`). No PowerShell or data-layer changes required — all data is already in `REPORT_DATA`. The `LS()` helper (line 14 of report-app.jsx) namespaces localStorage keys per tenant.
+
+**Tech Stack:** React 18 UMD (no build step), inline CSS in `report-shell.css`, PowerShell wraps it all in `Get-ReportTemplate.ps1`
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `src/M365-Assess/assets/report-app.jsx` | All React changes (canonical source) |
+| `src/M365-Assess/assets/report-app.js` | Mirror of jsx — must be kept identical |
+| `src/M365-Assess/assets/report-shell.css` | Add `.posture-sub-label` class |
+
+---
+
+## Task 1: Reorder — Frameworks above Domain Posture (#669)
+
+**Files:**
+- Modify: `src/M365-Assess/assets/report-app.jsx:125-130` (exec nav array)
+- Modify: `src/M365-Assess/assets/report-app.jsx:762-766` (DomainRollup eyebrow)
+- Modify: `src/M365-Assess/assets/report-app.jsx:882-885` (FrameworkQuilt eyebrow)
+- Modify: `src/M365-Assess/assets/report-app.jsx:2044-2054` (App render order)
+- Modify: `src/M365-Assess/assets/report-app.js` (mirror all above)
+
+- [ ] **Step 1: Swap sidebar exec nav order**
+
+In `report-app.jsx` at lines 125-130, change:
+
+```javascript
+  const exec = [
+    { id: 'overview', label: 'Overview' },
+    { id: 'posture',  label: 'Posture score' },
+    { id: 'identity', label: 'Domain posture' },
+    { id: 'frameworks', label: 'Frameworks' },
+  ];
+```
+
+to:
+
+```javascript
+  const exec = [
+    { id: 'overview', label: 'Overview' },
+    { id: 'posture',  label: 'Posture score' },
+    { id: 'frameworks', label: 'Frameworks' },
+    { id: 'identity', label: 'Domain posture' },
+  ];
+```
+
+- [ ] **Step 2: Update eyebrow numbers**
+
+In `report-app.jsx` at line 884, change FrameworkQuilt eyebrow from:
+
+```jsx
+        <span className="eyebrow">02 · Compliance</span>
+```
+
+to:
+
+```jsx
+        <span className="eyebrow">01 · Compliance</span>
+```
+
+In `report-app.jsx` at line 764, change DomainRollup eyebrow from:
+
+```jsx
+        <span className="eyebrow">01 · Domains</span>
+```
+
+to:
+
+```jsx
+        <span className="eyebrow">02 · Domains</span>
+```
+
+- [ ] **Step 3: Swap render order in App**
+
+In `report-app.jsx` at lines 2046-2047, change:
+
+```jsx
+        <DomainRollup onJump={onDomainJump}/>
+        <FrameworkQuilt onSelect={onFrameworkSelect} selected={filters.framework[0]}/>
+```
+
+to:
+
+```jsx
+        <FrameworkQuilt onSelect={onFrameworkSelect} selected={filters.framework[0]}/>
+        <DomainRollup onJump={onDomainJump}/>
+```
+
+- [ ] **Step 4: Mirror changes to report-app.js**
+
+Apply the identical three changes (exec array, eyebrows, render order) to `src/M365-Assess/assets/report-app.js`. The two files must remain identical in logic.
+
+- [ ] **Step 5: Verify visually**
+
+Open any generated HTML report in a browser (or generate a test report). Confirm:
+- Sidebar shows "Frameworks" above "Domain posture" in the Executive section
+- Main content renders Framework Coverage section above Security posture by domain
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/M365-Assess/assets/report-app.jsx src/M365-Assess/assets/report-app.js
+git commit -m "feat(report): move Frameworks panel above Domain Posture (#669)"
+```
+
+---
+
+## Task 2: Domain Posture — expandable section with chevron (#670 part A)
+
+**Files:**
+- Modify: `src/M365-Assess/assets/report-app.jsx:759-804` (DomainRollup component)
+- Modify: `src/M365-Assess/assets/report-app.js` (mirror)
+
+- [ ] **Step 1: Replace DomainRollup with expandable version**
+
+Replace the entire `DomainRollup` function (lines 759-804) with:
+
+```jsx
+// ======================== Domain rollup ========================
+function DomainRollup({ onJump }) {
+  const [open, setOpen] = useState(() => {
+    try { return localStorage.getItem(LS('m365-domain-posture-open')) !== 'false'; }
+    catch { return true; }
+  });
+
+  function toggleOpen(e) {
+    e.stopPropagation();
+    const next = !open;
+    setOpen(next);
+    try { localStorage.setItem(LS('m365-domain-posture-open'), String(next)); } catch {}
+  }
+
+  return (
+    <section className="block" id="identity">
+      <div className="section-head" style={{cursor:'pointer'}} onClick={toggleOpen}>
+        <span className="eyebrow">02 · Domains</span>
+        <h2>Security posture by domain <span className="section-chevron" aria-hidden="true">{open ? '\u25be' : '\u25b8'}</span></h2>
+        <div className="hr"/>
+      </div>
+      {open && (
+        <>
+          <div className="domain-grid">
+            {DOMAIN_ORDER.map(name => {
+              const d = DOMAIN_STATS[name];
+              if (!d) return null;
+              const total = d.total;
+              const score = Math.round(((d.pass + d.info*0.5) / total) * 100);
+              return (
+                <div key={name} className="domain-card" onClick={()=>onJump(name)}>
+                  <div className="dc-head">
+                    <div className="dc-name">{name}</div>
+                    <div className="dc-score">{score}%</div>
+                  </div>
+                  <div className="dc-bar">
+                    {d.pass>0 && <i className="pass-seg" style={{flex: d.pass}}/>}
+                    {d.warn>0 && <i className="warn-seg" style={{flex: d.warn}}/>}
+                    {d.fail>0 && <i className="fail-seg" style={{flex: d.fail}}/>}
+                    {d.review>0 && <i className="review-seg" style={{flex: d.review}}/>}
+                    {d.info>0 && <i className="info-seg" style={{flex: d.info}}/>}
+                  </div>
+                  <div className="dc-meta">
+                    <span><b>{d.pass}</b> pass</span>
+                    <span><b>{d.warn}</b> warn</span>
+                    <span><b>{d.fail}</b> fail</span>
+                    {d.review>0 && <span><b>{d.review}</b> review</span>}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          <div id="identity-intune">
+            <IntuneCategoryGrid />
+          </div>
+          <div id="identity-mailbox">
+            <MailboxSummaryPanel />
+          </div>
+          <div id="identity-sharepoint">
+            <SharePointSummaryPanel />
+          </div>
+          <div id="identity-ad">
+            <AdHybridPanel />
+          </div>
+          <div id="identity-email">
+            <DnsAuthPanel />
+          </div>
+        </>
+      )}
+    </section>
+  );
+}
+```
+
+Note: `\u25be` = ▾ (down-pointing small triangle), `\u25b8` = ▸ (right-pointing small triangle). Use Unicode escapes in the .js file to avoid encoding issues.
+
+- [ ] **Step 2: Add section-chevron CSS**
+
+In `src/M365-Assess/assets/report-shell.css`, find line 235:
+
+```css
+.section-head h2 { margin: 0; font-size: 17px; font-weight: 700; letter-spacing: -0.01em; }
+```
+
+Add after it:
+
+```css
+.section-chevron { font-size: 13px; opacity: .6; margin-left: 6px; font-weight: 400; vertical-align: middle; }
+```
+
+- [ ] **Step 3: Mirror to report-app.js**
+
+Apply the identical DomainRollup replacement to `report-app.js`. The Unicode escapes (`\u25be`, `\u25b8`) should already be correct since this is a .js file.
+
+- [ ] **Step 4: Verify visually**
+
+Confirm in a browser:
+- Section header shows ▾ when expanded, ▸ when collapsed
+- Clicking header toggles collapse/expand
+- State persists after page refresh (localStorage key `m365-domain-posture-open-<tenantId>`)
+- Collapse hides all domain cards and sub-panels
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/M365-Assess/assets/report-app.jsx src/M365-Assess/assets/report-app.js src/M365-Assess/assets/report-shell.css
+git commit -m "feat(report): make Domain Posture section expandable with chevron (#670)"
+```
+
+---
+
+## Task 3: Domain Posture — subheading labels on sub-panels (#670 part B)
+
+**Files:**
+- Modify: `src/M365-Assess/assets/report-app.jsx:759-815` (DomainRollup, inside open block)
+- Modify: `src/M365-Assess/assets/report-shell.css` (add .posture-sub-label)
+- Modify: `src/M365-Assess/assets/report-app.js` (mirror)
+
+- [ ] **Step 1: Add posture-sub-label CSS class**
+
+In `report-shell.css`, after the `.section-chevron` rule you added in Task 2, add:
+
+```css
+.posture-sub-label {
+  font-size: 11px; font-weight: 600; letter-spacing: .08em;
+  text-transform: uppercase; color: var(--muted);
+  margin: 28px 0 10px; padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+}
+```
+
+- [ ] **Step 2: Add subheading labels to sub-panel wrappers in DomainRollup**
+
+Inside the `{open && ...}` block of DomainRollup (added in Task 2), replace the sub-panel wrappers with labeled versions:
+
+```jsx
+          <div id="identity-intune">
+            <div className="posture-sub-label">Intune coverage by category</div>
+            <IntuneCategoryGrid />
+          </div>
+          <div id="identity-mailbox">
+            <MailboxSummaryPanel />
+          </div>
+          <div id="identity-sharepoint">
+            <div className="posture-sub-label">SharePoint &amp; OneDrive posture</div>
+            <SharePointSummaryPanel />
+          </div>
+          <div id="identity-ad">
+            <div className="posture-sub-label">Active Directory &amp; hybrid posture</div>
+            <AdHybridPanel />
+          </div>
+          <div id="identity-email">
+            <div className="posture-sub-label">Email authentication posture</div>
+            <DnsAuthPanel />
+          </div>
+```
+
+Note: In JSX, `&` inside JSX attribute values is fine but inside JSX text nodes use `&amp;` OR just use `& ` with a space (JSX handles it). Use `{'SharePoint & OneDrive posture'}` inside curly braces if the `&amp;` approach feels wrong — both render correctly.
+
+- [ ] **Step 3: Mirror to report-app.js**
+
+Apply the identical sub-panel changes to `report-app.js`.
+
+- [ ] **Step 4: Verify visually**
+
+Confirm in a browser with the Domain Posture section expanded:
+- "Intune coverage by category" label appears above the Intune grid (if Intune data is present)
+- "SharePoint & OneDrive posture" label appears above the SPO panel (if SPO data is present)
+- "Active Directory & hybrid posture" label appears above the AD/hybrid panel (if AD data present)
+- "Email authentication posture" label appears above the DNS auth panel (if DNS data present)
+- Panels with no data render nothing (component returns null internally — no orphan labels needed)
+
+Note on empty panels: IntuneCategoryGrid, MailboxSummaryPanel, SharePointSummaryPanel, AdHybridPanel, and DnsAuthPanel all already guard against empty data and return null. The posture-sub-label sits in the same wrapper div and will still render even when the panel below it is empty. To avoid orphan labels, conditionally render the wrapper:
+
+- For IntuneCategoryGrid: check `FINDINGS.filter(f => f.domain === 'Intune').length > 0`
+- For MailboxSummaryPanel: check `D.mailboxSummary` is truthy (already done inside component)
+- For SharePointSummaryPanel: check `FINDINGS.filter(f => f.domain === 'SharePoint & OneDrive').length > 0`
+- For AdHybridPanel: check `D.adHybrid` is truthy
+- For DnsAuthPanel: check `(D.dns || []).length > 0`
+
+Replace the wrappers with guarded versions:
+
+```jsx
+          {FINDINGS.some(f => f.domain === 'Intune') && (
+            <div id="identity-intune">
+              <div className="posture-sub-label">Intune coverage by category</div>
+              <IntuneCategoryGrid />
+            </div>
+          )}
+          {D.mailboxSummary && (
+            <div id="identity-mailbox">
+              <MailboxSummaryPanel />
+            </div>
+          )}
+          {FINDINGS.some(f => f.domain === 'SharePoint & OneDrive') && (
+            <div id="identity-sharepoint">
+              <div className="posture-sub-label">SharePoint &amp; OneDrive posture</div>
+              <SharePointSummaryPanel />
+            </div>
+          )}
+          {D.adHybrid && (
+            <div id="identity-ad">
+              <div className="posture-sub-label">Active Directory &amp; hybrid posture</div>
+              <AdHybridPanel />
+            </div>
+          )}
+          {(D.dns || []).length > 0 && (
+            <div id="identity-email">
+              <div className="posture-sub-label">Email authentication posture</div>
+              <DnsAuthPanel />
+            </div>
+          )}
+```
+
+- [ ] **Step 5: Mirror to report-app.js**
+
+Apply the guarded wrapper version to `report-app.js`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/M365-Assess/assets/report-app.jsx src/M365-Assess/assets/report-app.js src/M365-Assess/assets/report-shell.css
+git commit -m "feat(report): add posture subheadings to Domain Posture sub-panels (#670)"
+```
+
+---
+
+## Task 4: Persist nav open state — Roadmap and Domain Posture sidebar (#671)
+
+**Files:**
+- Modify: `src/M365-Assess/assets/report-app.jsx:119-228` (Sidebar component)
+- Modify: `src/M365-Assess/assets/report-app.js` (mirror)
+
+The Sidebar component currently:
+- Shows roadmap sub-nav only when `active === 'roadmap'` (line 184)
+- Shows roadmap expand icon reflecting `active === 'roadmap'` (line 180)
+- Has no sub-nav for Domain posture
+
+Changes needed:
+1. Add `roadmapOpen` state (localStorage-persisted) — sub-nav visible when `roadmapOpen` OR `active==='roadmap'`
+2. Add `domainNavOpen` state (localStorage-persisted) — controls Domain posture sub-items in sidebar
+3. Clicking the expand icon on either nav item toggles + persists state
+
+- [ ] **Step 1: Add state to Sidebar and update roadmap sub-nav**
+
+Replace the Sidebar function signature and add state declarations. The current signature at line 120 is:
+
+```javascript
+function Sidebar({ active, counts, domainCounts, activeDomain, onDomainJump, onOverviewClick, navOpen, onClose }) {
+```
+
+Add two state declarations right after the opening brace (before the DOM_ORDER const):
+
+```javascript
+function Sidebar({ active, counts, domainCounts, activeDomain, onDomainJump, onOverviewClick, navOpen, onClose }) {
+  const [roadmapOpen, setRoadmapOpen] = useState(() => {
+    try { return localStorage.getItem(LS('m365-nav-roadmap')) === 'true'; }
+    catch { return false; }
+  });
+  const [domainNavOpen, setDomainNavOpen] = useState(() => {
+    try { return localStorage.getItem(LS('m365-nav-domain')) === 'true'; }
+    catch { return false; }
+  });
+  function toggleRoadmap(e) {
+    e.preventDefault(); e.stopPropagation();
+    const next = !roadmapOpen;
+    setRoadmapOpen(next);
+    try { localStorage.setItem(LS('m365-nav-roadmap'), String(next)); } catch {}
+  }
+  function toggleDomainNav(e) {
+    e.preventDefault(); e.stopPropagation();
+    const next = !domainNavOpen;
+    setDomainNavOpen(next);
+    try { localStorage.setItem(LS('m365-nav-domain'), String(next)); } catch {}
+  }
+  const DOM_ORDER = ['Entra ID','Conditional Access','Enterprise Apps','Exchange Online','Intune','Defender','Purview / Compliance','SharePoint & OneDrive','Teams','Forms','Power BI','Active Directory','SOC 2','Value Opportunity'];
+  // ... rest unchanged
+```
+
+- [ ] **Step 2: Update roadmap expand icon and sub-nav condition**
+
+At line 179-190, find the roadmap expand icon and sub-nav block:
+
+```jsx
+                {it.id === 'roadmap'
+                  ? <span className="nav-expand-icon">{active === 'roadmap' ? '−' : '+'}</span>
+                  : it.count !== undefined && <span className="count">{it.count}</span>
+                }
+              </a>
+              {it.id === 'roadmap' && active === 'roadmap' && (
+                <div className="nav-subitems">
+                  <a href="#roadmap-now"   className="nav-subitem">Now   <span className="count">{ROADMAP_COUNTS.now}</span></a>
+                  <a href="#roadmap-next"  className="nav-subitem">Next  <span className="count">{ROADMAP_COUNTS.soon}</span></a>
+                  <a href="#roadmap-later" className="nav-subitem">Later <span className="count">{ROADMAP_COUNTS.later}</span></a>
+                </div>
+              )}
+```
+
+Replace with:
+
+```jsx
+                {it.id === 'roadmap'
+                  ? <span className="nav-expand-icon" onClick={toggleRoadmap}>{(roadmapOpen || active === 'roadmap') ? '\u2212' : '+'}</span>
+                  : it.count !== undefined && <span className="count">{it.count}</span>
+                }
+              </a>
+              {it.id === 'roadmap' && (roadmapOpen || active === 'roadmap') && (
+                <div className="nav-subitems">
+                  <a href="#roadmap-now"   className="nav-subitem">Now   <span className="count">{ROADMAP_COUNTS.now}</span></a>
+                  <a href="#roadmap-next"  className="nav-subitem">Next  <span className="count">{ROADMAP_COUNTS.soon}</span></a>
+                  <a href="#roadmap-later" className="nav-subitem">Later <span className="count">{ROADMAP_COUNTS.later}</span></a>
+                </div>
+              )}
+```
+
+Note: `\u2212` = − (minus sign, same as what was there before as literal `−`).
+
+- [ ] **Step 3: Add Domain posture expand icon and sub-items in exec loop**
+
+Find the exec.map block (lines 152-158):
+
+```jsx
+          {exec.map(it => (
+            <a href={`#${it.id}`} key={it.id}
+               onClick={e => { if (it.id === 'overview') { e.preventDefault(); onOverviewClick(); } closeIfMobile(); }}
+               className={'nav-item' + (active===it.id?' active':'')}>
+              <span>{it.label}</span>
+            </a>
+          ))}
+```
+
+Replace with a version that special-cases `identity`:
+
+```jsx
+          {exec.map(it => (
+            <React.Fragment key={it.id}>
+              <a href={`#${it.id}`}
+                 onClick={e => { if (it.id === 'overview') { e.preventDefault(); onOverviewClick(); } closeIfMobile(); }}
+                 className={'nav-item' + (active===it.id?' active':'')}>
+                <span>{it.label}</span>
+                {it.id === 'identity' && (
+                  <span className="nav-expand-icon" onClick={toggleDomainNav}>
+                    {domainNavOpen ? '\u2212' : '+'}
+                  </span>
+                )}
+              </a>
+              {it.id === 'identity' && domainNavOpen && (
+                <div className="nav-subitems">
+                  {FINDINGS.some(f => f.domain === 'Intune') && (
+                    <a href="#identity-intune" className="nav-subitem" onClick={closeIfMobile}>Intune coverage</a>
+                  )}
+                  {FINDINGS.some(f => f.domain === 'SharePoint & OneDrive') && (
+                    <a href="#identity-sharepoint" className="nav-subitem" onClick={closeIfMobile}>SharePoint &amp; OneDrive</a>
+                  )}
+                  {D.adHybrid && (
+                    <a href="#identity-ad" className="nav-subitem" onClick={closeIfMobile}>AD &amp; hybrid</a>
+                  )}
+                  {(D.dns || []).length > 0 && (
+                    <a href="#identity-email" className="nav-subitem" onClick={closeIfMobile}>Email auth</a>
+                  )}
+                </div>
+              )}
+            </React.Fragment>
+          ))}
+```
+
+- [ ] **Step 4: Mirror to report-app.js**
+
+Apply the identical Sidebar changes to `report-app.js`.
+
+- [ ] **Step 5: Verify visually**
+
+Confirm in a browser:
+- Clicking '+' next to Remediation roadmap opens the sub-nav and keeps it open when scrolling away
+- Clicking '+' next to Domain posture opens sub-items (Intune coverage, SharePoint & OneDrive, AD & hybrid, Email auth — each only if data is present)
+- Both states persist after a hard refresh
+- Both items' '+' becomes '−' when open
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/M365-Assess/assets/report-app.jsx src/M365-Assess/assets/report-app.js
+git commit -m "feat(report): persist sidebar nav open state for Roadmap and Domain Posture (#671)"
+```
+
+---
+
+## Task 5: Enrich tenant appendix (#672)
+
+**Files:**
+- Modify: `src/M365-Assess/assets/report-app.jsx:1794-1849` (Appendix component)
+- Modify: `src/M365-Assess/assets/report-app.js` (mirror)
+
+All data is already in `REPORT_DATA`. No PowerShell changes needed:
+- `TENANT` (line 6): OrgDisplayName, TenantId, DefaultDomain, CreatedDateTime, tenantAgeYears
+- `MFA_STATS` (line 10): phishResistant, standard, weak, none, adminsWithoutMfa, total
+- `D.adHybrid`: syncType, lastSync, pwHashSync, onPremSyncEnabled
+- `D.dns`: Domain, SPF, DMARC, DMARCPolicy, DKIM per domain
+- `D['admin-roles']`: RoleName, MemberDisplayName (all privileged roles, not just Global Admin)
+
+- [ ] **Step 1: Replace Appendix component**
+
+Replace the entire `Appendix` function (lines 1794-1849) with:
+
+```jsx
+// ======================== Appendix ========================
+function Appendix() {
+  // MFA coverage percentages
+  const mfaTotal = MFA_STATS.total || 1;
+  const mfaPct = n => Math.round((n / mfaTotal) * 100);
+
+  // DNS summary: count domains passing SPF, DKIM, DMARC
+  const dns = D.dns || [];
+  const dnsTotal = dns.length;
+  const spfPass  = dns.filter(r => r.SPF === 'Pass').length;
+  const dkimPass = dns.filter(r => r.DKIMStatus === 'Pass' || r.DKIM === 'Pass').length;
+  const dmarcEnf = dns.filter(r => r.DMARCPolicy === 'reject' || r.DMARCPolicy === 'quarantine').length;
+
+  // Admin roles: all unique privileged roles with member counts
+  const allRoles = D['admin-roles'] || [];
+  const roleCounts = allRoles.reduce((acc, r) => {
+    acc[r.RoleName] = (acc[r.RoleName] || 0) + 1;
+    return acc;
+  }, {});
+  const roleEntries = Object.entries(roleCounts).sort((a,b) => b[1] - a[1]);
+
+  // Hybrid sync
+  const ad = D.adHybrid;
+  const phsLabel = ad
+    ? (ad.pwHashSync === true ? 'Enabled' : ad.pwHashSync === null || ad.pwHashSync === undefined ? 'Verify' : 'Disabled')
+    : null;
+  const phsColor = ad
+    ? (ad.pwHashSync === true ? 'var(--success-text)' : ad.pwHashSync === null || ad.pwHashSync === undefined ? 'var(--warn-text)' : 'var(--danger-text)')
+    : 'var(--muted)';
+
+  const labelStyle = {fontSize:12,color:'var(--muted)',textTransform:'uppercase',letterSpacing:'.08em',fontWeight:600,marginBottom:10};
+  const rowStyle   = {borderTop:'1px solid var(--border)'};
+  const cellStyle  = {padding:'6px 0', fontSize:12};
+  const monoRight  = {textAlign:'right',fontFamily:'var(--font-mono)',fontVariantNumeric:'tabular-nums'};
+
+  return (
+    <section className="block" id="appendix">
+      <div className="section-head">
+        <span className="eyebrow">05 \xb7 Reference</span>
+        <h2>Tenant appendix</h2>
+        <div className="hr"/>
+      </div>
+
+      {/* Tenant info strip */}
+      <div className="card" style={{marginBottom:14}}>
+        <div style={labelStyle}>Tenant</div>
+        <div style={{display:'flex',flexWrap:'wrap',gap:'6px 24px',fontSize:12}}>
+          <span><span style={{color:'var(--muted)'}}>org</span> <b>{TENANT.OrgDisplayName}</b></span>
+          <span><span style={{color:'var(--muted)'}}>domain</span> <b>{TENANT.DefaultDomain}</b></span>
+          <span><span style={{color:'var(--muted)'}}>id</span> <span style={{fontFamily:'var(--font-mono)'}}>{TENANT.TenantId}</span></span>
+          {TENANT.tenantAgeYears != null && (
+            <span><span style={{color:'var(--muted)'}}>age</span> <b>{TENANT.tenantAgeYears} yrs</b></span>
+          )}
+          {TENANT.CreatedDateTime && (
+            <span><span style={{color:'var(--muted)'}}>created</span> <b>{TENANT.CreatedDateTime.slice(0,10)}</b></span>
+          )}
+        </div>
+      </div>
+
+      <div style={{display:'grid',gridTemplateColumns:'1fr 1fr',gap:14}}>
+
+        {/* Licenses */}
+        <div className="card">
+          <div style={labelStyle}>Licenses</div>
+          <table style={{width:'100%',fontSize:12,borderCollapse:'collapse'}}>
+            <thead><tr style={{textAlign:'left',color:'var(--muted)'}}><th style={{padding:'6px 0'}}>SKU</th><th style={{textAlign:'right'}}>Assigned</th><th style={{textAlign:'right'}}>Total</th></tr></thead>
+            <tbody>
+              {D.licenses.filter(l => parseInt(l.Assigned) > 0).map((l,i)=>(
+                <tr key={i} style={rowStyle}>
+                  <td style={cellStyle}>{l.License}</td>
+                  <td style={{...cellStyle,...monoRight}}>{l.Assigned}</td>
+                  <td style={{...cellStyle,...monoRight,color:'var(--muted)'}}>{l.Total}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* MFA coverage */}
+        <div className="card">
+          <div style={labelStyle}>MFA coverage ({fmt(mfaTotal)} users)</div>
+          <table style={{width:'100%',fontSize:12,borderCollapse:'collapse'}}>
+            <tbody>
+              {MFA_STATS.phishResistant > 0 && (
+                <tr style={rowStyle}>
+                  <td style={cellStyle}>Phish-resistant</td>
+                  <td style={{...cellStyle,...monoRight}}>{fmt(MFA_STATS.phishResistant)}</td>
+                  <td style={{...cellStyle,...monoRight,color:'var(--success-text)'}}>{mfaPct(MFA_STATS.phishResistant)}%</td>
+                </tr>
+              )}
+              {MFA_STATS.standard > 0 && (
+                <tr style={rowStyle}>
+                  <td style={cellStyle}>Standard MFA</td>
+                  <td style={{...cellStyle,...monoRight}}>{fmt(MFA_STATS.standard)}</td>
+                  <td style={{...cellStyle,...monoRight,color:'var(--text-soft)'}}>{mfaPct(MFA_STATS.standard)}%</td>
+                </tr>
+              )}
+              {MFA_STATS.weak > 0 && (
+                <tr style={rowStyle}>
+                  <td style={cellStyle}>Weak (SMS/voice)</td>
+                  <td style={{...cellStyle,...monoRight}}>{fmt(MFA_STATS.weak)}</td>
+                  <td style={{...cellStyle,...monoRight,color:'var(--warn-text)'}}>{mfaPct(MFA_STATS.weak)}%</td>
+                </tr>
+              )}
+              <tr style={rowStyle}>
+                <td style={cellStyle}>No MFA</td>
+                <td style={{...cellStyle,...monoRight}}>{fmt(MFA_STATS.none)}</td>
+                <td style={{...cellStyle,...monoRight,color:MFA_STATS.none>0?'var(--danger-text)':'var(--muted)'}}>{mfaPct(MFA_STATS.none)}%</td>
+              </tr>
+              {MFA_STATS.adminsWithoutMfa > 0 && (
+                <tr style={rowStyle}>
+                  <td style={{...cellStyle,color:'var(--danger-text)',fontWeight:600}}>Admins without MFA</td>
+                  <td style={{...cellStyle,...monoRight,color:'var(--danger-text)',fontWeight:600}}>{fmt(MFA_STATS.adminsWithoutMfa)}</td>
+                  <td style={cellStyle}/>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Conditional Access */}
+        <div className="card">
+          <div style={labelStyle}>Conditional Access policies ({D.ca.length})</div>
+          <table style={{width:'100%',fontSize:12,borderCollapse:'collapse'}}>
+            <tbody>
+              {D.ca.map((r,i)=>(
+                <tr key={i} style={rowStyle}>
+                  <td style={cellStyle}>{r.DisplayName}</td>
+                  <td style={{textAlign:'right',paddingRight:6}}><StatusDot ok={r.State==='enabled'} warn={r.State?.includes('Report')}/></td>
+                  <td style={{...cellStyle,textAlign:'right',color:'var(--muted)'}}>{r.State}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Privileged roles */}
+        <div className="card">
+          <div style={labelStyle}>Privileged roles ({allRoles.length} assignments)</div>
+          <table style={{width:'100%',fontSize:12,borderCollapse:'collapse'}}>
+            <tbody>
+              {roleEntries.map(([role, count], i) => (
+                <tr key={i} style={rowStyle}>
+                  <td style={cellStyle}>{role}</td>
+                  <td style={{...cellStyle,...monoRight,color:'var(--muted)'}}>{count}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Email authentication */}
+        {dnsTotal > 0 && (
+          <div className="card">
+            <div style={labelStyle}>Email authentication ({dnsTotal} domain{dnsTotal!==1?'s':''})</div>
+            <table style={{width:'100%',fontSize:12,borderCollapse:'collapse'}}>
+              <tbody>
+                <tr style={rowStyle}>
+                  <td style={cellStyle}>SPF passing</td>
+                  <td style={{...cellStyle,...monoRight,color:spfPass===dnsTotal?'var(--success-text)':spfPass>0?'var(--warn-text)':'var(--danger-text)'}}>{spfPass}/{dnsTotal}</td>
+                </tr>
+                <tr style={rowStyle}>
+                  <td style={cellStyle}>DKIM passing</td>
+                  <td style={{...cellStyle,...monoRight,color:dkimPass===dnsTotal?'var(--success-text)':dkimPass>0?'var(--warn-text)':'var(--danger-text)'}}>{dkimPass}/{dnsTotal}</td>
+                </tr>
+                <tr style={rowStyle}>
+                  <td style={cellStyle}>DMARC enforced</td>
+                  <td style={{...cellStyle,...monoRight,color:dmarcEnf===dnsTotal?'var(--success-text)':dmarcEnf>0?'var(--warn-text)':'var(--danger-text)'}}>{dmarcEnf}/{dnsTotal}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* Hybrid sync */}
+        {ad && (
+          <div className="card">
+            <div style={labelStyle}>Hybrid sync</div>
+            <table style={{width:'100%',fontSize:12,borderCollapse:'collapse'}}>
+              <tbody>
+                <tr style={rowStyle}>
+                  <td style={cellStyle}>Sync type</td>
+                  <td style={{...cellStyle,textAlign:'right'}}>{ad.syncType || 'Cloud-only'}</td>
+                </tr>
+                <tr style={rowStyle}>
+                  <td style={cellStyle}>Password hash sync</td>
+                  <td style={{...cellStyle,textAlign:'right',color:phsColor,fontWeight:600}}>{phsLabel}</td>
+                </tr>
+                {ad.lastSync && (
+                  <tr style={rowStyle}>
+                    <td style={cellStyle}>Last sync</td>
+                    <td style={{...cellStyle,textAlign:'right',fontFamily:'var(--font-mono)'}}>{String(ad.lastSync).slice(0,19).replace('T',' ')}</td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+      </div>
+    </section>
+  );
+}
+```
+
+Note on `\xb7`: the eyebrow uses `·` (middle dot U+00B7) as a JS escape. If the file uses literal `·` elsewhere, use the literal character consistently.
+
+- [ ] **Step 2: Mirror to report-app.js**
+
+Apply the identical Appendix replacement to `report-app.js`.
+
+- [ ] **Step 3: Verify visually**
+
+Open a generated report and confirm the appendix shows:
+- Tenant info strip (org name, domain, tenant ID, age, creation date)
+- Licenses table (unchanged from before)
+- MFA coverage table with percentages
+- CA policies table with count in header
+- Privileged roles table (all roles, not just Global Admin)
+- Email authentication summary card (if DNS data present)
+- Hybrid sync card (if adHybrid data present)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/M365-Assess/assets/report-app.jsx src/M365-Assess/assets/report-app.js
+git commit -m "feat(report): enrich tenant appendix with MFA, email auth, hybrid sync, privileged roles (#672)"
+```
+
+---
+
+## Task 6: Open PR
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin feat/v2.4.0-report-ux
+```
+
+- [ ] **Step 2: Create PR**
+
+```bash
+gh pr create \
+  --title "feat(report): v2.4.0 UX — section reorder, expandable domain posture, nav persistence, appendix enrichment" \
+  --body "Closes #669, closes #670, closes #671, closes #672
+
+## Changes
+- Frameworks panel moved above Domain Posture in home view and sidebar nav (#669)
+- Domain Posture section is now expandable/collapsible with a chevron; state persists to localStorage (#670)
+- Four posture subheadings added inside Domain Posture: Intune, SharePoint & OneDrive, AD & hybrid, Email auth (#670)
+- Remediation Roadmap and Domain Posture sidebar nav open state persists via localStorage (#671)
+- Domain Posture sidebar item now has expand sub-items linking to subheadings (#671)
+- Tenant appendix enriched with MFA coverage, privileged roles, email auth summary, hybrid sync card, full tenant info strip (#672)
+
+## Test plan
+- [ ] CI passes (no PS changes, CI runs Pester which shouldn't be affected)
+- [ ] Framework Coverage appears above Security posture by domain in report
+- [ ] Domain Posture chevron toggles section; refresh restores state
+- [ ] Subheadings render only when data is present for that domain
+- [ ] Roadmap nav stays open after scrolling away when manually toggled
+- [ ] Appendix shows new cards for MFA, roles, email auth, hybrid sync
+"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Requirement | Task |
+|-------------|------|
+| Move frameworks above domain posture (#669) | Task 1 ✓ |
+| Domain posture expandable with chevron (#670) | Task 2 ✓ |
+| Intune, SPO, AD/hybrid, Email auth subheadings (#670) | Task 3 ✓ |
+| Roadmap nav state persists (#671) | Task 4 ✓ |
+| Domain posture nav state persists (#671) | Task 4 ✓ |
+| Enrich tenant appendix (#672) | Task 5 ✓ |
+
+**Placeholder scan:** None — all code blocks are complete implementations.
+
+**Type consistency:**
+- `LS()` helper used consistently for all new localStorage keys
+- `D.adHybrid.pwHashSync` tri-state check matches the pattern established in report-app.jsx (null = Verify, true = Enabled, false = Disabled)
+- `D.dns` array used consistently with `.length > 0` guard in both Task 3 and Task 5
+- `FINDINGS.some(f => f.domain === 'Intune')` guard in Task 3 matches domain strings used in Task 4 sidebar sub-items
+- `ad.syncType`, `ad.lastSync`, `ad.pwHashSync` property names match the adHybridData shape from `Build-ReportData.ps1` (lines 296-314)

--- a/src/M365-Assess/Common/Build-ReportData.ps1
+++ b/src/M365-Assess/Common/Build-ReportData.ps1
@@ -141,7 +141,11 @@ function Build-ReportDataJson {
                        elseif ($f.PSObject.Properties['Recommended'])   { $f.Recommended }
                        else                                              { '' }
 
-        $learnMore = if ($regEntry -and $regEntry.references -and $regEntry.references.Count -gt 0) { [string]$regEntry.references[0].url } else { $null }
+        $references = if ($regEntry -and $regEntry.references -and $regEntry.references.Count -gt 0) {
+                         @($regEntry.references | Select-Object url, title)
+                     } else { @() }
+        $impact     = if ($regEntry) { $regEntry.impact }    else { $null }
+        $rationale  = if ($regEntry) { $regEntry.rationale } else { $null }
         $evidence  = if ($f.PSObject.Properties['Evidence'] -and $null -ne $f.Evidence) {
                          $f.Evidence | ConvertTo-Json -Depth 5 -Compress
                      } else { $null }
@@ -162,7 +166,9 @@ function Build-ReportDataJson {
             fwMeta       = $fwMeta
             intentDesign    = [bool]($f.PSObject.Properties['IntentDesign'] -and $f.IntentDesign)
             intentRationale = if ($f.PSObject.Properties['ImpactRationale'] -and $f.ImpactRationale) { [string]$f.ImpactRationale } else { $null }
-            learnMore    = $learnMore
+            references   = $references
+            impact       = $impact
+            rationale    = $rationale
             evidence     = $evidence
         })
     }

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -2551,13 +2551,22 @@ function FindingsTable({
       className: "block-title"
     }, "Recommended value"), /*#__PURE__*/React.createElement("div", {
       className: "value-box recommended"
-    }, f.recommended || '—')), f.learnMore && /*#__PURE__*/React.createElement("div", {
+    }, f.recommended || '—')), f.remediation && /*#__PURE__*/React.createElement("div", {
+      className: "finding-remediation"
+    }, /*#__PURE__*/React.createElement("div", {
+      className: "block-title"
+    }, "Remediation"), /*#__PURE__*/React.createElement("div", {
+      className: "remediation-text"
+    }, f.remediation)), f.references && f.references.length > 0 && /*#__PURE__*/React.createElement("div", {
       className: "finding-learn-more"
-    }, /*#__PURE__*/React.createElement("a", {
-      href: f.learnMore,
+    }, /*#__PURE__*/React.createElement("div", {
+      className: "block-title"
+    }, "Learn more"), f.references.map((r, i) => /*#__PURE__*/React.createElement("a", {
+      key: i,
+      href: r.url,
       target: "_blank",
       rel: "noreferrer noopener"
-    }, "Learn more on Microsoft Docs \u2197")), f.evidence && /*#__PURE__*/React.createElement("details", {
+    }, "📖 ", r.title, " \u2197"))), f.evidence && /*#__PURE__*/React.createElement("details", {
       className: "finding-evidence"
     }, /*#__PURE__*/React.createElement("summary", null, "Evidence"), /*#__PURE__*/React.createElement("pre", null, JSON.stringify(JSON.parse(f.evidence), null, 2)))));
   })));
@@ -2673,7 +2682,7 @@ function Roadmap({
       items.forEach(t => {
         const fw = FW_PREF_RM.find(k => t.fwMeta?.[k]?.controlId);
         const ref = fw ? `${fw}: ${t.fwMeta[fw].controlId}` : '';
-        rows.push([label, t.setting, t.checkId, t.severity, t.effort ?? 'medium', t.category, t.section, t.currentValue, t.recommendedValue, t.remediation, t.learnMore ?? '', ref].map(esc).join(','));
+        rows.push([label, t.setting, t.checkId, t.severity, t.effort ?? 'medium', t.category, t.section, t.currentValue, t.recommendedValue, t.remediation, (t.references && t.references.length > 0 ? t.references[0].url : ''), ref].map(esc).join(','));
       });
     });
     return rows.join('\r\n');
@@ -2830,7 +2839,27 @@ function Roadmap({
       className: "task-field-label"
     }, "Business rationale"), /*#__PURE__*/React.createElement("div", {
       className: "task-field-value"
-    }, t.rationale)), /*#__PURE__*/React.createElement("div", {
+    }, t.rationale)), t.references && t.references.length > 0 && /*#__PURE__*/React.createElement("div", {
+      className: "task-field"
+    }, /*#__PURE__*/React.createElement("div", {
+      className: "task-field-label"
+    }, "Learn more"), /*#__PURE__*/React.createElement("div", {
+      className: "task-field-value",
+      style: {
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '4px'
+      }
+    }, t.references.map((r, i) => /*#__PURE__*/React.createElement("a", {
+      key: i,
+      href: r.url,
+      target: "_blank",
+      rel: "noreferrer noopener",
+      style: {
+        color: 'var(--accent-text)',
+        textDecoration: 'none'
+      }
+    }, "📖 ", r.title, " \u2197")))), /*#__PURE__*/React.createElement("div", {
       className: "task-meta-row"
     }, /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, "Section:"), " ", t.section), /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, "Severity:"), " ", SEV_LABEL[t.severity]), t.effort && /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, "Effort:"), " ", t.effort), /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, "Frameworks:"), " ", t.frameworks.join(', ') || '—')), /*#__PURE__*/React.createElement("div", {
       className: "task-actions"
@@ -2840,11 +2869,7 @@ function Roadmap({
         e.preventDefault();
         onViewFinding?.(t.checkId);
       }
-    }, "View in findings table \u2192"), t.learnMore && /*#__PURE__*/React.createElement("a", {
-      href: t.learnMore,
-      target: "_blank",
-      rel: "noreferrer noopener"
-    }, "Learn more on Microsoft Docs \u2197"))));
+    }, "View in findings table \u2192"))));
   };
   const LaneReset = ({
     laneItems

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -1501,9 +1501,18 @@ function FindingsTable({ filters, search, focusFinding, onFocusClear, editMode, 
                     <div className="block-title">Recommended value</div>
                     <div className="value-box recommended">{f.recommended || '—'}</div>
                   </div>
-                  {f.learnMore && (
+                  {f.remediation && (
+                    <div className="finding-remediation">
+                      <div className="block-title">Remediation</div>
+                      <div className="remediation-text">{f.remediation}</div>
+                    </div>
+                  )}
+                  {f.references && f.references.length > 0 && (
                     <div className="finding-learn-more">
-                      <a href={f.learnMore} target="_blank" rel="noreferrer noopener">Learn more on Microsoft Docs ↗</a>
+                      <div className="block-title">Learn more</div>
+                      {f.references.map((r, i) => (
+                        <a key={i} href={r.url} target="_blank" rel="noreferrer noopener">📖 {r.title} ↗</a>
+                      ))}
                     </div>
                   )}
                   {f.evidence && (
@@ -1606,7 +1615,7 @@ function Roadmap({ onViewFinding, editMode, hiddenFindings, roadmapOverrides, on
         const ref = fw ? `${fw}: ${t.fwMeta[fw].controlId}` : '';
         rows.push([label, t.setting, t.checkId, t.severity, t.effort ?? 'medium',
                    t.category, t.section, t.currentValue, t.recommendedValue,
-                   t.remediation, t.learnMore ?? '', ref].map(esc).join(','));
+                   t.remediation, (t.references && t.references.length > 0 ? t.references[0].url : ''), ref].map(esc).join(','));
       });
     });
     return rows.join('\r\n');
@@ -1705,6 +1714,18 @@ function Roadmap({ onViewFinding, editMode, hiddenFindings, roadmapOverrides, on
                 <div className="task-field-value">{t.rationale}</div>
               </div>
             )}
+            {t.references && t.references.length > 0 && (
+              <div className="task-field">
+                <div className="task-field-label">Learn more</div>
+                <div className="task-field-value" style={{display:'flex',flexDirection:'column',gap:'4px'}}>
+                  {t.references.map((r, i) => (
+                    <a key={i} href={r.url} target="_blank" rel="noreferrer noopener" style={{color:'var(--accent-text)',textDecoration:'none'}}>
+                      📖 {r.title} ↗
+                    </a>
+                  ))}
+                </div>
+              </div>
+            )}
             <div className="task-meta-row">
               <span><b>Section:</b> {t.section}</span>
               <span><b>Severity:</b> {SEV_LABEL[t.severity]}</span>
@@ -1716,9 +1737,6 @@ function Roadmap({ onViewFinding, editMode, hiddenFindings, roadmapOverrides, on
                 e.preventDefault();
                 onViewFinding?.(t.checkId);
               }}>View in findings table →</a>
-              {t.learnMore && (
-                <a href={t.learnMore} target="_blank" rel="noreferrer noopener">Learn more on Microsoft Docs ↗</a>
-              )}
             </div>
           </div>
         )}

--- a/src/M365-Assess/assets/report-shell.css
+++ b/src/M365-Assess/assets/report-shell.css
@@ -712,9 +712,17 @@ mark.search-hl {
   font-size: 12.5px; line-height: 1.6;
   color: var(--text);
 }
+.finding-remediation {
+  grid-column: 1 / -1;
+  padding-top: 4px;
+}
+.finding-detail .remediation-text {
+  font-size: 13px; line-height: 1.6; color: var(--text);
+}
 .finding-learn-more {
   grid-column: 1 / -1;
   padding-top: 2px;
+  display: flex; flex-direction: column; gap: 6px;
 }
 .finding-learn-more a {
   font-size: 12px; color: var(--accent-text); text-decoration: none;

--- a/tests/Common/Build-ReportData.Tests.ps1
+++ b/tests/Common/Build-ReportData.Tests.ps1
@@ -166,19 +166,22 @@ Describe 'Build-ReportData' {
             $d.findings[0].effort | Should -Be 'medium'
         }
 
-        It 'should propagate learnMore URL from registry references[0].url' {
+        It 'should propagate references array from registry with url and title' {
             $f = New-Finding -CheckId 'CA-LEGACYAUTH-001.1'
             $url = 'https://learn.microsoft.com/en-us/entra/identity/conditional-access/block-legacy-authentication'
             $registry = @{ 'CA-LEGACYAUTH-001' = @{ riskSeverity = 'Critical'; frameworks = @{}; references = @(@{ url = $url; title = 'Docs' }) } }
             $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @($f) -RegistryData $registry)
-            $d.findings[0].learnMore | Should -Be $url
+            $d.findings[0].references | Should -HaveCount 1
+            $d.findings[0].references[0].url | Should -Be $url
+            $d.findings[0].references[0].title | Should -Be 'Docs'
         }
 
-        It 'should set learnMore to null when references array is absent' {
+        It 'should emit empty references when registry has no references' {
             $f = New-Finding -CheckId 'CA-LEGACYAUTH-001.1'
             $registry = @{ 'CA-LEGACYAUTH-001' = @{ riskSeverity = 'Critical'; frameworks = @{} } }
             $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @($f) -RegistryData $registry)
-            $d.findings[0].PSObject.Properties['learnMore'] | Should -Not -BeNullOrEmpty -Because 'field must exist even when null'
+            # Empty @() serializes as null in ConvertTo-Json; either null or empty array is acceptable
+            $d.findings[0].references.Count | Should -Be 0
         }
     }
 


### PR DESCRIPTION
## Summary

- Replaces the single `learnMore` URL field with `references[]`, `impact`, and `rationale` sourced from `registry.json`
- Findings expansion panel now shows a **Remediation** block (guidance text + portal steps) and a **Learn more** block (all titled links as `📖 {title} ↗`)
- Roadmap cards show the same titled links in place of the old raw URL
- Blocks are conditional — findings with no registry entry render neither block

## Test Plan

- [x] `Invoke-Pester -Path './tests' -Output Detailed` — 2075 passing, 0 failures
- [x] No `learnMore` references remain in `report-app.jsx` or `report-app.js`
- [x] `report-app.js` is fully compiled `React.createElement` (no raw JSX)
- [ ] Open HTML report, expand any Fail/Warning finding → Remediation text + titled Learn links visible
- [ ] Open Roadmap section, expand a card → multiple titled links rendered
- [ ] Expand a finding with no registry match → no Remediation or Learn more block

Closes #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)