### PR TITLE
fix(report): repair Appendix paren mismatch + Babel build CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,10 @@ jobs:
           }
           Write-Host "PSScriptAnalyzer: All checks passed" -ForegroundColor Green
 
+      - name: JS syntax check
+        shell: bash
+        run: node --check src/M365-Assess/assets/report-app.js
+
       - name: Smoke tests
         shell: pwsh
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,12 +74,11 @@ jobs:
         shell: bash
         run: |
           npm ci --ignore-scripts
-          cp src/M365-Assess/assets/report-app.js src/M365-Assess/assets/report-app.js.bak
           npm run build
           node --check src/M365-Assess/assets/report-app.js
-          if ! diff -q src/M365-Assess/assets/report-app.js.bak src/M365-Assess/assets/report-app.js > /dev/null 2>&1; then
+          if git diff --name-only | grep -q "report-app.js"; then
             echo "::error::report-app.js is out of sync with report-app.jsx — run 'npm run build' and commit the result"
-            diff src/M365-Assess/assets/report-app.js.bak src/M365-Assess/assets/report-app.js | head -40
+            git diff src/M365-Assess/assets/report-app.js | head -60
             exit 1
           fi
           echo "JS build check passed — report-app.js matches Babel output"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,19 @@ jobs:
           }
           Write-Host "PSScriptAnalyzer: All checks passed" -ForegroundColor Green
 
-      - name: JS syntax check
+      - name: JS build check
         shell: bash
-        run: node --check src/M365-Assess/assets/report-app.js
+        run: |
+          npm ci --ignore-scripts
+          cp src/M365-Assess/assets/report-app.js src/M365-Assess/assets/report-app.js.bak
+          npm run build
+          node --check src/M365-Assess/assets/report-app.js
+          if ! diff -q src/M365-Assess/assets/report-app.js.bak src/M365-Assess/assets/report-app.js > /dev/null 2>&1; then
+            echo "::error::report-app.js is out of sync with report-app.jsx — run 'npm run build' and commit the result"
+            diff src/M365-Assess/assets/report-app.js.bak src/M365-Assess/assets/report-app.js | head -40
+            exit 1
+          fi
+          echo "JS build check passed — report-app.js matches Babel output"
 
       - name: Smoke tests
         shell: pwsh

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "build": "babel src/M365-Assess/assets/report-app.jsx --presets @babel/preset-react --out-file src/M365-Assess/assets/report-app.js"
   },
   "devDependencies": {
-    "@babel/cli": "^7.24.0",
-    "@babel/core": "^7.24.0",
-    "@babel/preset-react": "^7.24.0"
+    "@babel/cli": "^7.28.0",
+    "@babel/core": "^7.28.0",
+    "@babel/preset-react": "^7.28.0"
   }
 }

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -333,11 +333,13 @@ function Sidebar({
   const [roadmapOpen, setRoadmapOpen] = useState(false);
   const [domainNavOpen, setDomainNavOpen] = useState(false);
   function toggleRoadmap(e) {
-    e.preventDefault(); e.stopPropagation();
+    e.preventDefault();
+    e.stopPropagation();
     setRoadmapOpen(o => !o);
   }
   function toggleDomainNav(e) {
-    e.preventDefault(); e.stopPropagation();
+    e.preventDefault();
+    e.stopPropagation();
     setDomainNavOpen(o => !o);
   }
   const DOM_ORDER = ['Entra ID', 'Conditional Access', 'Enterprise Apps', 'Exchange Online', 'Intune', 'Defender', 'Purview / Compliance', 'SharePoint & OneDrive', 'Teams', 'Forms', 'Power BI', 'Active Directory', 'SOC 2', 'Value Opportunity'];
@@ -463,7 +465,7 @@ function Sidebar({
   }, /*#__PURE__*/React.createElement("span", null, it.label), it.id === 'roadmap' ? /*#__PURE__*/React.createElement("span", {
     className: "nav-expand-icon",
     onClick: toggleRoadmap
-  }, (roadmapOpen || active === 'roadmap') ? '\u2212' : '+') : it.count !== undefined && /*#__PURE__*/React.createElement("span", {
+  }, roadmapOpen || active === 'roadmap' ? '\u2212' : '+') : it.count !== undefined && /*#__PURE__*/React.createElement("span", {
     className: "count"
   }, it.count)), it.id === 'roadmap' && (roadmapOpen || active === 'roadmap') && /*#__PURE__*/React.createElement("div", {
     className: "nav-subitems"
@@ -2566,7 +2568,7 @@ function FindingsTable({
       href: r.url,
       target: "_blank",
       rel: "noreferrer noopener"
-    }, "📖 ", r.title, " \u2197"))), f.evidence && /*#__PURE__*/React.createElement("details", {
+    }, "\uD83D\uDCD6 ", r.title, " \u2197"))), f.evidence && /*#__PURE__*/React.createElement("details", {
       className: "finding-evidence"
     }, /*#__PURE__*/React.createElement("summary", null, "Evidence"), /*#__PURE__*/React.createElement("pre", null, JSON.stringify(JSON.parse(f.evidence), null, 2)))));
   })));
@@ -2682,7 +2684,7 @@ function Roadmap({
       items.forEach(t => {
         const fw = FW_PREF_RM.find(k => t.fwMeta?.[k]?.controlId);
         const ref = fw ? `${fw}: ${t.fwMeta[fw].controlId}` : '';
-        rows.push([label, t.setting, t.checkId, t.severity, t.effort ?? 'medium', t.category, t.section, t.currentValue, t.recommendedValue, t.remediation, (t.references && t.references.length > 0 ? t.references[0].url : ''), ref].map(esc).join(','));
+        rows.push([label, t.setting, t.checkId, t.severity, t.effort ?? 'medium', t.category, t.section, t.currentValue, t.recommendedValue, t.remediation, t.references && t.references.length > 0 ? t.references[0].url : '', ref].map(esc).join(','));
       });
     });
     return rows.join('\r\n');
@@ -2859,7 +2861,7 @@ function Roadmap({
         color: 'var(--accent-text)',
         textDecoration: 'none'
       }
-    }, "📖 ", r.title, " \u2197")))), /*#__PURE__*/React.createElement("div", {
+    }, "\uD83D\uDCD6 ", r.title, " \u2197")))), /*#__PURE__*/React.createElement("div", {
       className: "task-meta-row"
     }, /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, "Section:"), " ", t.section), /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, "Severity:"), " ", SEV_LABEL[t.severity]), t.effort && /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, "Effort:"), " ", t.effort), /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, "Frameworks:"), " ", t.frameworks.join(', ') || '—')), /*#__PURE__*/React.createElement("div", {
       className: "task-actions"
@@ -3251,11 +3253,13 @@ function Appendix() {
   }, /*#__PURE__*/React.createElement("td", {
     style: cellStyle
   }, l.License), /*#__PURE__*/React.createElement("td", {
-    style: { ...cellStyle,
+    style: {
+      ...cellStyle,
       ...monoRight
     }
   }, l.Assigned), /*#__PURE__*/React.createElement("td", {
-    style: { ...cellStyle,
+    style: {
+      ...cellStyle,
       ...monoRight,
       color: 'var(--muted)'
     }
@@ -3274,11 +3278,13 @@ function Appendix() {
   }, /*#__PURE__*/React.createElement("td", {
     style: cellStyle
   }, "Phish-resistant"), /*#__PURE__*/React.createElement("td", {
-    style: { ...cellStyle,
+    style: {
+      ...cellStyle,
       ...monoRight
     }
   }, fmt(MFA_STATS.phishResistant)), /*#__PURE__*/React.createElement("td", {
-    style: { ...cellStyle,
+    style: {
+      ...cellStyle,
       ...monoRight,
       color: 'var(--success-text)'
     }
@@ -3287,11 +3293,13 @@ function Appendix() {
   }, /*#__PURE__*/React.createElement("td", {
     style: cellStyle
   }, "Standard MFA"), /*#__PURE__*/React.createElement("td", {
-    style: { ...cellStyle,
+    style: {
+      ...cellStyle,
       ...monoRight
     }
   }, fmt(MFA_STATS.standard)), /*#__PURE__*/React.createElement("td", {
-    style: { ...cellStyle,
+    style: {
+      ...cellStyle,
       ...monoRight,
       color: 'var(--text-soft)'
     }
@@ -3300,11 +3308,13 @@ function Appendix() {
   }, /*#__PURE__*/React.createElement("td", {
     style: cellStyle
   }, "Weak (SMS/voice)"), /*#__PURE__*/React.createElement("td", {
-    style: { ...cellStyle,
+    style: {
+      ...cellStyle,
       ...monoRight
     }
   }, fmt(MFA_STATS.weak)), /*#__PURE__*/React.createElement("td", {
-    style: { ...cellStyle,
+    style: {
+      ...cellStyle,
       ...monoRight,
       color: 'var(--warn-text)'
     }
@@ -3313,23 +3323,27 @@ function Appendix() {
   }, /*#__PURE__*/React.createElement("td", {
     style: cellStyle
   }, "No MFA"), /*#__PURE__*/React.createElement("td", {
-    style: { ...cellStyle,
+    style: {
+      ...cellStyle,
       ...monoRight
     }
   }, fmt(MFA_STATS.none)), /*#__PURE__*/React.createElement("td", {
-    style: { ...cellStyle,
+    style: {
+      ...cellStyle,
       ...monoRight,
       color: MFA_STATS.none > 0 ? 'var(--danger-text)' : 'var(--muted)'
     }
   }, mfaPct(MFA_STATS.none), "%")), MFA_STATS.adminsWithoutMfa > 0 && /*#__PURE__*/React.createElement("tr", {
     style: rowStyle
   }, /*#__PURE__*/React.createElement("td", {
-    style: { ...cellStyle,
+    style: {
+      ...cellStyle,
       color: 'var(--danger-text)',
       fontWeight: 600
     }
   }, "Admins without MFA"), /*#__PURE__*/React.createElement("td", {
-    style: { ...cellStyle,
+    style: {
+      ...cellStyle,
       ...monoRight,
       color: 'var(--danger-text)',
       fontWeight: 600
@@ -3360,7 +3374,8 @@ function Appendix() {
     ok: r.State === 'enabled',
     warn: r.State?.includes('Report')
   })), /*#__PURE__*/React.createElement("td", {
-    style: { ...cellStyle,
+    style: {
+      ...cellStyle,
       textAlign: 'right',
       color: 'var(--muted)'
     }
@@ -3380,7 +3395,8 @@ function Appendix() {
   }, /*#__PURE__*/React.createElement("td", {
     style: cellStyle
   }, role), /*#__PURE__*/React.createElement("td", {
-    style: { ...cellStyle,
+    style: {
+      ...cellStyle,
       ...monoRight,
       color: 'var(--muted)'
     }
@@ -3399,7 +3415,8 @@ function Appendix() {
   }, /*#__PURE__*/React.createElement("td", {
     style: cellStyle
   }, "SPF passing"), /*#__PURE__*/React.createElement("td", {
-    style: { ...cellStyle,
+    style: {
+      ...cellStyle,
       ...monoRight,
       color: spfPass === dnsTotal ? 'var(--success-text)' : spfPass > 0 ? 'var(--warn-text)' : 'var(--danger-text)'
     }
@@ -3408,7 +3425,8 @@ function Appendix() {
   }, /*#__PURE__*/React.createElement("td", {
     style: cellStyle
   }, "DKIM passing"), /*#__PURE__*/React.createElement("td", {
-    style: { ...cellStyle,
+    style: {
+      ...cellStyle,
       ...monoRight,
       color: dkimPass === dnsTotal ? 'var(--success-text)' : dkimPass > 0 ? 'var(--warn-text)' : 'var(--danger-text)'
     }
@@ -3417,7 +3435,8 @@ function Appendix() {
   }, /*#__PURE__*/React.createElement("td", {
     style: cellStyle
   }, "DMARC enforced"), /*#__PURE__*/React.createElement("td", {
-    style: { ...cellStyle,
+    style: {
+      ...cellStyle,
       ...monoRight,
       color: dmarcEnf === dnsTotal ? 'var(--success-text)' : dmarcEnf > 0 ? 'var(--warn-text)' : 'var(--danger-text)'
     }
@@ -3436,7 +3455,8 @@ function Appendix() {
   }, /*#__PURE__*/React.createElement("td", {
     style: cellStyle
   }, "Sync type"), /*#__PURE__*/React.createElement("td", {
-    style: { ...cellStyle,
+    style: {
+      ...cellStyle,
       textAlign: 'right'
     }
   }, ad.syncType || 'Cloud-only')), /*#__PURE__*/React.createElement("tr", {
@@ -3444,7 +3464,8 @@ function Appendix() {
   }, /*#__PURE__*/React.createElement("td", {
     style: cellStyle
   }, "Password hash sync"), /*#__PURE__*/React.createElement("td", {
-    style: { ...cellStyle,
+    style: {
+      ...cellStyle,
       textAlign: 'right',
       color: phsColor,
       fontWeight: 600
@@ -3454,7 +3475,8 @@ function Appendix() {
   }, /*#__PURE__*/React.createElement("td", {
     style: cellStyle
   }, "Last sync"), /*#__PURE__*/React.createElement("td", {
-    style: { ...cellStyle,
+    style: {
+      ...cellStyle,
       textAlign: 'right',
       fontFamily: 'var(--font-mono)'
     }

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -3458,7 +3458,7 @@ function Appendix() {
       textAlign: 'right',
       fontFamily: 'var(--font-mono)'
     }
-  }, String(ad.lastSync).slice(0, 19).replace('T', ' '))))))));
+  }, String(ad.lastSync).slice(0, 19).replace('T', ' ')))))))));
 }
 function StatusDot({
   ok,

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -3384,7 +3384,7 @@ function Appendix() {
       ...monoRight,
       color: 'var(--muted)'
     }
-  }, count))))), dnsTotal > 0 && /*#__PURE__*/React.createElement("div", {
+  }, count)))))), dnsTotal > 0 && /*#__PURE__*/React.createElement("div", {
     className: "card"
   }, /*#__PURE__*/React.createElement("div", {
     style: labelStyle
@@ -3458,7 +3458,7 @@ function Appendix() {
       textAlign: 'right',
       fontFamily: 'var(--font-mono)'
     }
-  }, String(ad.lastSync).slice(0, 19).replace('T', ' ')))))))));
+  }, String(ad.lastSync).slice(0, 19).replace('T', ' '))))))));
 }
 function StatusDot({
   ok,


### PR DESCRIPTION
## Summary

- **Root cause fix**: PR #673 introduced a missing `)` in the `Appendix()` React.createElement chain — Email Auth and Hybrid Sync cards were nested inside the Privileged Roles card instead of being peer grid cells. The paren was relocated from the section end (L3461) to its correct position closing the Privileged Roles card.
- **Babel CI gate**: Replaces the bare `node --check` step with `npm run build` + diff comparison. CI now compiles `report-app.jsx` fresh and fails if the committed `report-app.js` has drifted from Babel output — enforces `.js` is always a true compiled mirror of `.jsx`.
- **Compiled .js**: Commits the canonical Babel output (74-line normalisation diff — formatting, redundant parens, emoji encoding).
- **package.json**: Pins `devDependencies` to `^7.28.0` to match the lock file (lock resolves `@babel/cli@7.28.6`, `@babel/core@7.29.0`).

## Test Plan
- [ ] Open HTML report → Appendix section → confirm Email Auth and Hybrid Sync cards appear as peer grid tiles, not nested inside Privileged Roles
- [ ] CI `JS build check` step: `npm ci && npm run build` completes, `node --check` passes, diff is empty
- [ ] CI fails as expected if `.js` is manually edited without a matching `.jsx` change

🤖 Generated with [Claude Code](https://claude.com/claude-code)