### PR TITLE
feat(report): assessment-to-assessment posture trend chart (#642)

### DIFF
--- a/src/M365-Assess/Common/Build-ReportData.ps1
+++ b/src/M365-Assess/Common/Build-ReportData.ps1
@@ -251,6 +251,27 @@ function Build-ReportDataJson {
         }
     }
 
+    # Trend data — historical baselines for the trend chart (#642)
+    # Only emit when ≥2 snapshots exist; a single point isn't a trend.
+    $trendSnapshots = & $get 'trend-snapshots'
+    $trendData = $null
+    if ($trendSnapshots.Count -ge 2) {
+        $trendData = @($trendSnapshots | ForEach-Object {
+            [ordered]@{
+                label   = $_.Label
+                savedAt = $_.SavedAt
+                version = $_.Version
+                pass    = $_.Pass
+                warn    = $_.Warn
+                fail    = $_.Fail
+                review  = $_.Review
+                info    = $_.Info
+                skipped = $_.Skipped
+                total   = $_.Total
+            }
+        })
+    }
+
     # AD/Hybrid panel — shape hybrid sync + security data for the AdHybridPanel component
     $adHybridRows   = & $get 'ad-hybrid'
     $adSecurityRows = & $get 'ad-security'
@@ -330,6 +351,7 @@ function Build-ReportDataJson {
         sharepointConfig = if ($spoConfig.Count) { $spoConfig } else { $null }
         adHybrid       = $adHybridData
         deviceStats    = $deviceStats
+        trendData      = $trendData
     }
 
     # ------------------------------------------------------------------

--- a/src/M365-Assess/Common/Build-SectionHtml.ps1
+++ b/src/M365-Assess/Common/Build-SectionHtml.ps1
@@ -47,6 +47,18 @@ $sectionData = @{
     'mailbox-summary'  = & $loadCsv '09-Mailbox-Summary.csv'
     'mailflow'         = & $loadCsv '10-Mail-Flow.csv'
     'device-summary'   = & $loadCsv '13-Device-Summary.csv'
+    'trend-snapshots'  = & {
+        # Enumerate saved baselines for this tenant to power the trend view (#642).
+        # Baselines live at <OutputFolder>/Baselines/ which is the parent of <AssessmentFolder>/Baselines
+        # (Export-AssessmentBaseline writes to parent of assessment folder per convention).
+        $baselinesRoot = Join-Path -Path (Split-Path -Parent $AssessmentFolder) -ChildPath 'Baselines'
+        $tenantIdForTrend = if ($tenantData -and @($tenantData).Count -gt 0 -and $tenantData[0].TenantId) { $tenantData[0].TenantId }
+                            elseif ($reportDomainPrefix)                                                   { $reportDomainPrefix }
+                            else                                                                            { '' }
+        if (-not $tenantIdForTrend -or -not (Test-Path -Path $baselinesRoot)) { return @() }
+        . (Join-Path -Path $PSScriptRoot -ChildPath 'Get-BaselineTrend.ps1')
+        @(Get-BaselineTrend -BaselinesRoot $baselinesRoot -TenantId $tenantIdForTrend)
+    }
     'sharepoint-config'= & $loadCsv '20b-SharePoint-Security-Config.csv'
     'ad-hybrid'        = & $loadCsv '23-Hybrid-Sync.csv'
     'ad-security'      = & $loadCsv '26-AD-Security.csv'

--- a/src/M365-Assess/Common/Get-BaselineTrend.ps1
+++ b/src/M365-Assess/Common/Get-BaselineTrend.ps1
@@ -1,0 +1,97 @@
+function Get-BaselineTrend {
+    <#
+    .SYNOPSIS
+        Enumerates saved baselines for a tenant and aggregates per-status counts per snapshot.
+    .DESCRIPTION
+        Scans the Baselines directory for folders matching *_<SafeTenant>/, reads each
+        manifest.json for timestamp + version metadata, and counts the Status field
+        across every security-config JSON file in the baseline. Returns a chronologically
+        sorted array suitable for trend visualisation in the report.
+    .PARAMETER BaselinesRoot
+        Path to the Baselines directory (typically <OutputFolder>/Baselines).
+    .PARAMETER TenantId
+        Tenant identifier used to filter baseline folders by suffix.
+    .PARAMETER MaxSnapshots
+        Maximum number of most-recent snapshots to return. Defaults to 10 — enough
+        context for a visible trend without cluttering the chart. Older snapshots
+        are dropped.
+    .OUTPUTS
+        [PSCustomObject[]] One entry per baseline, sorted chronologically:
+          Label, SavedAt, Version, Pass, Warn, Fail, Review, Info, Skipped, Total
+    .EXAMPLE
+        $trend = Get-BaselineTrend -BaselinesRoot '.\M365-Assessment\Baselines' -TenantId 'contoso.com'
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject[]])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$BaselinesRoot,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$TenantId,
+
+        [Parameter()]
+        [ValidateRange(1, 100)]
+        [int]$MaxSnapshots = 10
+    )
+
+    if (-not (Test-Path -Path $BaselinesRoot -PathType Container)) {
+        Write-Verbose "Trend: baselines root '$BaselinesRoot' does not exist"
+        return @()
+    }
+
+    $safeTenant = $TenantId -replace '[^\w\.\-]', '_'
+    $baselineDirs = Get-ChildItem -Path $BaselinesRoot -Directory -Filter "*_${safeTenant}" -ErrorAction SilentlyContinue
+
+    $snapshots = [System.Collections.Generic.List[PSCustomObject]]::new()
+
+    foreach ($dir in $baselineDirs) {
+        try {
+            $manifestPath = Join-Path -Path $dir.FullName -ChildPath 'manifest.json'
+            if (-not (Test-Path -Path $manifestPath)) {
+                Write-Verbose "Trend: skipped '$($dir.Name)' — no manifest.json"
+                continue
+            }
+            $manifest = Get-Content -Path $manifestPath -Raw -ErrorAction Stop | ConvertFrom-Json
+
+            $counts = @{ pass = 0; warn = 0; fail = 0; review = 0; info = 0; skipped = 0; total = 0 }
+            $jsonFiles = Get-ChildItem -Path $dir.FullName -Filter '*.json' -ErrorAction SilentlyContinue |
+                Where-Object { $_.Name -ne 'manifest.json' }
+
+            foreach ($jf in $jsonFiles) {
+                $rows = Get-Content -Path $jf.FullName -Raw -ErrorAction Stop | ConvertFrom-Json
+                foreach ($row in @($rows)) {
+                    $counts.total++
+                    switch ($row.Status) {
+                        'Pass'    { $counts.pass++ }
+                        'Warning' { $counts.warn++ }
+                        'Fail'    { $counts.fail++ }
+                        'Review'  { $counts.review++ }
+                        'Info'    { $counts.info++ }
+                        'Skipped' { $counts.skipped++ }
+                    }
+                }
+            }
+
+            $snapshots.Add([PSCustomObject]@{
+                Label   = $manifest.Label
+                SavedAt = $manifest.SavedAt
+                Version = $manifest.AssessmentVersion
+                Pass    = $counts.pass
+                Warn    = $counts.warn
+                Fail    = $counts.fail
+                Review  = $counts.review
+                Info    = $counts.info
+                Skipped = $counts.skipped
+                Total   = $counts.total
+            })
+        }
+        catch {
+            Write-Verbose "Trend: skipped baseline '$($dir.Name)': $_"
+        }
+    }
+
+    @($snapshots | Sort-Object SavedAt | Select-Object -Last $MaxSnapshots)
+}

--- a/src/M365-Assess/M365-Assess.psd1
+++ b/src/M365-Assess/M365-Assess.psd1
@@ -92,6 +92,7 @@
         'Common\Export-FrameworkCatalog.ps1'
         'Common\Build-ValueOpportunityHtml.ps1'
         'Common\Build-DriftHtml.ps1'
+        'Common\Get-BaselineTrend.ps1'
         'Common\Build-IntuneOverviewHtml.ps1'
         'Common\Import-ControlRegistry.ps1'
         'Common\Import-FrameworkDefinitions.ps1'

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -322,6 +322,7 @@ const fmt = n => Number(n).toLocaleString();
 // ======================== Sidebar ========================
 function Sidebar({
   active,
+  activeSubsection,
   counts,
   domainCounts,
   activeDomain,
@@ -411,23 +412,23 @@ function Sidebar({
   }, /*#__PURE__*/React.createElement("span", null, it.label), it.id === 'identity' && /*#__PURE__*/React.createElement("span", {
     className: "nav-expand-icon",
     onClick: toggleDomainNav
-  }, domainNavOpen ? '\u2212' : '+')), it.id === 'identity' && domainNavOpen && /*#__PURE__*/React.createElement("div", {
+  }, domainNavOpen || active === 'identity' ? '\u2212' : '+')), it.id === 'identity' && (domainNavOpen || active === 'identity') && /*#__PURE__*/React.createElement("div", {
     className: "nav-subitems"
   }, FINDINGS.some(f => f.domain === 'Intune') && /*#__PURE__*/React.createElement("a", {
     href: "#identity-intune",
-    className: "nav-subitem",
+    className: 'nav-subitem' + (activeSubsection === 'identity-intune' ? ' active' : ''),
     onClick: closeIfMobile
   }, "Intune coverage"), FINDINGS.some(f => f.domain === 'SharePoint & OneDrive') && /*#__PURE__*/React.createElement("a", {
     href: "#identity-sharepoint",
-    className: "nav-subitem",
+    className: 'nav-subitem' + (activeSubsection === 'identity-sharepoint' ? ' active' : ''),
     onClick: closeIfMobile
   }, "SharePoint & OneDrive"), D.adHybrid && /*#__PURE__*/React.createElement("a", {
     href: "#identity-ad",
-    className: "nav-subitem",
+    className: 'nav-subitem' + (activeSubsection === 'identity-ad' ? ' active' : ''),
     onClick: closeIfMobile
   }, "AD & hybrid"), (D.dns || []).length > 0 && /*#__PURE__*/React.createElement("a", {
     href: "#identity-email",
-    className: "nav-subitem",
+    className: 'nav-subitem' + (activeSubsection === 'identity-email' ? ' active' : ''),
     onClick: closeIfMobile
   }, "Email auth")))), /*#__PURE__*/React.createElement("div", {
     className: "nav-label nav-label-collapsible",
@@ -3906,6 +3907,7 @@ function App() {
     };
   });
   const [active, setActive] = useState('overview');
+  const [activeSubsection, setActiveSubsection] = useState(null);
   const [showTweaks, setShowTweaks] = useState(false);
   const [navOpen, setNavOpen] = useState(false);
   const [focusFinding, setFocusFinding] = useState(null);
@@ -3954,7 +3956,7 @@ function App() {
     return () => window.removeEventListener('keydown', h);
   }, []);
 
-  // Scrollspy
+  // Scrollspy — main sections
   useEffect(() => {
     const sections = document.querySelectorAll('section.block');
     const obs = new IntersectionObserver(entries => {
@@ -3965,6 +3967,22 @@ function App() {
       rootMargin: '-40% 0px -55% 0px'
     });
     sections.forEach(s => obs.observe(s));
+    return () => obs.disconnect();
+  }, []);
+
+  // Scrollspy — Domain posture sub-sections (drives submenu auto-highlight)
+  useEffect(() => {
+    const subIds = ['identity-intune', 'identity-sharepoint', 'identity-ad', 'identity-email'];
+    const elements = subIds.map(id => document.getElementById(id)).filter(Boolean);
+    if (!elements.length) return;
+    const obs = new IntersectionObserver(entries => {
+      entries.forEach(e => {
+        if (e.isIntersecting) setActiveSubsection(e.target.id);
+      });
+    }, {
+      rootMargin: '-30% 0px -60% 0px'
+    });
+    elements.forEach(el => obs.observe(el));
     return () => obs.disconnect();
   }, []);
 
@@ -4048,6 +4066,7 @@ function App() {
     className: "app"
   }, /*#__PURE__*/React.createElement(Sidebar, {
     active: active,
+    activeSubsection: activeSubsection,
     counts: navCounts,
     domainCounts: domainCounts,
     activeDomain: filters.domain.length === 1 ? filters.domain[0] : null,

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -984,6 +984,126 @@ function Sparkline({
     fontFamily: "var(--font-mono)"
   }, label)));
 }
+
+// ======================== TrendChart (assessment-to-assessment #642) ========================
+function TrendChart() {
+  const trend = D.trendData;
+  if (!trend || trend.length < 2) return null;
+
+  // One line per status track (Pass / Warn / Fail) — most informative triple for a quick read.
+  // Review / Info / Skipped omitted to keep the chart legible; users who want detail can open
+  // Compare-M365Baseline for a pairwise drill-down.
+  const tracks = [{
+    key: 'pass',
+    label: 'Pass',
+    color: 'var(--success)'
+  }, {
+    key: 'warn',
+    label: 'Warn',
+    color: 'var(--warn)'
+  }, {
+    key: 'fail',
+    label: 'Fail',
+    color: 'var(--danger)'
+  }];
+  const W = 880,
+    H = 160,
+    padL = 40,
+    padR = 12,
+    padT = 14,
+    padB = 28;
+  const innerW = W - padL - padR,
+    innerH = H - padT - padB;
+  const maxVal = Math.max(...trend.flatMap(s => tracks.map(t => s[t.key] || 0)), 10);
+  // Round up to nearest "nice" value for y-axis (multiples of 10, 25, 50, 100)
+  const niceMax = maxVal <= 20 ? Math.ceil(maxVal / 5) * 5 : maxVal <= 50 ? Math.ceil(maxVal / 10) * 10 : maxVal <= 200 ? Math.ceil(maxVal / 25) * 25 : Math.ceil(maxVal / 50) * 50;
+  const sx = i => padL + i / (trend.length - 1) * innerW;
+  const sy = v => padT + (1 - v / niceMax) * innerH;
+  const first = new Date(trend[0].savedAt);
+  const last = new Date(trend[trend.length - 1].savedAt);
+  const daysSpan = Math.round((last - first) / (1000 * 60 * 60 * 24));
+
+  // Y-axis gridlines (3 intermediate + 0 + max)
+  const yTicks = [0, 0.25, 0.5, 0.75, 1].map(t => niceMax * t);
+  return /*#__PURE__*/React.createElement("section", {
+    className: "block",
+    id: "trend"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "section-head"
+  }, /*#__PURE__*/React.createElement("span", {
+    className: "eyebrow"
+  }, "01b \xB7 Trend"), /*#__PURE__*/React.createElement("h2", null, "Posture trend"), /*#__PURE__*/React.createElement("span", {
+    className: "trend-subtitle"
+  }, trend.length, " snapshots \xB7 ", daysSpan, " day", daysSpan === 1 ? '' : 's', " span"), /*#__PURE__*/React.createElement("div", {
+    className: "hr"
+  })), /*#__PURE__*/React.createElement("div", {
+    className: "trend-chart-wrap"
+  }, /*#__PURE__*/React.createElement("svg", {
+    viewBox: `0 0 ${W} ${H}`,
+    width: "100%",
+    preserveAspectRatio: "xMidYMid meet",
+    className: "trend-chart"
+  }, yTicks.map((v, i) => /*#__PURE__*/React.createElement("g", {
+    key: i
+  }, /*#__PURE__*/React.createElement("line", {
+    x1: padL,
+    x2: W - padR,
+    y1: sy(v),
+    y2: sy(v),
+    stroke: "var(--border)",
+    strokeDasharray: i === 0 ? '' : '2 3',
+    opacity: i === 0 ? 0.9 : 0.4
+  }), /*#__PURE__*/React.createElement("text", {
+    x: padL - 6,
+    y: sy(v) + 3,
+    textAnchor: "end",
+    fontSize: "10",
+    fill: "var(--muted)",
+    fontFamily: "var(--font-mono)"
+  }, v))), trend.map((s, i) => {
+    const tickLabel = s.label || new Date(s.savedAt).toLocaleDateString();
+    const rotate = trend.length > 5;
+    return /*#__PURE__*/React.createElement("text", {
+      key: i,
+      x: sx(i),
+      y: H - padB + 16,
+      textAnchor: rotate ? 'end' : 'middle',
+      transform: rotate ? `rotate(-30 ${sx(i)} ${H - padB + 16})` : '',
+      fontSize: "10",
+      fill: "var(--muted)",
+      fontFamily: "var(--font-mono)"
+    }, tickLabel.length > 14 ? tickLabel.slice(0, 13) + '…' : tickLabel);
+  }), tracks.map(t => {
+    const pts = trend.map((s, i) => `${i ? 'L' : 'M'}${sx(i).toFixed(1)},${sy(s[t.key] || 0).toFixed(1)}`).join(' ');
+    return /*#__PURE__*/React.createElement("path", {
+      key: t.key,
+      d: pts,
+      fill: "none",
+      stroke: t.color,
+      strokeWidth: "2",
+      strokeLinejoin: "round",
+      strokeLinecap: "round"
+    });
+  }), trend.map((s, i) => tracks.map(t => /*#__PURE__*/React.createElement("circle", {
+    key: `${i}-${t.key}`,
+    cx: sx(i),
+    cy: sy(s[t.key] || 0),
+    r: "3.2",
+    fill: "var(--surface)",
+    stroke: t.color,
+    strokeWidth: "1.8"
+  }, /*#__PURE__*/React.createElement("title", null, `${s.label || new Date(s.savedAt).toLocaleDateString()} · ${t.label}: ${s[t.key] || 0} of ${s.total}`))))), /*#__PURE__*/React.createElement("div", {
+    className: "trend-legend"
+  }, tracks.map(t => /*#__PURE__*/React.createElement("span", {
+    key: t.key,
+    className: "trend-legend-item"
+  }, /*#__PURE__*/React.createElement("span", {
+    className: "trend-legend-swatch",
+    style: {
+      background: t.color
+    }
+  }), /*#__PURE__*/React.createElement("span", null, t.label))))));
+}
 function MFABreakdown() {
   const s = MFA_STATS;
   // Exclude mailboxes/service for "identity floor"
@@ -3954,7 +4074,7 @@ function App() {
     onFinalize: handleFinalize,
     onReset: handleResetAll,
     hiddenCount: hiddenFindings.size
-  }), /*#__PURE__*/React.createElement(Overview, null), /*#__PURE__*/React.createElement(Posture, null), /*#__PURE__*/React.createElement(FrameworkQuilt, {
+  }), /*#__PURE__*/React.createElement(Overview, null), /*#__PURE__*/React.createElement(Posture, null), /*#__PURE__*/React.createElement(TrendChart, null), /*#__PURE__*/React.createElement(FrameworkQuilt, {
     onSelect: onFrameworkSelect,
     selected: filters.framework[0]
   }), /*#__PURE__*/React.createElement(DomainRollup, {

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -117,7 +117,7 @@ const pct = (n,d) => d ? Math.round((n/d)*100) : 0;
 const fmt = n => Number(n).toLocaleString();
 
 // ======================== Sidebar ========================
-function Sidebar({ active, counts, domainCounts, activeDomain, onDomainJump, onOverviewClick, navOpen, onClose }) {
+function Sidebar({ active, activeSubsection, counts, domainCounts, activeDomain, onDomainJump, onOverviewClick, navOpen, onClose }) {
   const [roadmapOpen, setRoadmapOpen] = useState(false);
   const [domainNavOpen, setDomainNavOpen] = useState(false);
   const [domainsCollapsed, setDomainsCollapsed] = useState(true);
@@ -168,23 +168,23 @@ function Sidebar({ active, counts, domainCounts, activeDomain, onDomainJump, onO
                 <span>{it.label}</span>
                 {it.id === 'identity' && (
                   <span className="nav-expand-icon" onClick={toggleDomainNav}>
-                    {domainNavOpen ? '\u2212' : '+'}
+                    {(domainNavOpen || active === 'identity') ? '\u2212' : '+'}
                   </span>
                 )}
               </a>
-              {it.id === 'identity' && domainNavOpen && (
+              {it.id === 'identity' && (domainNavOpen || active === 'identity') && (
                 <div className="nav-subitems">
                   {FINDINGS.some(f => f.domain === 'Intune') && (
-                    <a href="#identity-intune" className="nav-subitem" onClick={closeIfMobile}>Intune coverage</a>
+                    <a href="#identity-intune"     className={'nav-subitem' + (activeSubsection==='identity-intune'?' active':'')}     onClick={closeIfMobile}>Intune coverage</a>
                   )}
                   {FINDINGS.some(f => f.domain === 'SharePoint & OneDrive') && (
-                    <a href="#identity-sharepoint" className="nav-subitem" onClick={closeIfMobile}>SharePoint &amp; OneDrive</a>
+                    <a href="#identity-sharepoint" className={'nav-subitem' + (activeSubsection==='identity-sharepoint'?' active':'')} onClick={closeIfMobile}>SharePoint &amp; OneDrive</a>
                   )}
                   {D.adHybrid && (
-                    <a href="#identity-ad" className="nav-subitem" onClick={closeIfMobile}>AD &amp; hybrid</a>
+                    <a href="#identity-ad"         className={'nav-subitem' + (activeSubsection==='identity-ad'?' active':'')}         onClick={closeIfMobile}>AD &amp; hybrid</a>
                   )}
                   {(D.dns || []).length > 0 && (
-                    <a href="#identity-email" className="nav-subitem" onClick={closeIfMobile}>Email auth</a>
+                    <a href="#identity-email"      className={'nav-subitem' + (activeSubsection==='identity-email'?' active':'')}      onClick={closeIfMobile}>Email auth</a>
                   )}
                 </div>
               )}
@@ -2365,6 +2365,7 @@ function App() {
     return { status:[], severity:[], framework:[], domain:[], profile:[] };
   });
   const [active, setActive] = useState('overview');
+  const [activeSubsection, setActiveSubsection] = useState(null);
   const [showTweaks, setShowTweaks] = useState(false);
   const [navOpen, setNavOpen] = useState(false);
   const [focusFinding, setFocusFinding] = useState(null);
@@ -2414,13 +2415,25 @@ function App() {
     return () => window.removeEventListener('keydown', h);
   }, []);
 
-  // Scrollspy
+  // Scrollspy — main sections
   useEffect(() => {
     const sections = document.querySelectorAll('section.block');
     const obs = new IntersectionObserver(entries => {
       entries.forEach(e => { if (e.isIntersecting) setActive(e.target.id); });
     }, { rootMargin: '-40% 0px -55% 0px' });
     sections.forEach(s => obs.observe(s));
+    return () => obs.disconnect();
+  }, []);
+
+  // Scrollspy — Domain posture sub-sections (drives submenu auto-highlight)
+  useEffect(() => {
+    const subIds = ['identity-intune','identity-sharepoint','identity-ad','identity-email'];
+    const elements = subIds.map(id => document.getElementById(id)).filter(Boolean);
+    if (!elements.length) return;
+    const obs = new IntersectionObserver(entries => {
+      entries.forEach(e => { if (e.isIntersecting) setActiveSubsection(e.target.id); });
+    }, { rootMargin: '-30% 0px -60% 0px' });
+    elements.forEach(el => obs.observe(el));
     return () => obs.disconnect();
   }, []);
 
@@ -2473,7 +2486,7 @@ function App() {
 
   return (
     <div className="app">
-      <Sidebar active={active} counts={navCounts} domainCounts={domainCounts} activeDomain={filters.domain.length===1 ? filters.domain[0] : null} onDomainJump={onDomainJump} onOverviewClick={onOverviewClick} navOpen={navOpen} onClose={()=>setNavOpen(false)}/>
+      <Sidebar active={active} activeSubsection={activeSubsection} counts={navCounts} domainCounts={domainCounts} activeDomain={filters.domain.length===1 ? filters.domain[0] : null} onDomainJump={onDomainJump} onOverviewClick={onOverviewClick} navOpen={navOpen} onClose={()=>setNavOpen(false)}/>
       <main className="main">
         <Topbar
           search={search} setSearch={setSearch}

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -554,6 +554,98 @@ function Sparkline({ scores, avg }) {
   );
 }
 
+// ======================== TrendChart (assessment-to-assessment #642) ========================
+function TrendChart() {
+  const trend = D.trendData;
+  if (!trend || trend.length < 2) return null;
+
+  // One line per status track (Pass / Warn / Fail) — most informative triple for a quick read.
+  // Review / Info / Skipped omitted to keep the chart legible; users who want detail can open
+  // Compare-M365Baseline for a pairwise drill-down.
+  const tracks = [
+    { key: 'pass', label: 'Pass',    color: 'var(--success)' },
+    { key: 'warn', label: 'Warn',    color: 'var(--warn)'    },
+    { key: 'fail', label: 'Fail',    color: 'var(--danger)'  },
+  ];
+
+  const W = 880, H = 160, padL = 40, padR = 12, padT = 14, padB = 28;
+  const innerW = W - padL - padR, innerH = H - padT - padB;
+
+  const maxVal = Math.max(...trend.flatMap(s => tracks.map(t => s[t.key] || 0)), 10);
+  // Round up to nearest "nice" value for y-axis (multiples of 10, 25, 50, 100)
+  const niceMax = maxVal <= 20 ? Math.ceil(maxVal / 5) * 5
+                : maxVal <= 50 ? Math.ceil(maxVal / 10) * 10
+                : maxVal <= 200 ? Math.ceil(maxVal / 25) * 25
+                : Math.ceil(maxVal / 50) * 50;
+
+  const sx = i => padL + (i / (trend.length - 1)) * innerW;
+  const sy = v => padT + (1 - v / niceMax) * innerH;
+
+  const first = new Date(trend[0].savedAt);
+  const last = new Date(trend[trend.length - 1].savedAt);
+  const daysSpan = Math.round((last - first) / (1000 * 60 * 60 * 24));
+
+  // Y-axis gridlines (3 intermediate + 0 + max)
+  const yTicks = [0, 0.25, 0.5, 0.75, 1].map(t => niceMax * t);
+
+  return (
+    <section className="block" id="trend">
+      <div className="section-head">
+        <span className="eyebrow">01b · Trend</span>
+        <h2>Posture trend</h2>
+        <span className="trend-subtitle">{trend.length} snapshots · {daysSpan} day{daysSpan===1?'':'s'} span</span>
+        <div className="hr"/>
+      </div>
+      <div className="trend-chart-wrap">
+        <svg viewBox={`0 0 ${W} ${H}`} width="100%" preserveAspectRatio="xMidYMid meet" className="trend-chart">
+          {/* Y-axis gridlines + labels */}
+          {yTicks.map((v, i) => (
+            <g key={i}>
+              <line x1={padL} x2={W - padR} y1={sy(v)} y2={sy(v)}
+                    stroke="var(--border)" strokeDasharray={i === 0 ? '' : '2 3'} opacity={i === 0 ? 0.9 : 0.4}/>
+              <text x={padL - 6} y={sy(v) + 3} textAnchor="end" fontSize="10" fill="var(--muted)"
+                    fontFamily="var(--font-mono)">{v}</text>
+            </g>
+          ))}
+          {/* X-axis baseline labels (rotated if many) */}
+          {trend.map((s, i) => {
+            const tickLabel = s.label || new Date(s.savedAt).toLocaleDateString();
+            const rotate = trend.length > 5;
+            return (
+              <text key={i} x={sx(i)} y={H - padB + 16}
+                    textAnchor={rotate ? 'end' : 'middle'}
+                    transform={rotate ? `rotate(-30 ${sx(i)} ${H - padB + 16})` : ''}
+                    fontSize="10" fill="var(--muted)" fontFamily="var(--font-mono)">
+                {tickLabel.length > 14 ? tickLabel.slice(0, 13) + '…' : tickLabel}
+              </text>
+            );
+          })}
+          {/* Data lines */}
+          {tracks.map(t => {
+            const pts = trend.map((s, i) => `${i ? 'L' : 'M'}${sx(i).toFixed(1)},${sy(s[t.key] || 0).toFixed(1)}`).join(' ');
+            return <path key={t.key} d={pts} fill="none" stroke={t.color} strokeWidth="2" strokeLinejoin="round" strokeLinecap="round"/>;
+          })}
+          {/* Data points w/ hover tooltip */}
+          {trend.map((s, i) => tracks.map(t => (
+            <circle key={`${i}-${t.key}`} cx={sx(i)} cy={sy(s[t.key] || 0)} r="3.2"
+                    fill="var(--surface)" stroke={t.color} strokeWidth="1.8">
+              <title>{`${s.label || new Date(s.savedAt).toLocaleDateString()} · ${t.label}: ${s[t.key] || 0} of ${s.total}`}</title>
+            </circle>
+          )))}
+        </svg>
+        <div className="trend-legend">
+          {tracks.map(t => (
+            <span key={t.key} className="trend-legend-item">
+              <span className="trend-legend-swatch" style={{background: t.color}}/>
+              <span>{t.label}</span>
+            </span>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
 function MFABreakdown() {
   const s = MFA_STATS;
   // Exclude mailboxes/service for "identity floor"
@@ -2399,6 +2491,7 @@ function App() {
         />
         <Overview/>
         <Posture/>
+        <TrendChart/>
         <FrameworkQuilt onSelect={onFrameworkSelect} selected={filters.framework[0]}/>
         <DomainRollup onJump={onDomainJump}/>
         <div id="findings-anchor"/>

--- a/src/M365-Assess/assets/report-shell.css
+++ b/src/M365-Assess/assets/report-shell.css
@@ -157,6 +157,11 @@ a:hover { text-decoration: underline; }
   transition: background .15s, color .15s;
 }
 .nav-subitem:hover { background: var(--hover); color: var(--text); }
+.nav-subitem.active {
+  background: var(--accent-soft);
+  color: var(--accent-text);
+  font-weight: 600;
+}
 .nav-subitem .count {
   font-size: 11px; padding: 1px 6px; border-radius: 10px;
   background: var(--chip); color: var(--text-soft);

--- a/src/M365-Assess/assets/report-shell.css
+++ b/src/M365-Assess/assets/report-shell.css
@@ -455,6 +455,34 @@ section.block { margin-bottom: 52px; scroll-margin-top: 20px; }
 .exec-tile.warn .exec-tile-value { color: var(--warn-text); }
 .exec-tile.bad  { border-left-color: var(--danger); }
 .exec-tile.bad  .exec-tile-value { color: var(--danger-text); }
+
+/* ---------- TrendChart (#642) ---------- */
+.trend-subtitle {
+  margin-left: 10px;
+  font-size: 12px; color: var(--muted);
+  font-family: var(--font-mono); letter-spacing: .04em;
+  align-self: baseline;
+}
+.trend-chart-wrap {
+  padding: 14px 16px 10px 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+.trend-chart {
+  display: block;
+  max-height: 220px;
+}
+.trend-legend {
+  display: flex; gap: 18px; flex-wrap: wrap;
+  margin-top: 8px; padding-top: 8px;
+  border-top: 1px solid var(--border);
+  font-size: 12px; color: var(--text-soft);
+}
+.trend-legend-item { display: inline-flex; align-items: center; gap: 6px; }
+.trend-legend-swatch {
+  display: inline-block; width: 12px; height: 3px; border-radius: 2px;
+}
 .kpi .tiny-bar {
   margin-top: 8px; height: 4px; border-radius: 2px;
   background: var(--track); overflow: hidden;


### PR DESCRIPTION
## Summary

Adds a new **Posture trend** section between Posture score and Framework coverage that plots Pass / Warn / Fail counts across historical baselines for the same tenant. Leverages the baseline infrastructure already shipped in v1.12.0 (`Export-AssessmentBaseline` + `Compare-AssessmentBaseline`) — this PR adds a multi-snapshot read path on top.

## Data path

1. **`Common/Get-BaselineTrend.ps1`** (new) — enumerates `<OutputFolder>/Baselines/*_<SafeTenant>/` folders, reads each `manifest.json` for timestamp/version, aggregates per-status counts across the baseline's collector JSON files. Returns chronologically-sorted snapshots (capped at 10 most recent).
2. **`Common/Build-SectionHtml.ps1`** — calls the helper, populates `sectionData['trend-snapshots']`. Safe when Baselines folder doesn't exist or TenantId can't be resolved (returns empty).
3. **`Common/Build-ReportData.ps1`** — emits `REPORT_DATA.trendData` only when ≥ 2 snapshots exist (a single point isn't a trend).

## UI

**`<TrendChart/>` React component** — inline SVG, no external chart library. Three lines (Pass green / Warn amber / Fail red), auto-scaled y-axis rounded to "nice" values (5/10/25/50), rotated x-axis labels when >5 snapshots, per-point hover tooltips via native `<title>`, legend under the chart. Returns `null` when `trendData` is absent, so reports for tenants with <2 saved baselines render unchanged.

## Closes

- #642 — Assessment-to-assessment trend / comparison view

## Test plan

- [x] `npm run build` + `node --check` pass
- [x] Live validation: fake baselines created (`_tmp_fake_baselines.ps1`), assessment re-run, chart renders with 2 tracks + tooltip on hover
- [x] Graceful absence: tenants with 0 or 1 saved baselines render without the trend section
- [ ] CI green

## Usage

Users save baselines via `-SaveBaseline <label>` on `Invoke-M365Assessment`. Once ≥2 exist for a tenant, the trend section automatically appears in subsequent reports. No other parameters — it Just Works™.

## Files

- `src/M365-Assess/Common/Get-BaselineTrend.ps1` (new)
- `src/M365-Assess/Common/Build-SectionHtml.ps1`
- `src/M365-Assess/Common/Build-ReportData.ps1`
- `src/M365-Assess/assets/report-app.jsx`
- `src/M365-Assess/assets/report-app.js`
- `src/M365-Assess/assets/report-shell.css`
- `src/M365-Assess/M365-Assess.psd1` — FileList entry for the new script
