### PR TITLE
feat(report): v2.6.0 quick-wins sweep — 4 finding-interaction polish items

### DIFF
--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -585,6 +585,10 @@ function Sidebar({
 function Topbar({
   search,
   setSearch,
+  searchMatches,
+  matchIdx,
+  onAdvanceMatch,
+  onRetreatMatch,
   mode,
   setMode,
   theme,
@@ -640,8 +644,18 @@ function Topbar({
   }, /*#__PURE__*/React.createElement(Icon.search, null), /*#__PURE__*/React.createElement("input", {
     value: search,
     onChange: e => setSearch(e.target.value),
-    placeholder: "Search findings, check IDs, remediation\u2026"
-  }), /*#__PURE__*/React.createElement("kbd", null, "/")), /*#__PURE__*/React.createElement("div", {
+    onKeyDown: e => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        if (e.shiftKey) onRetreatMatch?.();else onAdvanceMatch?.();
+      } else if (e.key === 'Escape') {
+        setSearch('');
+      }
+    },
+    placeholder: "Search findings, check IDs, remediation\u2026 (Enter to cycle)"
+  }), search && /*#__PURE__*/React.createElement("span", {
+    className: 'search-counter' + ((searchMatches || []).length === 0 ? ' is-empty' : '')
+  }, (searchMatches || []).length === 0 ? '0/0' : matchIdx + 1 + '/' + searchMatches.length), /*#__PURE__*/React.createElement("kbd", null, "/")), /*#__PURE__*/React.createElement("div", {
     className: "palette-switch"
   }, /*#__PURE__*/React.createElement("button", {
     className: theme === 'neon' ? 'active' : '',
@@ -1949,6 +1963,23 @@ function FrameworkQuilt({
   const handleCardClick = fwId => setExpandedFw(e => e === fwId ? null : fwId);
   const expandedMeta = expandedFw ? FRAMEWORKS.find(f => f.id === expandedFw) : null;
   const expandedData = expandedFw ? byFw[expandedFw] : null;
+
+  // Count of findings within the expanded framework that match the active level-chip
+  // selection (L1/L2/L3/E3/E5only). When no chips are selected, falls back to the
+  // framework total so the CTA renders the original phrasing. Uses the same
+  // matchProfileToken semantics as fwDomainBreakdown above.
+  const selectedCount = useMemo(() => {
+    if (!expandedFw || !expandedData) return 0;
+    const tokens = activeProfiles || [];
+    if (tokens.length === 0) return expandedData.total;
+    let n = 0;
+    FINDINGS.forEach(f => {
+      if (!f.frameworks.includes(expandedFw)) return;
+      const profs = [].concat(f.fwMeta?.[expandedFw]?.profiles || []);
+      if (tokens.some(t => matchProfileToken(profs, t))) n++;
+    });
+    return n;
+  }, [expandedFw, activeProfiles, expandedData]);
   return /*#__PURE__*/React.createElement("section", {
     className: "block",
     id: "frameworks"
@@ -2306,7 +2337,7 @@ function FrameworkQuilt({
         block: 'start'
       });
     }
-  }, "View all ", expandedData.total, " findings in this framework \u2192"))));
+  }, (activeProfiles || []).length === 0 ? /*#__PURE__*/React.createElement(React.Fragment, null, "View all ", expandedData.total, " findings in this framework \u2192") : /*#__PURE__*/React.createElement(React.Fragment, null, "View ", selectedCount, " of ", expandedData.total, " findings matching ", (activeProfiles || []).join(' + '), " \u2192")))));
 }
 
 // ======================== Filter bar ========================
@@ -2627,6 +2658,7 @@ function FindingsTable({
   search,
   focusFinding,
   onFocusClear,
+  onMatchesChange,
   editMode,
   hiddenFindings,
   onHide,
@@ -2652,8 +2684,27 @@ function FindingsTable({
       document.removeEventListener('mousedown', onOut);
     };
   }, [colPickerOpen]);
+
+  // Issue #697: track the previously focused finding so smart-search cycling
+  // can collapse the prior expanded row. Plain ref — does not trigger renders.
+  const prevFocusRef = useRef(null);
   useEffect(() => {
     if (!focusFinding) return;
+    // Expand the new match and collapse the previously cycled-to one. Indices
+    // in the `open` Set track positions in `filtered`, so this only works if
+    // the row actually appears in the current filtered view.
+    setOpen(o => {
+      const n = new Set(o);
+      const prev = prevFocusRef.current;
+      if (prev && prev !== focusFinding) {
+        const prevIdx = filtered.findIndex(f => f.checkId === prev);
+        if (prevIdx >= 0) n.delete(prevIdx);
+      }
+      const idx = filtered.findIndex(f => f.checkId === focusFinding);
+      if (idx >= 0) n.add(idx);
+      return n;
+    });
+    prevFocusRef.current = focusFinding;
     const timer = setTimeout(() => {
       const rowId = 'finding-row-' + focusFinding.replace(/\./g, '-');
       const el = document.getElementById(rowId);
@@ -2674,6 +2725,11 @@ function FindingsTable({
   const toggleCol = id => setVisibleCols(v => v.includes(id) ? v.length > 1 ? v.filter(c => c !== id) : v : [...v, id]);
   const cols = ALL_COLS.filter(c => visibleCols.includes(c.id));
   const gridTpl = cols.map(c => c.width).join(' ') + ' 28px';
+
+  // Issue #697: publish the current filtered set up to App so the smart-search
+  // counter and Enter-cycling can operate over the same in-view findings.
+  // Empty array when no search query — counter hides and cycling no-ops.
+
   const filtered = useMemo(() => {
     const s = search.toLowerCase();
     return FINDINGS.filter(f => {
@@ -2694,6 +2750,13 @@ function FindingsTable({
       return true;
     });
   }, [filters, search, editMode, hiddenFindings]);
+
+  // Issue #697: publish matches up to App. Only emit when there is a query;
+  // empty list when search is cleared so the counter hides and cycling no-ops.
+  useEffect(() => {
+    if (!onMatchesChange) return;
+    onMatchesChange(search ? filtered.map(f => f.checkId) : []);
+  }, [filtered, search, onMatchesChange]);
   const isFiltered = search.length > 0 || filters.status.length > 0 || filters.severity.length > 0 || filters.framework.length > 0 || filters.domain.length > 0 || (filters.profile || []).length > 0;
   const toggle = i => setOpen(o => {
     const n = new Set(o);
@@ -2992,23 +3055,52 @@ function renderRemediation(text) {
       color: 'var(--muted)'
     }
   }, "No remediation guidance provided.");
-  // Highlight Run: PowerShell commands
+  // Split into ordered blocks: portal-text segments and Run: PowerShell commands.
+  // Each block renders on its own line so a consultant can scan by action type.
   const parts = text.split(/(Run:[^.]*\.)/);
-  return /*#__PURE__*/React.createElement("span", null, parts.map((p, i) => {
+  const blocks = [];
+  let portalBuf = '';
+  parts.forEach(p => {
+    if (!p) return;
     if (p.startsWith('Run:')) {
+      const trimmed = portalBuf.trim();
+      if (trimmed) blocks.push({
+        type: 'portal',
+        text: trimmed
+      });
+      portalBuf = '';
       const cmd = p.replace(/^Run:\s*/, '').replace(/\.$/, '');
-      return /*#__PURE__*/React.createElement("span", {
-        key: i
-      }, /*#__PURE__*/React.createElement("strong", {
-        style: {
-          color: 'var(--accent-text)'
-        }
-      }, "PowerShell:"), " ", /*#__PURE__*/React.createElement("code", null, cmd), ". ");
+      blocks.push({
+        type: 'ps',
+        cmd
+      });
+    } else {
+      portalBuf += p;
     }
-    return /*#__PURE__*/React.createElement("span", {
-      key: i
-    }, p);
-  }));
+  });
+  const tail = portalBuf.trim();
+  if (tail) blocks.push({
+    type: 'portal',
+    text: tail
+  });
+  if (blocks.length === 0) return /*#__PURE__*/React.createElement("span", {
+    style: {
+      color: 'var(--muted)'
+    }
+  }, "No remediation guidance provided.");
+  return /*#__PURE__*/React.createElement("div", {
+    className: "remediation-blocks"
+  }, blocks.map((b, i) => b.type === 'ps' ? /*#__PURE__*/React.createElement("div", {
+    key: i,
+    className: "remediation-block remediation-ps"
+  }, /*#__PURE__*/React.createElement("span", {
+    className: "remediation-label"
+  }, "PowerShell"), /*#__PURE__*/React.createElement("pre", null, /*#__PURE__*/React.createElement("code", null, b.cmd))) : /*#__PURE__*/React.createElement("div", {
+    key: i,
+    className: "remediation-block remediation-portal"
+  }, /*#__PURE__*/React.createElement("span", {
+    className: "remediation-label"
+  }, "Portal"), /*#__PURE__*/React.createElement("p", null, b.text))));
 }
 function whyItMatters(f) {
   const id = f.checkId;
@@ -3179,9 +3271,9 @@ function Roadmap({
     }, t.checkId, " \xB7 ", t.domain), /*#__PURE__*/React.createElement("div", {
       className: "task-tags"
     }, /*#__PURE__*/React.createElement("span", {
-      className: "task-tag"
+      className: 'task-tag task-tag-sev sev-' + t.severity
     }, SEV_LABEL[t.severity]), t.effort && /*#__PURE__*/React.createElement("span", {
-      className: "task-tag"
+      className: "task-tag task-tag-effort"
     }, t.effort, " effort"), t.frameworks.slice(0, 3).map(fw => /*#__PURE__*/React.createElement("span", {
       key: fw,
       className: "task-tag",
@@ -3266,7 +3358,7 @@ function Roadmap({
     }, "Business rationale"), /*#__PURE__*/React.createElement("div", {
       className: "task-field-value"
     }, t.rationale)), t.references && t.references.length > 0 && /*#__PURE__*/React.createElement("div", {
-      className: "task-field"
+      className: "task-field task-field-learn-more"
     }, /*#__PURE__*/React.createElement("div", {
       className: "task-field-label"
     }, "Learn more"), /*#__PURE__*/React.createElement("div", {
@@ -4054,6 +4146,29 @@ function App() {
   const [showTweaks, setShowTweaks] = useState(false);
   const [navOpen, setNavOpen] = useState(false);
   const [focusFinding, setFocusFinding] = useState(null);
+  // Issue #697: smart search — App owns the matches array (checkIds) and the
+  // current cursor so FilterBar can render a counter and FindingsTable can
+  // scroll/expand the active match. FindingsTable publishes its filtered set
+  // via onMatchesChange; Topbar drives advance/retreat from the search input.
+  const [searchMatches, setSearchMatches] = useState([]);
+  const [matchIdx, setMatchIdx] = useState(0);
+  // Reset cursor whenever the query changes; matches array re-derives anyway,
+  // but we want index=0 to land on the first match for new queries.
+  useEffect(() => {
+    setMatchIdx(0);
+  }, [search]);
+  const handleAdvanceMatch = useCallback(() => {
+    if (searchMatches.length === 0) return;
+    const next = (matchIdx + 1) % searchMatches.length;
+    setMatchIdx(next);
+    setFocusFinding(searchMatches[next]);
+  }, [matchIdx, searchMatches]);
+  const handleRetreatMatch = useCallback(() => {
+    if (searchMatches.length === 0) return;
+    const prev = (matchIdx - 1 + searchMatches.length) % searchMatches.length;
+    setMatchIdx(prev);
+    setFocusFinding(searchMatches[prev]);
+  }, [matchIdx, searchMatches]);
   const [editMode, setEditMode] = useState(false);
   const [hiddenFindings, setHiddenFindings] = useState(() => new Set(RO?.hiddenFindings || []));
   const [roadmapOverrides, setRoadmapOverrides] = useState(() => RO?.roadmapOverrides || {});
@@ -4232,6 +4347,10 @@ function App() {
   }, /*#__PURE__*/React.createElement(Topbar, {
     search: search,
     setSearch: setSearch,
+    searchMatches: searchMatches,
+    matchIdx: matchIdx,
+    onAdvanceMatch: handleAdvanceMatch,
+    onRetreatMatch: handleRetreatMatch,
     mode: mode,
     setMode: setMode,
     theme: theme,
@@ -4271,6 +4390,7 @@ function App() {
     search: search,
     focusFinding: focusFinding,
     onFocusClear: () => setFocusFinding(null),
+    onMatchesChange: setSearchMatches,
     editMode: editMode,
     hiddenFindings: hiddenFindings,
     onHide: toggleHideFinding,

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -278,7 +278,7 @@ function Sidebar({ active, activeSubsection, counts, domainCounts, activeDomain,
 }
 
 // ======================== Topbar ========================
-function Topbar({ search, setSearch, mode, setMode, theme, setTheme, textScale, setTextScale, onPrint, onTweaks, onHamburger, editMode, onEditToggle, onFinalize, onReset, hiddenCount }) {
+function Topbar({ search, setSearch, searchMatches, matchIdx, onAdvanceMatch, onRetreatMatch, mode, setMode, theme, setTheme, textScale, setTextScale, onPrint, onTweaks, onHamburger, editMode, onEditToggle, onFinalize, onReset, hiddenCount }) {
   const SCALE_CYCLE = ['normal', 'large', 'xlarge'];
   const cycleScale = () => setTextScale(s => SCALE_CYCLE[(SCALE_CYCLE.indexOf(s) + 1) % SCALE_CYCLE.length] || 'normal');
   const scaleLabel = { normal: 'A', large: 'A+', xlarge: 'A++' }[textScale] || 'A';
@@ -305,7 +305,22 @@ function Topbar({ search, setSearch, mode, setMode, theme, setTheme, textScale, 
         <div className="spacer" />
         <div className="search">
           <Icon.search />
-          <input value={search} onChange={e=>setSearch(e.target.value)} placeholder="Search findings, check IDs, remediation…" />
+          <input value={search}
+            onChange={e=>setSearch(e.target.value)}
+            onKeyDown={e=>{
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                if (e.shiftKey) onRetreatMatch?.(); else onAdvanceMatch?.();
+              } else if (e.key === 'Escape') {
+                setSearch('');
+              }
+            }}
+            placeholder="Search findings, check IDs, remediation… (Enter to cycle)" />
+          {search && (
+            <span className={'search-counter' + ((searchMatches||[]).length === 0 ? ' is-empty' : '')}>
+              {(searchMatches||[]).length === 0 ? '0/0' : (matchIdx + 1) + '/' + searchMatches.length}
+            </span>
+          )}
           <kbd>/</kbd>
         </div>
         <div className="palette-switch">
@@ -1181,6 +1196,23 @@ function FrameworkQuilt({ onSelect, selected, onProfileSelect, activeProfiles })
   const expandedMeta = expandedFw ? FRAMEWORKS.find(f => f.id === expandedFw) : null;
   const expandedData = expandedFw ? byFw[expandedFw] : null;
 
+  // Count of findings within the expanded framework that match the active level-chip
+  // selection (L1/L2/L3/E3/E5only). When no chips are selected, falls back to the
+  // framework total so the CTA renders the original phrasing. Uses the same
+  // matchProfileToken semantics as fwDomainBreakdown above.
+  const selectedCount = useMemo(() => {
+    if (!expandedFw || !expandedData) return 0;
+    const tokens = activeProfiles || [];
+    if (tokens.length === 0) return expandedData.total;
+    let n = 0;
+    FINDINGS.forEach(f => {
+      if (!f.frameworks.includes(expandedFw)) return;
+      const profs = [].concat(f.fwMeta?.[expandedFw]?.profiles || []);
+      if (tokens.some(t => matchProfileToken(profs, t))) n++;
+    });
+    return n;
+  }, [expandedFw, activeProfiles, expandedData]);
+
   return (
     <section className="block" id="frameworks">
       <div className="section-head">
@@ -1348,7 +1380,9 @@ function FrameworkQuilt({ onSelect, selected, onProfileSelect, activeProfiles })
               onSelect(expandedFw);
               document.getElementById('findings-anchor')?.scrollIntoView({behavior:'smooth', block:'start'});
             }}>
-              View all {expandedData.total} findings in this framework →
+              {(activeProfiles || []).length === 0
+                ? <>View all {expandedData.total} findings in this framework →</>
+                : <>View {selectedCount} of {expandedData.total} findings matching {(activeProfiles || []).join(' + ')} →</>}
             </button>
           </div>
         </div>
@@ -1559,7 +1593,7 @@ const ALL_COLS = [
 ];
 const DEFAULT_COLS = ['status', 'finding', 'domain', 'controlId', 'checkId', 'severity'];
 
-function FindingsTable({ filters, search, focusFinding, onFocusClear, editMode, hiddenFindings, onHide, onHideBulk, onRestoreAll }) {
+function FindingsTable({ filters, search, focusFinding, onFocusClear, onMatchesChange, editMode, hiddenFindings, onHide, onHideBulk, onRestoreAll }) {
   const [open, setOpen] = useState(new Set());
   const [visibleCols, setVisibleCols] = useState(DEFAULT_COLS);
   const [colPickerOpen, setColPickerOpen] = useState(false);
@@ -1577,8 +1611,27 @@ function FindingsTable({ filters, search, focusFinding, onFocusClear, editMode, 
     };
   }, [colPickerOpen]);
 
+  // Issue #697: track the previously focused finding so smart-search cycling
+  // can collapse the prior expanded row. Plain ref — does not trigger renders.
+  const prevFocusRef = useRef(null);
+
   useEffect(() => {
     if (!focusFinding) return;
+    // Expand the new match and collapse the previously cycled-to one. Indices
+    // in the `open` Set track positions in `filtered`, so this only works if
+    // the row actually appears in the current filtered view.
+    setOpen(o => {
+      const n = new Set(o);
+      const prev = prevFocusRef.current;
+      if (prev && prev !== focusFinding) {
+        const prevIdx = filtered.findIndex(f => f.checkId === prev);
+        if (prevIdx >= 0) n.delete(prevIdx);
+      }
+      const idx = filtered.findIndex(f => f.checkId === focusFinding);
+      if (idx >= 0) n.add(idx);
+      return n;
+    });
+    prevFocusRef.current = focusFinding;
     const timer = setTimeout(() => {
       const rowId = 'finding-row-' + focusFinding.replace(/\./g, '-');
       const el = document.getElementById(rowId);
@@ -1597,6 +1650,10 @@ function FindingsTable({ filters, search, focusFinding, onFocusClear, editMode, 
 
   const cols = ALL_COLS.filter(c => visibleCols.includes(c.id));
   const gridTpl = cols.map(c => c.width).join(' ') + ' 28px';
+
+  // Issue #697: publish the current filtered set up to App so the smart-search
+  // counter and Enter-cycling can operate over the same in-view findings.
+  // Empty array when no search query — counter hides and cycling no-ops.
 
   const filtered = useMemo(() => {
     const s = search.toLowerCase();
@@ -1618,6 +1675,13 @@ function FindingsTable({ filters, search, focusFinding, onFocusClear, editMode, 
       return true;
     });
   }, [filters, search, editMode, hiddenFindings]);
+
+  // Issue #697: publish matches up to App. Only emit when there is a query;
+  // empty list when search is cleared so the counter hides and cycling no-ops.
+  useEffect(() => {
+    if (!onMatchesChange) return;
+    onMatchesChange(search ? filtered.map(f => f.checkId) : []);
+  }, [filtered, search, onMatchesChange]);
 
   const isFiltered = search.length > 0
     || filters.status.length > 0
@@ -1826,18 +1890,39 @@ function FindingsTable({ filters, search, focusFinding, onFocusClear, editMode, 
 
 function renderRemediation(text) {
   if (!text) return <span style={{color:'var(--muted)'}}>No remediation guidance provided.</span>;
-  // Highlight Run: PowerShell commands
+  // Split into ordered blocks: portal-text segments and Run: PowerShell commands.
+  // Each block renders on its own line so a consultant can scan by action type.
   const parts = text.split(/(Run:[^.]*\.)/);
+  const blocks = [];
+  let portalBuf = '';
+  parts.forEach(p => {
+    if (!p) return;
+    if (p.startsWith('Run:')) {
+      const trimmed = portalBuf.trim();
+      if (trimmed) blocks.push({ type: 'portal', text: trimmed });
+      portalBuf = '';
+      const cmd = p.replace(/^Run:\s*/, '').replace(/\.$/, '');
+      blocks.push({ type: 'ps', cmd });
+    } else {
+      portalBuf += p;
+    }
+  });
+  const tail = portalBuf.trim();
+  if (tail) blocks.push({ type: 'portal', text: tail });
+  if (blocks.length === 0) return <span style={{color:'var(--muted)'}}>No remediation guidance provided.</span>;
   return (
-    <span>
-      {parts.map((p,i) => {
-        if (p.startsWith('Run:')) {
-          const cmd = p.replace(/^Run:\s*/, '').replace(/\.$/, '');
-          return <span key={i}><strong style={{color:'var(--accent-text)'}}>PowerShell:</strong> <code>{cmd}</code>. </span>;
-        }
-        return <span key={i}>{p}</span>;
-      })}
-    </span>
+    <div className="remediation-blocks">
+      {blocks.map((b, i) => b.type === 'ps'
+        ? <div key={i} className="remediation-block remediation-ps">
+            <span className="remediation-label">PowerShell</span>
+            <pre><code>{b.cmd}</code></pre>
+          </div>
+        : <div key={i} className="remediation-block remediation-portal">
+            <span className="remediation-label">Portal</span>
+            <p>{b.text}</p>
+          </div>
+      )}
+    </div>
   );
 }
 
@@ -1977,8 +2062,8 @@ function Roadmap({ onViewFinding, editMode, hiddenFindings, roadmapOverrides, on
           </div>
           <div className="task-id">{t.checkId} · {t.domain}</div>
           <div className="task-tags">
-            <span className="task-tag">{SEV_LABEL[t.severity]}</span>
-            {t.effort && <span className="task-tag">{t.effort} effort</span>}
+            <span className={'task-tag task-tag-sev sev-' + t.severity}>{SEV_LABEL[t.severity]}</span>
+            {t.effort && <span className="task-tag task-tag-effort">{t.effort} effort</span>}
             {t.frameworks.slice(0,3).map(fw => <span key={fw} className="task-tag" style={{fontFamily:'var(--font-mono)'}}>{fw}</span>)}
             <span className="task-chev" aria-hidden="true">{isOpen ? '−' : '+'}</span>
           </div>
@@ -2019,7 +2104,7 @@ function Roadmap({ onViewFinding, editMode, hiddenFindings, roadmapOverrides, on
               </div>
             )}
             {t.references && t.references.length > 0 && (
-              <div className="task-field">
+              <div className="task-field task-field-learn-more">
                 <div className="task-field-label">Learn more</div>
                 <div className="task-field-value" style={{display:'flex',flexDirection:'column',gap:'4px'}}>
                   {t.references.map((r, i) => (
@@ -2451,6 +2536,27 @@ function App() {
   const [showTweaks, setShowTweaks] = useState(false);
   const [navOpen, setNavOpen] = useState(false);
   const [focusFinding, setFocusFinding] = useState(null);
+  // Issue #697: smart search — App owns the matches array (checkIds) and the
+  // current cursor so FilterBar can render a counter and FindingsTable can
+  // scroll/expand the active match. FindingsTable publishes its filtered set
+  // via onMatchesChange; Topbar drives advance/retreat from the search input.
+  const [searchMatches, setSearchMatches] = useState([]);
+  const [matchIdx, setMatchIdx] = useState(0);
+  // Reset cursor whenever the query changes; matches array re-derives anyway,
+  // but we want index=0 to land on the first match for new queries.
+  useEffect(() => { setMatchIdx(0); }, [search]);
+  const handleAdvanceMatch = useCallback(() => {
+    if (searchMatches.length === 0) return;
+    const next = (matchIdx + 1) % searchMatches.length;
+    setMatchIdx(next);
+    setFocusFinding(searchMatches[next]);
+  }, [matchIdx, searchMatches]);
+  const handleRetreatMatch = useCallback(() => {
+    if (searchMatches.length === 0) return;
+    const prev = (matchIdx - 1 + searchMatches.length) % searchMatches.length;
+    setMatchIdx(prev);
+    setFocusFinding(searchMatches[prev]);
+  }, [matchIdx, searchMatches]);
   const [editMode, setEditMode] = useState(false);
   const [hiddenFindings, setHiddenFindings] = useState(() => new Set(RO?.hiddenFindings || []));
   const [roadmapOverrides, setRoadmapOverrides] = useState(() => RO?.roadmapOverrides || {});
@@ -2582,6 +2688,8 @@ function App() {
       <main className="main">
         <Topbar
           search={search} setSearch={setSearch}
+          searchMatches={searchMatches} matchIdx={matchIdx}
+          onAdvanceMatch={handleAdvanceMatch} onRetreatMatch={handleRetreatMatch}
           mode={mode} setMode={setMode}
           theme={theme} setTheme={setTheme}
           textScale={textScale} setTextScale={setTextScale}
@@ -2603,6 +2711,7 @@ function App() {
         <div style={{marginTop:20}}/>
         <FilterBar filters={filters} setFilters={setFilters} counts={counts} total={FINDINGS.length} search={search} setSearch={setSearch}/>
         <FindingsTable filters={filters} search={search} focusFinding={focusFinding} onFocusClear={() => setFocusFinding(null)}
+          onMatchesChange={setSearchMatches}
           editMode={editMode} hiddenFindings={hiddenFindings} onHide={toggleHideFinding} onRestoreAll={restoreAllFindings}/>
         <Roadmap onViewFinding={onViewFinding} editMode={editMode} hiddenFindings={hiddenFindings} roadmapOverrides={roadmapOverrides} onRoadmapChange={setRoadmapOverrides}/>
         <Appendix/>

--- a/src/M365-Assess/assets/report-shell.css
+++ b/src/M365-Assess/assets/report-shell.css
@@ -213,6 +213,33 @@ a:hover { text-decoration: underline; }
   background: var(--chip); color: var(--muted);
   border: 1px solid var(--border);
 }
+/* Issue #697: smart-search match counter (e.g. "3/15"). Sits between the
+   input text and the kbd hint. The :has() selector pushes input padding
+   right so typed text never collides with the counter. */
+.search-counter {
+  position: absolute; right: 38px; top: 50%;
+  transform: translateY(-50%);
+  font-family: var(--font-mono); font-size: 11px;
+  padding: 1px 6px; border-radius: 3px;
+  background: var(--accent-soft); color: var(--accent-text);
+  border: 1px solid color-mix(in oklab, var(--accent) 30%, transparent);
+  letter-spacing: 0.04em;
+  pointer-events: none;
+  user-select: none;
+}
+.search-counter.is-empty {
+  background: transparent; color: var(--muted);
+  border-color: var(--border);
+}
+.search:has(.search-counter) input { padding-right: 92px; }
+/* Highlight the row the smart-search cycle just landed on so it pops out
+   even after the existing 2.5s focus pulse fades. Reuses .highlight-focus
+   for the pulse; this is the steady-state "active match" treatment. */
+.finding-row.highlight-focus {
+  outline: 2px solid var(--accent);
+  outline-offset: -1px;
+  background: color-mix(in oklab, var(--accent) 6%, transparent);
+}
 
 /* Icon buttons */
 .icon-btn {
@@ -836,6 +863,48 @@ mark.search-hl {
 .finding-detail .remediation-text {
   font-size: 13px; line-height: 1.6; color: var(--text);
 }
+/* Issue #687: split portal nav steps from PowerShell commands so each
+   action type renders on its own block. PS gets a code-style treatment;
+   portal gets prose styling. Labels use the chip palette for consistency. */
+.remediation-blocks { display: flex; flex-direction: column; gap: 8px; }
+.remediation-block {
+  position: relative;
+  padding: 8px 10px 8px 64px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  font-size: 12.5px; line-height: 1.55;
+}
+.remediation-block .remediation-label {
+  position: absolute; left: 8px; top: 8px;
+  font-size: 10px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.08em;
+  padding: 2px 6px; border-radius: 4px;
+}
+.remediation-block.remediation-portal {
+  background: var(--card-subtle, rgba(255,255,255,0.02));
+}
+.remediation-block.remediation-portal .remediation-label {
+  color: var(--accent-text);
+  background: rgba(96, 165, 250, 0.12);
+}
+.remediation-block.remediation-portal p { margin: 0; color: var(--text); }
+.remediation-block.remediation-ps {
+  background: rgba(155, 135, 245, 0.06);
+  border-color: rgba(155, 135, 245, 0.25);
+}
+.remediation-block.remediation-ps .remediation-label {
+  color: #c4b5fd;
+  background: rgba(155, 135, 245, 0.18);
+}
+.remediation-block.remediation-ps pre {
+  margin: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text);
+}
+.remediation-block.remediation-ps code { background: transparent; padding: 0; }
 .finding-learn-more {
   grid-column: 1 / -1;
   padding-top: 2px;
@@ -954,6 +1023,12 @@ mark.search-hl {
 .lane-head .lane-dot.crit { background: var(--danger); box-shadow: 0 0 10px var(--danger); }
 .lane-head .lane-dot.soon { background: var(--warn); }
 .lane-head .lane-dot.later { background: var(--accent); }
+/* Issue #686: lane-level color tint via :has() so each Now/Next/Later
+   container reads as semantically distinct without needing a class hook
+   on the lane itself. Modern browsers all support :has() (Chrome 105+). */
+.lane:has(.lane-dot.crit)  { border-left: 3px solid color-mix(in oklab, var(--danger) 55%, var(--border)); }
+.lane:has(.lane-dot.soon)  { border-left: 3px solid color-mix(in oklab, var(--warn)   55%, var(--border)); }
+.lane:has(.lane-dot.later) { border-left: 3px solid color-mix(in oklab, var(--accent) 40%, var(--border)); }
 .task {
   padding: 0;
   border-radius: 6px;
@@ -1046,12 +1121,52 @@ mark.search-hl {
   background: var(--bg); border: 1px solid var(--border);
   padding: 8px; border-radius: 4px; white-space: pre-wrap;
 }
+/* Issue #686: stronger separation between guidance (Why/Remediation/Learn more)
+   and metadata (severity/effort/frameworks). Solid border + extra spacing makes
+   the divider read as "section change" rather than "field separator". */
 .task-meta-row {
   display: flex; flex-wrap: wrap; gap: 12px;
   font-size: 10.5px; color: var(--muted);
-  padding-top: 8px; border-top: 1px dashed var(--border);
+  padding-top: 12px; margin-top: 4px;
+  border-top: 1px solid var(--border);
 }
 .task-meta-row b { color: var(--text-soft); font-weight: 600; }
+/* Issue #686: severity tag in the task head adopts the chip palette so a
+   consultant scanning Now/Next/Later can spot critical items at a glance
+   without expanding cards. Mirrors .sev-badge color logic. */
+.task-tag.task-tag-sev {
+  font-weight: 600;
+  border: 1px solid transparent;
+}
+.task-tag.task-tag-sev.sev-critical {
+  background: var(--danger-soft); color: var(--danger-text);
+  border-color: color-mix(in oklab, var(--danger) 35%, transparent);
+}
+.task-tag.task-tag-sev.sev-high {
+  background: rgba(255, 122, 69, 0.14); color: #ff7a45;
+  border-color: rgba(255, 122, 69, 0.35);
+}
+.task-tag.task-tag-sev.sev-medium {
+  background: var(--warn-soft); color: var(--warn-text);
+  border-color: color-mix(in oklab, var(--warn) 35%, transparent);
+}
+.task-tag.task-tag-sev.sev-low,
+.task-tag.task-tag-sev.sev-info {
+  background: color-mix(in oklab, var(--accent) 12%, transparent);
+  color: var(--accent-text);
+  border-color: color-mix(in oklab, var(--accent) 30%, transparent);
+}
+/* Issue #686: Learn more block gets a subtle accent left border so the
+   guidance/reference hierarchy is visible even without expanding cards. */
+.task-field-learn-more {
+  padding: 8px 10px;
+  border-left: 2px solid color-mix(in oklab, var(--accent) 45%, transparent);
+  background: color-mix(in oklab, var(--accent) 4%, transparent);
+  border-radius: 0 4px 4px 0;
+}
+.task-field-learn-more .task-field-label {
+  color: var(--accent-text);
+}
 .task-actions { padding-top: 2px; display: flex; flex-wrap: wrap; gap: 16px; }
 .task-actions a {
   font-size: 12px; color: var(--accent);


### PR DESCRIPTION
## Summary

Closes 4 small v2.6.0 (Finding Interaction) issues in a single PR. All changes scoped to the React report (`report-app.jsx` source, `report-app.js` Babel-built mirror, `report-shell.css`). No PowerShell or data-shape changes.

- **Closes #748** — Framework panel CTA shows filtered count when level chips are active (e.g. *"View 242 of 160 findings matching L1 + E3 →"*). Reuses the existing `matchProfileToken` helper.
- **Closes #687** — Remediation blocks split PowerShell commands from portal navigation steps. New `.remediation-ps` (code-style with violet "PowerShell" label) and `.remediation-portal` (prose with accent "Portal" label) blocks; segments preserve original order.
- **Closes #686** — Roadmap card visual polish: lane-level color tint via `:has()` (Now=danger, Next=warn, Later=accent), stronger solid divider between guidance and metadata, severity tag adopts chip palette colors, Learn more block gets accent border.
- **Closes #697** — Smart search: Enter cycles through matches, Shift+Enter reverses, Esc clears. Counter chip (`3/15`) appears inside the search input. Active match auto-expands and scrolls into center; previously cycled-to row auto-collapses. Reuses existing `focusFinding` + `highlight-focus` infrastructure.

## Implementation notes

- `report-app.jsx` is the source. `report-app.js` is regenerated via `npm run build` (Babel) — not hand-mirrored. CI's build-drift check will validate they match.
- `:has()` selector for lane tinting is a deliberate choice (vs. adding `lane-now`/`lane-soon`/`lane-later` classes) to keep the change CSS-only. Modern browser support is universal (Chrome 105+, Safari 15.4+, Firefox 121+).
- For #697, App owns the matches array (checkIds) and cursor; FindingsTable publishes filtered findings via `onMatchesChange` callback; Topbar drives advance/retreat. State lift mirrors the existing `roadmapOverrides` pattern.

## Test plan

- [x] `node --check src/M365-Assess/assets/report-app.js` passes
- [x] `npm run build` produces matching `.js` (no drift)
- [x] `Invoke-Pester -Path './tests/Common'` — 575/575 passing
- [x] PSScriptAnalyzer no new warnings
- [ ] Manual browser verification per acceptance criteria:
  - [ ] **#748** Framework Quilt: open CIS panel, click L1 chip → CTA reads `View N of 160 findings matching L1 →`. Add E3 → label updates. Clear chips → reverts.
  - [ ] **#687** Find a remediation with both portal text and `Run:` PS → confirms two distinct blocks render, never on the same line.
  - [ ] **#686** Open Roadmap, expand Now and Later tasks → confirms lane left-border tint, severity tag color, divider above metadata row, Learn more accent.
  - [ ] **#697** Type a query matching multiple findings → counter shows `1/N`. Enter cycles forward (auto-expand + scroll + collapse previous), Shift+Enter cycles back, Esc clears. Empty match → muted `0/0`.