### PR TITLE
feat(report): collapsible sections + trend opt-in + CMMC L2/L3 tooltip

### DIFF
--- a/src/M365-Assess/Common/Build-ReportData.ps1
+++ b/src/M365-Assess/Common/Build-ReportData.ps1
@@ -89,7 +89,10 @@ function Build-ReportDataJson {
         [string]$XlsxFileName = '',
 
         [Parameter()]
-        [hashtable]$CmmcHandoff = $null
+        [hashtable]$CmmcHandoff = $null,
+
+        [Parameter()]
+        [switch]$IncludeTrend
     )
 
     # ------------------------------------------------------------------
@@ -378,6 +381,7 @@ function Build-ReportDataJson {
         adHybrid       = $adHybridData
         deviceStats    = $deviceStats
         trendData      = $trendData
+        trendOptIn     = [bool]$IncludeTrend
         cmmcHandoff    = $CmmcHandoff
         cmmcCoverage   = $cmmcCoverage
     }

--- a/src/M365-Assess/Common/Export-AssessmentReport.ps1
+++ b/src/M365-Assess/Common/Export-AssessmentReport.ps1
@@ -71,6 +71,9 @@ param(
     [switch]$QuickScan,
 
     [Parameter()]
+    [switch]$IncludeTrend,
+
+    [Parameter()]
     [AllowEmptyCollection()]
     [PSCustomObject[]]$DriftReport = @(),
 
@@ -173,7 +176,8 @@ $reportJson = Build-ReportDataJson `
     -WhiteLabel:    $WhiteLabel `
     -XlsxFileName   $xlsxName `
     -FrameworkDefs  $allFrameworks `
-    -CmmcHandoff    $cmmcHandoff
+    -CmmcHandoff    $cmmcHandoff `
+    -IncludeTrend:  $IncludeTrend
 
 # ------------------------------------------------------------------
 # Assemble HTML and write output

--- a/src/M365-Assess/Invoke-M365Assessment.ps1
+++ b/src/M365-Assess/Invoke-M365Assessment.ps1
@@ -90,6 +90,11 @@
     Lists all saved baselines for the tenant (label, date, registry version,
     check count) and exits without running an assessment. Use -TenantId to
     scope results; omit to list baselines for all tenants.
+.PARAMETER IncludeTrend
+    Renders the Posture trend section in the HTML report when two or more
+    baselines exist for the tenant. Off by default — baselines still auto-save
+    for drift comparison, but the trend section appears only when the user
+    explicitly opts in to longitudinal posture tracking.
 .PARAMETER DryRun
     Show a dry-run preview of what the assessment would do (sections,
     services, Graph scopes, check counts) without connecting or collecting
@@ -242,6 +247,9 @@ param(
 
     [Parameter()]
     [switch]$ListBaselines,
+
+    [Parameter()]
+    [switch]$IncludeTrend,
 
     [Parameter(ParameterSetName = 'ConnectionProfile', Mandatory)]
     [ArgumentCompleter({
@@ -1307,6 +1315,7 @@ if (Test-Path -Path $reportScriptPath) {
         if ($CompactReport)     { $reportParams['CompactReport']     = $true }
         if ($OpenReport)        { $reportParams['OpenReport']        = $true }
         if ($QuickScan)         { $reportParams['QuickScan']         = $true }
+        if ($IncludeTrend)      { $reportParams['IncludeTrend']      = $true }
         if ($driftReport.Count -gt 0 -or $driftBaselineLabel) {
             $reportParams['DriftReport']            = $driftReport
             $reportParams['DriftBaselineLabel']     = $driftBaselineLabel

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -581,6 +581,36 @@ function Sidebar({
   }, fmt(MFA_STATS.adminsWithoutMfa)))))));
 }
 
+// Issue #737: shared collapsible-section hook. Each top-level section's
+// .section-head spreads `headProps` to gain click + keyboard toggle. The
+// `beforeprint` listener auto-expands so PDF/print exports never lose
+// content that happens to be collapsed in-screen.
+function useCollapsibleSection(defaultOpen = true) {
+  const [open, setOpen] = useState(defaultOpen);
+  useEffect(() => {
+    const expand = () => setOpen(true);
+    window.addEventListener('beforeprint', expand);
+    return () => window.removeEventListener('beforeprint', expand);
+  }, []);
+  const headProps = {
+    role: 'button',
+    tabIndex: 0,
+    'aria-expanded': open,
+    className: 'section-head section-head-toggle' + (open ? '' : ' is-closed'),
+    onClick: () => setOpen(o => !o),
+    onKeyDown: e => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        setOpen(o => !o);
+      }
+    }
+  };
+  return {
+    open,
+    headProps
+  };
+}
+
 // ======================== Topbar ========================
 function Topbar({
   search,
@@ -1002,7 +1032,15 @@ function Sparkline({
 
 // ======================== TrendChart (assessment-to-assessment #642) ========================
 function TrendChart() {
+  const {
+    open,
+    headProps
+  } = useCollapsibleSection();
   const trend = D.trendData;
+  // Issue #750: Posture trend is opt-in. Renders only when the assessment was
+  // run with -IncludeTrend (which propagates to D.trendOptIn) AND there are
+  // enough snapshots for a meaningful chart.
+  if (!D.trendOptIn) return null;
   if (!trend || trend.length < 2) return null;
 
   // One line per status track (Pass / Warn / Fail) — most informative triple for a quick read.
@@ -1043,15 +1081,16 @@ function TrendChart() {
   return /*#__PURE__*/React.createElement("section", {
     className: "block",
     id: "trend"
-  }, /*#__PURE__*/React.createElement("div", {
-    className: "section-head"
-  }, /*#__PURE__*/React.createElement("span", {
+  }, /*#__PURE__*/React.createElement("div", headProps, /*#__PURE__*/React.createElement("span", {
     className: "eyebrow"
   }, "01b \xB7 Trend"), /*#__PURE__*/React.createElement("h2", null, "Posture trend"), /*#__PURE__*/React.createElement("span", {
     className: "trend-subtitle"
-  }, trend.length, " snapshots \xB7 ", daysSpan, " day", daysSpan === 1 ? '' : 's', " span"), /*#__PURE__*/React.createElement("div", {
+  }, trend.length, " snapshots \xB7 ", daysSpan, " day", daysSpan === 1 ? '' : 's', " span"), /*#__PURE__*/React.createElement("span", {
+    className: "section-chevron",
+    "aria-hidden": "true"
+  }, open ? '▾' : '▸'), /*#__PURE__*/React.createElement("div", {
     className: "hr"
-  })), /*#__PURE__*/React.createElement("div", {
+  })), open && /*#__PURE__*/React.createElement("div", {
     className: "trend-chart-wrap"
   }, /*#__PURE__*/React.createElement("svg", {
     viewBox: `0 0 ${W} ${H}`,
@@ -1850,6 +1889,10 @@ function FrameworkQuilt({
   onProfileSelect,
   activeProfiles
 }) {
+  const {
+    open,
+    headProps
+  } = useCollapsibleSection();
   const [visibleFws, setVisibleFws] = useState(['cis-m365-v6']);
   const [pickerOpen, setPickerOpen] = useState(false);
   // Panel open by default (#735): the first visible framework ('cis-m365-v6' initially)
@@ -1983,9 +2026,7 @@ function FrameworkQuilt({
   return /*#__PURE__*/React.createElement("section", {
     className: "block",
     id: "frameworks"
-  }, /*#__PURE__*/React.createElement("div", {
-    className: "section-head"
-  }, /*#__PURE__*/React.createElement("span", {
+  }, /*#__PURE__*/React.createElement("div", headProps, /*#__PURE__*/React.createElement("span", {
     className: "eyebrow"
   }, "01 \xB7 Compliance"), /*#__PURE__*/React.createElement("h2", null, "Framework coverage"), /*#__PURE__*/React.createElement("div", {
     ref: pickerRef,
@@ -1993,7 +2034,8 @@ function FrameworkQuilt({
       position: 'relative',
       marginLeft: 12,
       flexShrink: 0
-    }
+    },
+    onClick: e => e.stopPropagation()
   }, /*#__PURE__*/React.createElement("button", {
     className: 'chip chip-more' + (visibleFws.length > 1 ? ' selected' : ''),
     onClick: () => setPickerOpen(o => !o)
@@ -2043,9 +2085,12 @@ function FrameworkQuilt({
     }
   }, f.id)), /*#__PURE__*/React.createElement("span", {
     className: "ct"
-  }, byFw[f.id]?.total || 0))))), /*#__PURE__*/React.createElement("div", {
+  }, byFw[f.id]?.total || 0))))), /*#__PURE__*/React.createElement("span", {
+    className: "section-chevron",
+    "aria-hidden": "true"
+  }, open ? '▾' : '▸'), /*#__PURE__*/React.createElement("div", {
     className: "hr"
-  })), /*#__PURE__*/React.createElement("div", {
+  })), open && /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement("div", {
     className: "quilt"
   }, displayFws.map(f => {
     const d = byFw[f.id];
@@ -2178,7 +2223,10 @@ function FrameworkQuilt({
     className: 'fw-profile-chip level3 fw-profile-chip-btn' + ((activeProfiles || []).includes('L3') ? ' selected' : ''),
     onClick: () => handleProfileClick('L3'),
     "aria-pressed": (activeProfiles || []).includes('L3')
-  }, "L3 ", /*#__PURE__*/React.createElement("b", null, fwProfileStats.l3))) : /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement("button", {
+  }, "L3 ", /*#__PURE__*/React.createElement("b", null, fwProfileStats.l3)), fwProfileStats.l3 > 0 && /*#__PURE__*/React.createElement("span", {
+    className: "fw-profile-info",
+    title: "L2 includes all L3 practices. Every CMMC L3 control is also assessed at L2 by design \u2014 selecting L2 will count L3 checks too."
+  }, "L2 \u2287 L3")) : /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement("button", {
     type: "button",
     className: 'fw-profile-chip level fw-profile-chip-btn' + ((activeProfiles || []).includes('L1') ? ' selected' : ''),
     onClick: () => handleProfileClick('L1'),
@@ -2337,7 +2385,7 @@ function FrameworkQuilt({
         block: 'start'
       });
     }
-  }, (activeProfiles || []).length === 0 ? /*#__PURE__*/React.createElement(React.Fragment, null, "View all ", expandedData.total, " findings in this framework \u2192") : /*#__PURE__*/React.createElement(React.Fragment, null, "View ", selectedCount, " of ", expandedData.total, " findings matching ", (activeProfiles || []).join(' + '), " \u2192")))));
+  }, (activeProfiles || []).length === 0 ? /*#__PURE__*/React.createElement(React.Fragment, null, "View all ", expandedData.total, " findings in this framework \u2192") : /*#__PURE__*/React.createElement(React.Fragment, null, "View ", selectedCount, " of ", expandedData.total, " findings matching ", (activeProfiles || []).join(' + '), " \u2192"))))));
 }
 
 // ======================== Filter bar ========================
@@ -2665,6 +2713,10 @@ function FindingsTable({
   onHideBulk,
   onRestoreAll
 }) {
+  const {
+    open: sectionOpen,
+    headProps
+  } = useCollapsibleSection();
   const [open, setOpen] = useState(new Set());
   const [visibleCols, setVisibleCols] = useState(DEFAULT_COLS);
   const [colPickerOpen, setColPickerOpen] = useState(false);
@@ -2895,9 +2947,7 @@ function FindingsTable({
   return /*#__PURE__*/React.createElement("section", {
     className: "block",
     id: "findings"
-  }, /*#__PURE__*/React.createElement("div", {
-    className: "section-head"
-  }, /*#__PURE__*/React.createElement("span", {
+  }, /*#__PURE__*/React.createElement("div", headProps, /*#__PURE__*/React.createElement("span", {
     className: "eyebrow"
   }, "03 \xB7 Detail"), /*#__PURE__*/React.createElement("h2", null, "All findings", isFiltered ? /*#__PURE__*/React.createElement("span", {
     style: {
@@ -2919,14 +2969,20 @@ function FindingsTable({
     }
   }, " \xB7 ", FINDINGS.length, " total")), editMode && hiddenFindings?.size > 0 && /*#__PURE__*/React.createElement("button", {
     className: "restore-all-btn",
-    onClick: onRestoreAll
+    onClick: e => {
+      e.stopPropagation();
+      onRestoreAll();
+    }
   }, "\u21A9 Restore ", hiddenFindings.size, " hidden"), /*#__PURE__*/React.createElement("button", {
     className: "chip chip-more",
     style: {
       marginLeft: 12,
       flexShrink: 0
     },
-    onClick: () => setOpen(open.size === filtered.length && filtered.length > 0 ? new Set() : new Set(filtered.map((_, i) => i))),
+    onClick: e => {
+      e.stopPropagation();
+      setOpen(open.size === filtered.length && filtered.length > 0 ? new Set() : new Set(filtered.map((_, i) => i)));
+    },
     title: open.size === filtered.length && filtered.length > 0 ? 'Collapse all findings' : 'Expand all findings'
   }, open.size === filtered.length && filtered.length > 0 ? '− Collapse all' : '+ Expand all'), /*#__PURE__*/React.createElement("div", {
     ref: colPickerRef,
@@ -2934,7 +2990,8 @@ function FindingsTable({
       position: 'relative',
       marginLeft: 8,
       flexShrink: 0
-    }
+    },
+    onClick: e => e.stopPropagation()
   }, /*#__PURE__*/React.createElement("button", {
     className: 'chip chip-more' + (visibleCols.length !== DEFAULT_COLS.length ? ' selected' : ''),
     onClick: () => setColPickerOpen(o => !o),
@@ -2977,9 +3034,12 @@ function FindingsTable({
     type: "checkbox",
     checked: visibleCols.includes(c.id),
     onChange: () => toggleCol(c.id)
-  }), /*#__PURE__*/React.createElement("span", null, c.label))))), /*#__PURE__*/React.createElement("div", {
+  }), /*#__PURE__*/React.createElement("span", null, c.label))))), /*#__PURE__*/React.createElement("span", {
+    className: "section-chevron",
+    "aria-hidden": "true"
+  }, sectionOpen ? '▾' : '▸'), /*#__PURE__*/React.createElement("div", {
     className: "hr"
-  })), /*#__PURE__*/React.createElement("div", {
+  })), sectionOpen && /*#__PURE__*/React.createElement("div", {
     className: "findings"
   }, /*#__PURE__*/React.createElement("div", {
     className: "findings-head",
@@ -3136,6 +3196,10 @@ function Roadmap({
   roadmapOverrides,
   onRoadmapChange
 }) {
+  const {
+    open: sectionOpen,
+    headProps
+  } = useCollapsibleSection();
   const [open, setOpen] = useState(null);
   const moveTo = (checkId, lane) => {
     onRoadmapChange({
@@ -3402,19 +3466,23 @@ function Roadmap({
   return /*#__PURE__*/React.createElement("section", {
     className: "block",
     id: "roadmap"
-  }, /*#__PURE__*/React.createElement("div", {
-    className: "section-head"
-  }, /*#__PURE__*/React.createElement("span", {
+  }, /*#__PURE__*/React.createElement("div", headProps, /*#__PURE__*/React.createElement("span", {
     className: "eyebrow"
-  }, "04 \xB7 Action plan"), /*#__PURE__*/React.createElement("h2", null, "Remediation roadmap"), /*#__PURE__*/React.createElement("div", {
+  }, "04 \xB7 Action plan"), /*#__PURE__*/React.createElement("h2", null, "Remediation roadmap"), /*#__PURE__*/React.createElement("span", {
+    className: "section-chevron",
+    "aria-hidden": "true"
+  }, sectionOpen ? '▾' : '▸'), /*#__PURE__*/React.createElement("div", {
     className: "hr"
   }), /*#__PURE__*/React.createElement("button", {
     className: "lane-reset-btn",
     style: {
       marginTop: '8px'
     },
-    onClick: downloadCsv
-  }, "Download CSV")), /*#__PURE__*/React.createElement("div", {
+    onClick: e => {
+      e.stopPropagation();
+      downloadCsv();
+    }
+  }, "Download CSV")), sectionOpen && /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement("div", {
     className: "roadmap-intro"
   }, /*#__PURE__*/React.createElement("div", {
     className: "roadmap-intro-head"
@@ -3498,11 +3566,15 @@ function Roadmap({
     laneItems: later
   }), /*#__PURE__*/React.createElement("div", {
     className: "lane-eta"
-  }, "1 \u2013 3 months"))), later.map(t => renderTask(t, 'later')))));
+  }, "1 \u2013 3 months"))), later.map(t => renderTask(t, 'later'))))));
 }
 
 // ======================== Critical Exposure section ========================
 function StrykerBlock() {
+  const {
+    open,
+    headProps
+  } = useCollapsibleSection();
   const stryker = FINDINGS.filter(f => f.domain === 'Stryker Readiness');
   if (!stryker.length) return null;
   const fail = stryker.filter(f => f.status === 'Fail').length;
@@ -3510,13 +3582,14 @@ function StrykerBlock() {
   return /*#__PURE__*/React.createElement("section", {
     className: "block",
     id: "stryker"
-  }, /*#__PURE__*/React.createElement("div", {
-    className: "section-head"
-  }, /*#__PURE__*/React.createElement("span", {
+  }, /*#__PURE__*/React.createElement("div", headProps, /*#__PURE__*/React.createElement("span", {
     className: "eyebrow"
-  }, "01b \xB7 Targeted"), /*#__PURE__*/React.createElement("h2", null, "Critical exposure analysis"), /*#__PURE__*/React.createElement("div", {
+  }, "01b \xB7 Targeted"), /*#__PURE__*/React.createElement("h2", null, "Critical exposure analysis"), /*#__PURE__*/React.createElement("span", {
+    className: "section-chevron",
+    "aria-hidden": "true"
+  }, open ? '▾' : '▸'), /*#__PURE__*/React.createElement("div", {
     className: "hr"
-  })), /*#__PURE__*/React.createElement("div", {
+  })), open && /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement("div", {
     className: "card",
     style: {
       marginBottom: 12,
@@ -3619,7 +3692,7 @@ function StrykerBlock() {
   }, f.frameworks.map(fw => /*#__PURE__*/React.createElement("span", {
     key: fw,
     className: "fw-pill"
-  }, fw))), /*#__PURE__*/React.createElement("div", null)))));
+  }, fw))), /*#__PURE__*/React.createElement("div", null))))));
 }
 
 // ======================== Overview (tenant + summary) ========================
@@ -3645,6 +3718,10 @@ function Overview() {
 
 // ======================== Appendix ========================
 function Appendix() {
+  const {
+    open,
+    headProps
+  } = useCollapsibleSection();
   const mfaTotal = MFA_STATS.total || 1;
   const mfaPct = n => Math.round(n / mfaTotal * 100);
   const ca = D.ca || [];
@@ -3686,13 +3763,14 @@ function Appendix() {
   return /*#__PURE__*/React.createElement("section", {
     className: "block",
     id: "appendix"
-  }, /*#__PURE__*/React.createElement("div", {
-    className: "section-head"
-  }, /*#__PURE__*/React.createElement("span", {
+  }, /*#__PURE__*/React.createElement("div", headProps, /*#__PURE__*/React.createElement("span", {
     className: "eyebrow"
-  }, "05 \xB7 Reference"), /*#__PURE__*/React.createElement("h2", null, "Tenant appendix"), /*#__PURE__*/React.createElement("div", {
+  }, "05 \xB7 Reference"), /*#__PURE__*/React.createElement("h2", null, "Tenant appendix"), /*#__PURE__*/React.createElement("span", {
+    className: "section-chevron",
+    "aria-hidden": "true"
+  }, open ? '▾' : '▸'), /*#__PURE__*/React.createElement("div", {
     className: "hr"
-  })), /*#__PURE__*/React.createElement("div", {
+  })), open && /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement("div", {
     className: "card",
     style: {
       marginBottom: 14
@@ -3996,7 +4074,7 @@ function Appendix() {
       textAlign: 'right',
       fontFamily: 'var(--font-mono)'
     }
-  }, String(ad.lastSync).slice(0, 19).replace('T', ' '))))))));
+  }, String(ad.lastSync).slice(0, 19).replace('T', ' ')))))))));
 }
 function StatusDot({
   ok,

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -277,6 +277,30 @@ function Sidebar({ active, activeSubsection, counts, domainCounts, activeDomain,
   );
 }
 
+// Issue #737: shared collapsible-section hook. Each top-level section's
+// .section-head spreads `headProps` to gain click + keyboard toggle. The
+// `beforeprint` listener auto-expands so PDF/print exports never lose
+// content that happens to be collapsed in-screen.
+function useCollapsibleSection(defaultOpen = true) {
+  const [open, setOpen] = useState(defaultOpen);
+  useEffect(() => {
+    const expand = () => setOpen(true);
+    window.addEventListener('beforeprint', expand);
+    return () => window.removeEventListener('beforeprint', expand);
+  }, []);
+  const headProps = {
+    role: 'button',
+    tabIndex: 0,
+    'aria-expanded': open,
+    className: 'section-head section-head-toggle' + (open ? '' : ' is-closed'),
+    onClick: () => setOpen(o => !o),
+    onKeyDown: (e) => {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setOpen(o => !o); }
+    },
+  };
+  return { open, headProps };
+}
+
 // ======================== Topbar ========================
 function Topbar({ search, setSearch, searchMatches, matchIdx, onAdvanceMatch, onRetreatMatch, mode, setMode, theme, setTheme, textScale, setTextScale, onPrint, onTweaks, onHamburger, editMode, onEditToggle, onFinalize, onReset, hiddenCount }) {
   const SCALE_CYCLE = ['normal', 'large', 'xlarge'];
@@ -571,7 +595,12 @@ function Sparkline({ scores, avg }) {
 
 // ======================== TrendChart (assessment-to-assessment #642) ========================
 function TrendChart() {
+  const { open, headProps } = useCollapsibleSection();
   const trend = D.trendData;
+  // Issue #750: Posture trend is opt-in. Renders only when the assessment was
+  // run with -IncludeTrend (which propagates to D.trendOptIn) AND there are
+  // enough snapshots for a meaningful chart.
+  if (!D.trendOptIn) return null;
   if (!trend || trend.length < 2) return null;
 
   // One line per status track (Pass / Warn / Fail) — most informative triple for a quick read.
@@ -605,13 +634,14 @@ function TrendChart() {
 
   return (
     <section className="block" id="trend">
-      <div className="section-head">
+      <div {...headProps}>
         <span className="eyebrow">01b · Trend</span>
         <h2>Posture trend</h2>
         <span className="trend-subtitle">{trend.length} snapshots · {daysSpan} day{daysSpan===1?'':'s'} span</span>
+        <span className="section-chevron" aria-hidden="true">{open ? '▾' : '▸'}</span>
         <div className="hr"/>
       </div>
-      <div className="trend-chart-wrap">
+      {open && <div className="trend-chart-wrap">
         <svg viewBox={`0 0 ${W} ${H}`} width="100%" preserveAspectRatio="xMidYMid meet" className="trend-chart">
           {/* Y-axis gridlines + labels */}
           {yTicks.map((v, i) => (
@@ -656,7 +686,7 @@ function TrendChart() {
             </span>
           ))}
         </div>
-      </div>
+      </div>}
     </section>
   );
 }
@@ -1101,6 +1131,7 @@ const matchProfileToken = (profilesArr, token) => {
 
 // ======================== Framework quilt ========================
 function FrameworkQuilt({ onSelect, selected, onProfileSelect, activeProfiles }) {
+  const { open, headProps } = useCollapsibleSection();
   const [visibleFws, setVisibleFws] = useState(['cis-m365-v6']);
   const [pickerOpen, setPickerOpen] = useState(false);
   // Panel open by default (#735): the first visible framework ('cis-m365-v6' initially)
@@ -1215,10 +1246,10 @@ function FrameworkQuilt({ onSelect, selected, onProfileSelect, activeProfiles })
 
   return (
     <section className="block" id="frameworks">
-      <div className="section-head">
+      <div {...headProps}>
         <span className="eyebrow">01 · Compliance</span>
         <h2>Framework coverage</h2>
-        <div ref={pickerRef} style={{position:'relative', marginLeft:12, flexShrink:0}}>
+        <div ref={pickerRef} style={{position:'relative', marginLeft:12, flexShrink:0}} onClick={e => e.stopPropagation()}>
           <button className={'chip chip-more' + (visibleFws.length > 1 ? ' selected' : '')}
                   onClick={() => setPickerOpen(o => !o)}>
             {pickerLabel}
@@ -1239,8 +1270,10 @@ function FrameworkQuilt({ onSelect, selected, onProfileSelect, activeProfiles })
             </div>
           )}
         </div>
+        <span className="section-chevron" aria-hidden="true">{open ? '▾' : '▸'}</span>
         <div className="hr"/>
       </div>
+      {open && (<>
       <div className="quilt">
         {displayFws.map(f => {
           const d = byFw[f.id];
@@ -1314,6 +1347,8 @@ function FrameworkQuilt({ onSelect, selected, onProfileSelect, activeProfiles })
                   {fwProfileStats.l1 > 0 && <button type="button" className={'fw-profile-chip level fw-profile-chip-btn' + ((activeProfiles || []).includes('L1') ? ' selected' : '')} onClick={() => handleProfileClick('L1')} aria-pressed={(activeProfiles || []).includes('L1')}>L1 <b>{fwProfileStats.l1}</b></button>}
                   {fwProfileStats.l2 > 0 && <button type="button" className={'fw-profile-chip level2 fw-profile-chip-btn' + ((activeProfiles || []).includes('L2') ? ' selected' : '')} onClick={() => handleProfileClick('L2')} aria-pressed={(activeProfiles || []).includes('L2')}>L2 <b>{fwProfileStats.l2}</b></button>}
                   {fwProfileStats.l3 > 0 && <button type="button" className={'fw-profile-chip level3 fw-profile-chip-btn' + ((activeProfiles || []).includes('L3') ? ' selected' : '')} onClick={() => handleProfileClick('L3')} aria-pressed={(activeProfiles || []).includes('L3')}>L3 <b>{fwProfileStats.l3}</b></button>}
+                  {/* Issue #744: every CMMC L3 check is also tagged L2 in the registry (no L3-only checks exist), so L2 is a strict superset. Surfaces the inheritance so users don't read L2 + L3 as disjoint sets. */}
+                  {fwProfileStats.l3 > 0 && <span className="fw-profile-info" title="L2 includes all L3 practices. Every CMMC L3 control is also assessed at L2 by design — selecting L2 will count L3 checks too.">L2 ⊇ L3</span>}
                 </>
               ) : (
                 <>
@@ -1387,6 +1422,7 @@ function FrameworkQuilt({ onSelect, selected, onProfileSelect, activeProfiles })
           </div>
         </div>
       )}
+      </>)}
     </section>
   );
 }
@@ -1594,6 +1630,7 @@ const ALL_COLS = [
 const DEFAULT_COLS = ['status', 'finding', 'domain', 'controlId', 'checkId', 'severity'];
 
 function FindingsTable({ filters, search, focusFinding, onFocusClear, onMatchesChange, editMode, hiddenFindings, onHide, onHideBulk, onRestoreAll }) {
+  const { open: sectionOpen, headProps } = useCollapsibleSection();
   const [open, setOpen] = useState(new Set());
   const [visibleCols, setVisibleCols] = useState(DEFAULT_COLS);
   const [colPickerOpen, setColPickerOpen] = useState(false);
@@ -1778,23 +1815,23 @@ function FindingsTable({ filters, search, focusFinding, onFocusClear, onMatchesC
 
   return (
     <section className="block" id="findings">
-      <div className="section-head">
+      <div {...headProps}>
         <span className="eyebrow">03 · Detail</span>
         <h2>All findings{isFiltered
           ? <span style={{marginLeft:8,fontSize:12,fontWeight:500,background:'var(--accent-soft)',border:'1px solid var(--accent-border)',color:'var(--accent-text)',borderRadius:20,padding:'2px 10px',verticalAlign:'middle'}}>Showing {filtered.length} of {FINDINGS.length}</span>
           : <span style={{fontWeight:400,color:'var(--muted)',fontSize:13}}> · {FINDINGS.length} total</span>
         }</h2>
         {editMode && (hiddenFindings?.size > 0) && (
-          <button className="restore-all-btn" onClick={onRestoreAll}>
+          <button className="restore-all-btn" onClick={e => {e.stopPropagation(); onRestoreAll();}}>
             ↩ Restore {hiddenFindings.size} hidden
           </button>
         )}
         <button className="chip chip-more" style={{marginLeft:12,flexShrink:0}}
-                onClick={() => setOpen(open.size === filtered.length && filtered.length > 0 ? new Set() : new Set(filtered.map((_,i) => i)))}
+                onClick={e => {e.stopPropagation(); setOpen(open.size === filtered.length && filtered.length > 0 ? new Set() : new Set(filtered.map((_,i) => i)));}}
                 title={open.size === filtered.length && filtered.length > 0 ? 'Collapse all findings' : 'Expand all findings'}>
           {open.size === filtered.length && filtered.length > 0 ? '− Collapse all' : '+ Expand all'}
         </button>
-        <div ref={colPickerRef} style={{position:'relative', marginLeft:8, flexShrink:0}}>
+        <div ref={colPickerRef} style={{position:'relative', marginLeft:8, flexShrink:0}} onClick={e => e.stopPropagation()}>
           <button className={'chip chip-more' + (visibleCols.length !== DEFAULT_COLS.length ? ' selected' : '')}
                   onClick={() => setColPickerOpen(o => !o)} title="Choose columns">
             <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" style={{marginRight:4}}><path d="M3 5h10M3 11h10"/><circle cx="6" cy="5" r="1.5" fill="currentColor" stroke="none"/><circle cx="10" cy="11" r="1.5" fill="currentColor" stroke="none"/></svg>
@@ -1811,10 +1848,11 @@ function FindingsTable({ filters, search, focusFinding, onFocusClear, onMatchesC
             </div>
           )}
         </div>
+        <span className="section-chevron" aria-hidden="true">{sectionOpen ? '▾' : '▸'}</span>
         <div className="hr"/>
       </div>
 
-      <div className="findings">
+      {sectionOpen && <div className="findings">
         <div className="findings-head" style={{gridTemplateColumns: gridTpl}}>
           {cols.map(c => <div key={c.id}>{c.label}</div>)}
           <div/>
@@ -1883,7 +1921,7 @@ function FindingsTable({ filters, search, focusFinding, onFocusClear, onMatchesC
             </React.Fragment>
           );
         })}
-      </div>
+      </div>}
     </section>
   );
 }
@@ -1954,6 +1992,7 @@ function whyItMatters(f) {
 
 // ======================== Roadmap ========================
 function Roadmap({ onViewFinding, editMode, hiddenFindings, roadmapOverrides, onRoadmapChange }) {
+  const { open: sectionOpen, headProps } = useCollapsibleSection();
   const [open, setOpen] = useState(null);
 
   const moveTo = (checkId, lane) => {
@@ -2143,13 +2182,14 @@ function Roadmap({ onViewFinding, editMode, hiddenFindings, roadmapOverrides, on
 
   return (
     <section className="block" id="roadmap">
-      <div className="section-head">
+      <div {...headProps}>
         <span className="eyebrow">04 · Action plan</span>
         <h2>Remediation roadmap</h2>
+        <span className="section-chevron" aria-hidden="true">{sectionOpen ? '▾' : '▸'}</span>
         <div className="hr"/>
-        <button className="lane-reset-btn" style={{marginTop:'8px'}} onClick={downloadCsv}>Download CSV</button>
+        <button className="lane-reset-btn" style={{marginTop:'8px'}} onClick={e => {e.stopPropagation(); downloadCsv();}}>Download CSV</button>
       </div>
-      <div className="roadmap-intro">
+      {sectionOpen && <><div className="roadmap-intro">
         <div className="roadmap-intro-head">How we prioritized</div>
         <div className="roadmap-intro-body">
           Findings are bucketed by severity. Critical findings — identity takeover, data exfiltration, privilege escalation paths — always go in <b>Now</b>. High-severity findings land in <b>Next</b>: risk is real but remediation typically requires coordination or scheduling. Medium-severity items also join <b>Next</b> when tractable, or <b>Later</b> for larger hardening work. <br/>
@@ -2187,25 +2227,27 @@ function Roadmap({ onViewFinding, editMode, hiddenFindings, roadmapOverrides, on
           </div>
           {later.map(t => renderTask(t, 'later'))}
         </div>
-      </div>
+      </div></>}
     </section>
   );
 }
 
 // ======================== Critical Exposure section ========================
 function StrykerBlock() {
+  const { open, headProps } = useCollapsibleSection();
   const stryker = FINDINGS.filter(f => f.domain === 'Stryker Readiness');
   if (!stryker.length) return null;
   const fail = stryker.filter(f => f.status==='Fail').length;
   const pass = stryker.filter(f => f.status==='Pass').length;
   return (
     <section className="block" id="stryker">
-      <div className="section-head">
+      <div {...headProps}>
         <span className="eyebrow">01b · Targeted</span>
         <h2>Critical exposure analysis</h2>
+        <span className="section-chevron" aria-hidden="true">{open ? '▾' : '▸'}</span>
         <div className="hr"/>
       </div>
-      <div className="card" style={{marginBottom:12, display:'flex', gap:24, alignItems:'center', flexWrap:'wrap'}}>
+      {open && <><div className="card" style={{marginBottom:12, display:'flex', gap:24, alignItems:'center', flexWrap:'wrap'}}>
         <div>
           <div style={{fontSize:12, color:'var(--muted)', textTransform:'uppercase', letterSpacing:'.1em', fontWeight:600}}>Coverage</div>
           <div style={{fontSize:34, fontWeight:700, fontFamily:'var(--font-display)', letterSpacing:'-.02em'}}>
@@ -2235,7 +2277,7 @@ function StrykerBlock() {
             <div/>
           </div>
         ))}
-      </div>
+      </div></>}
     </section>
   );
 }
@@ -2268,6 +2310,7 @@ function Overview() {
 
 // ======================== Appendix ========================
 function Appendix() {
+  const { open, headProps } = useCollapsibleSection();
   const mfaTotal = MFA_STATS.total || 1;
   const mfaPct = n => Math.round((n / mfaTotal) * 100);
 
@@ -2301,13 +2344,14 @@ function Appendix() {
 
   return (
     <section className="block" id="appendix">
-      <div className="section-head">
+      <div {...headProps}>
         <span className="eyebrow">05 · Reference</span>
         <h2>Tenant appendix</h2>
+        <span className="section-chevron" aria-hidden="true">{open ? '▾' : '▸'}</span>
         <div className="hr"/>
       </div>
 
-      <div className="card" style={{marginBottom:14}}>
+      {open && <><div className="card" style={{marginBottom:14}}>
         <div style={labelStyle}>Tenant</div>
         <div style={{display:'flex',flexWrap:'wrap',gap:'6px 24px',fontSize:12}}>
           <span><span style={{color:'var(--muted)'}}>org</span> <b>{TENANT.OrgDisplayName}</b></span>
@@ -2454,7 +2498,7 @@ function Appendix() {
             </table>
           </div>
         )}
-      </div>
+      </div></>}
     </section>
   );
 }

--- a/src/M365-Assess/assets/report-shell.css
+++ b/src/M365-Assess/assets/report-shell.css
@@ -301,6 +301,41 @@ section.block { margin-bottom: 52px; scroll-margin-top: 20px; }
   color: var(--accent);
 }
 .section-head .hr { flex: 1; height: 1px; background: var(--border); }
+/* Issue #737: every section header is now collapsible. The .section-head-toggle
+   class is added by the useCollapsibleSection hook for sections that opt in. */
+.section-head-toggle {
+  cursor: pointer;
+  user-select: none;
+  border-radius: 4px;
+  padding: 2px 4px;
+  margin-left: -4px;
+  margin-right: -4px;
+  transition: background 0.12s;
+}
+.section-head-toggle:hover {
+  background: color-mix(in oklab, var(--accent) 6%, transparent);
+}
+.section-head-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.section-head-toggle.is-closed {
+  margin-bottom: 0;
+}
+/* Issue #744: small inline indicator on the CMMC chip row clarifying that L2
+   is a strict superset of L3 (no L3-only-by-controlId checks exist). Hover
+   surfaces the longer explanation via the title attribute. */
+.fw-profile-info {
+  display: inline-flex; align-items: center;
+  font-family: var(--font-mono); font-size: 10.5px;
+  padding: 2px 6px; border-radius: 3px;
+  background: color-mix(in oklab, var(--accent) 8%, transparent);
+  color: var(--muted);
+  border: 1px dashed color-mix(in oklab, var(--accent) 30%, transparent);
+  margin-left: 4px;
+  cursor: help;
+  letter-spacing: 0.04em;
+}
 
 /* ---------- Cards ---------- */
 .card {


### PR DESCRIPTION
## Summary

Closes 3 v2.6.0 issues. Bundles two report-UX changes (#737, #744) with one PowerShell-side opt-in (#750) since they all touch the report layer.

- **Closes #737** — Every top-level section header is collapsible. Click the section-head to toggle, beforeprint auto-expands, plain useState (no localStorage). New \`useCollapsibleSection\` hook applied to Trend, FrameworkQuilt, FindingsTable, Roadmap, StrykerBlock, Appendix. DomainRollup keeps its existing toggle.
- **Closes #750** — Posture trend now explicitly opt-in via new \`-IncludeTrend\` switch on \`Invoke-M365Assessment\` (threaded through Export-AssessmentReport → Build-ReportData → \`window.REPORT_DATA.trendOptIn\`). TrendChart returns null when off. Baselines still auto-save for drift comparison; only the section visibility is gated.
- **Closes #744** — Tiny "L2 ⊇ L3" pill chip on the CMMC chip row with hover tooltip: "L2 includes all L3 practices. Every CMMC L3 control is also assessed at L2 by design." Verified by probe: zero L3-only-by-controlId checks exist in the v2.22.1 registry — Explanation A from the issue body confirmed.

## Implementation notes

- Hook approach (\`useCollapsibleSection\`) over wrapper component because each section's head has different inline content (subtitle, picker buttons, expand-all). Hook returns \`{open, headProps}\`; sections spread \`headProps\` onto existing \`.section-head\` divs and gate body in \`{open && (<>...</>)}\`.
- Interactive elements inside section-heads (framework picker, columns picker, restore-all, expand-all, download CSV) get \`onClick={e => e.stopPropagation()}\` so clicking them doesn't toggle the section.
- The \`open\` symbol clashes with Roadmap's per-task \`open\` state, so the hook return is renamed to \`sectionOpen\`/\`sectionHeadProps\` in Roadmap and FindingsTable.

## Test plan

- [x] \`npm run build\` clean (Babel produces matching .js)
- [x] \`Invoke-Pester -Path './tests/Common'\` — 575/575 passing
- [ ] Manual browser verification:
  - [ ] **#737** Click each section header → body collapses, chevron flips, header stays visible. Print preview expands all.
  - [ ] **#750** Run assessment without \`-IncludeTrend\` → no Trend section. Run with \`-IncludeTrend\` and ≥2 baselines → Trend section appears.
  - [ ] **#744** Open Framework Quilt → CIS or CMMC panel → see "L2 ⊇ L3" pill on CMMC chip row, hover shows tooltip.