### PR TITLE
fix(ci): remove doubled scope in Dependabot commit prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
       - "dependencies"
       - "chore"
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "chore"
       include: "scope"
     groups:
       actions-minor-and-patch:
@@ -39,8 +39,7 @@ updates:
       - "dependencies"
       - "chore"
     commit-message:
-      prefix: "chore(deps)"
-      prefix-development: "chore(deps-dev)"
+      prefix: "chore"
       include: "scope"
     groups:
       babel-minor-and-patch:


### PR DESCRIPTION
## Summary

Fixes a config bug introduced in #677 that caused Dependabot's first wave of PRs (#679–#683) to have titles like `chore(deps)(deps): Bump actions/checkout from 4 to 6` — the `(deps)` scope is duplicated and violates conventional-commits parsing.

## Related Issues

Follow-up to #677. Affects the 5 open Dependabot PRs (#679–#683).

## Root cause

When `commit-message.include: "scope"` is set, Dependabot **auto-inserts** `(deps)` for production deps or `(deps-dev)` for dev deps *after* whatever `prefix` you supply. The original config had `prefix: "chore(deps)"` **and** `include: "scope"` together, producing:

```
chore(deps) + (deps) + :  →  chore(deps)(deps):
```

## Fix

- Change `prefix` on both ecosystems from `"chore(deps)"` to `"chore"`
- Remove the now-redundant `prefix-development: "chore(deps-dev)"` from the npm block — `include: "scope"` switches to `(deps-dev)` for dev deps on its own

Resulting subject lines will be:
- Actions / runtime npm: `chore(deps): Bump foo from 1.0 to 1.1`
- Dev npm: `chore(deps-dev): Bump foo from 1.0 to 1.1`

Both are valid conventional commits and will pass `commit-guard`.

## What happens to #679–#683 after merge

On the next Dependabot scan, those 5 PRs will be superseded by new PRs with corrected titles. No manual cleanup needed — Dependabot closes stale PRs automatically when the config that produced them changes. You can force the rescan via **Insights → Dependency graph → Dependabot → "Check for updates"** on `github-actions` instead of waiting for the next Monday cron.

## Changes

- `.github/dependabot.yml`: 2-line fix on the two `commit-message` blocks

## Test Plan

- [x] YAML re-validated locally (`python -c "import yaml; yaml.safe_load(...)"` passes)
- [x] PSScriptAnalyzer — N/A (no PS changes)
- [x] Pester tests — N/A (CI-only config change)
- [x] Ran against test tenant — N/A
- [x] HTML report renders correctly — N/A
- [x] No secrets or tenant PII — verified
- [ ] After merge: trigger **Check for updates** on the `github-actions` ecosystem; confirm new PRs open with `chore(deps): Bump ...` titles (single scope)
- [ ] Confirm `commit-guard` passes on the new PRs

## Breaking Changes

None.