### PR TITLE
chore(release): bump version to v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to M365 Assess are documented here. This project uses [Conve
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-04-22
+
+### Added
+- User-controlled text scale cycle in the topbar (A / A+ / A++) — scales finding-title and detail body text without touching chrome; preference persisted in localStorage (#689, #704)
+- Expand-all / collapse-all button on the findings table header (#688)
+- Explicit "skipped" grey segment on domain-card and framework-quilt bars, with matching muted label and hover tooltip explaining the color legend (#703)
+- Print preview auto-expands the first visible framework in the Framework Coverage section via `beforeprint` listener, ensuring framework details always render in the PDF output (#694)
+
+### Changed
+- EDIT MODE banner now renders above the topbar (was below) by reordering the Topbar fragment — the existing `position: sticky; top: 0` CSS then pins it to the top of the main column (#693)
+- Left sidebar: `DOMAINS` section collapsed by default with a `+` toggle; `DETAILS` renamed to `Findings & action` with an accent top-border for visual emphasis; all `+` expand indicators right-aligned consistently (#695, #702)
+- Filter bar restructured into three rows (search / status+severity / framework+domain) and adds `.filter-bar-active` sticky treatment when search or any filter is active (#696)
+- Topbar icon-btn-group now right-aligns even when wrapping to a second row in narrow viewports (#700)
+- Email authentication posture bars now render as discrete per-domain segments (green for pass, red for fail) instead of a single partial bar — 3 green + 1 red is more legible than a 75% filled bar (#699)
+- Domain-card meta counts colored to match their bar segments (pass = success, warn = amber, fail = danger, review = accent, skipped = muted) — the row now doubles as a legend (#703)
+
+### Fixed
+- Duplicate subsection headings removed from Domain Posture (Intune / SharePoint / AD-Hybrid / Email Auth panels each render their title exactly once; outer wrapper divs were repeating the internal panel label) (#701)
+- Microsoft-managed / Customer-earned Secure Score split tiles hidden when `microsoftScore === 0` — the computation uses an invalid `actionType = 'ProviderGenerated'` discriminator so the split was always broken; tiles will return once the classification logic is corrected (#698)
+
+### Documentation / Branding
+- Remaining "Azure AD" literals in PS remediation strings and Setting labels replaced with "Microsoft Entra" across SharePoint B2B, CA device compliance, Entra join/joined devices, PIM role paths, and P1/P2 premium warnings (#667)
+
 ## [2.3.1] - 2026-04-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [![Coverage](https://img.shields.io/badge/coverage-check%20CI-informational)](https://github.com/Galvnyz/M365-Assess/actions/workflows/ci.yml)
 [![PowerShell 7.x](https://img.shields.io/badge/PowerShell-7.x-blue?logo=powershell&logoColor=white)](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows)
 [![Read-Only](https://img.shields.io/badge/Operations-Read--Only-brightgreen)](.)
-[![Version](https://img.shields.io/badge/version-2.3.1-blue)](.)
+[![Version](https://img.shields.io/badge/version-2.4.0-blue)](.)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 </div>

--- a/src/M365-Assess/M365-Assess.psd1
+++ b/src/M365-Assess/M365-Assess.psd1
@@ -3,7 +3,7 @@
     # Generated: 2026-03-08
 
     RootModule        = 'M365-Assess.psm1'
-    ModuleVersion     = '2.3.1'
+    ModuleVersion     = '2.4.0'
     GUID              = 'f7e3b2a1-4c5d-6e8f-9a0b-1c2d3e4f5a6b'
     Author            = 'Galvnyz'
     CompanyName       = 'Community'
@@ -232,7 +232,7 @@
             IconUri      = 'https://raw.githubusercontent.com/Galvnyz/M365-Assess/main/src/M365-Assess/assets/m365-assess-logo.png'
             LicenseUri   = 'https://github.com/Galvnyz/M365-Assess/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/Galvnyz/M365-Assess'
-            ReleaseNotes = 'v2.3.1 - Filter state persistence; print/PDF CSS; Vibe theme + Neon boost; -ReportDensity param; anti-FOUC ValidateSet reflection; PowerBI Linux skip; PHS false-disabled fix; Secure Score 0pts fix; Entra Connect terminology'
+            ReleaseNotes = 'v2.4.0 - UX polish: EDIT MODE banner at top, sidebar DOMAINS collapsed + DETAILS emphasized, 3-row sticky filter bar, expand/collapse-all findings, topbar text-scale cycle, print auto-expands framework, per-domain email-auth segments, colored domain/framework counts + explicit skipped segment, duplicate Domain Posture headings removed, topbar right-align on wrap, Secure Score split hidden when broken, remaining Azure AD → Microsoft Entra branding'
         }
     }
 }


### PR DESCRIPTION
## Summary

Bumps the module version to **v2.4.0** following PR #707 (merged).

Updates all 4 version locations per \`.claude/rules/versions.md\`:
- \`M365-Assess.psd1\` ModuleVersion → 2.4.0
- \`M365-Assess.psd1\` ReleaseNotes → v2.4.0 summary
- README.md version badge → 2.4.0
- CHANGELOG.md → new [2.4.0] section covering 14 issues (#667, #688, #689/#704, #693–#696, #698–#703)

## Test plan

- [x] ModuleVersion reads correctly: \`(Import-PowerShellDataFile src/M365-Assess/M365-Assess.psd1).ModuleVersion\` returns \`2.4.0\`
- [x] Live assessment run shows \`M365 Assessment v2.4.0\` footer banner
- [x] CHANGELOG.md follows Keep-a-Changelog conventions (Added/Changed/Fixed/Documentation sections)
- [ ] CI green before merge
- [ ] After merge: create GitHub release tag \`v2.4.0\` (requires user approval)