### PR TITLE
feat(xlsx): Horizon column + Remediation Roadmap sheet (closes #715)

### DIFF
--- a/src/M365-Assess/Common/Build-ReportData.ps1
+++ b/src/M365-Assess/Common/Build-ReportData.ps1
@@ -1,4 +1,9 @@
-﻿function Get-CheckDomain {
+﻿# Issue #715: dot-source the lane helper so callers (Export-AssessmentReport and
+# Pester tests alike) don't have to know about it. Idempotent — re-sourcing the
+# function on each load is harmless.
+. (Join-Path -Path $PSScriptRoot -ChildPath 'Get-RemediationLane.ps1')
+
+function Get-CheckDomain {
     <#
     .SYNOPSIS
         Maps a base CheckId prefix to the React report domain label.
@@ -156,6 +161,12 @@ function Build-ReportDataJson {
                          $f.Evidence | ConvertTo-Json -Depth 5 -Compress
                      } else { $null }
 
+        $effort = if ($regEntry) { $e = if ($regEntry -is [hashtable]) { $regEntry['effort'] } else { $regEntry.effort }; if ($e) { $e } else { 'medium' } } else { 'medium' }
+
+        # Issue #715: precompute the remediation lane so the HTML report and the
+        # XLSX export agree without recomputing the bucketing rules in two places.
+        $lane = Get-RemediationLane -Status $f.Status -Severity $severity -Effort $effort
+
         $findings.Add([PSCustomObject]@{
             checkId      = $f.CheckId
             status       = $f.Status
@@ -167,7 +178,8 @@ function Build-ReportDataJson {
             current      = $f.CurrentValue
             recommended  = $recommended
             remediation  = $f.Remediation
-            effort       = if ($regEntry) { $e = if ($regEntry -is [hashtable]) { $regEntry['effort'] } else { $regEntry.effort }; if ($e) { $e } else { 'medium' } } else { 'medium' }
+            effort       = $effort
+            lane         = $lane
             frameworks   = $frameworks
             fwMeta       = $fwMeta
             intentDesign    = [bool]($f.PSObject.Properties['IntentDesign'] -and $f.IntentDesign)

--- a/src/M365-Assess/Common/Export-AssessmentReport.ps1
+++ b/src/M365-Assess/Common/Export-AssessmentReport.ps1
@@ -159,6 +159,7 @@ if (-not $OutputPath) {
 # ------------------------------------------------------------------
 # Load section data, build findings list, and export XLSX
 # ------------------------------------------------------------------
+. (Join-Path -Path $PSScriptRoot -ChildPath 'Get-RemediationLane.ps1')
 . (Join-Path -Path $PSScriptRoot -ChildPath 'Build-ReportData.ps1')
 . (Join-Path -Path $PSScriptRoot -ChildPath 'Build-SectionHtml.ps1')
 # $allCisFindings and $sectionData are now set in scope

--- a/src/M365-Assess/Common/Export-ComplianceMatrix.ps1
+++ b/src/M365-Assess/Common/Export-ComplianceMatrix.ps1
@@ -62,6 +62,7 @@ if (-not (Test-Path -Path $AssessmentFolder -PathType Container)) {
 # ------------------------------------------------------------------
 $projectRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
 . (Join-Path -Path $PSScriptRoot -ChildPath 'Import-ControlRegistry.ps1')
+. (Join-Path -Path $PSScriptRoot -ChildPath 'Get-RemediationLane.ps1')
 $controlsPath = Join-Path -Path $projectRoot -ChildPath 'controls'
 $controlRegistry = Import-ControlRegistry -ControlsPath $controlsPath
 
@@ -126,18 +127,27 @@ foreach ($c in $summary) {
         $entry = if ($controlRegistry.ContainsKey($baseCheckId)) { $controlRegistry[$baseCheckId] } else { $null }
         $fw = if ($entry) { $entry.frameworks } else { @{} }
 
+        # Issue #715: precompute Horizon (Now/Next/Later) so the XLSX agrees
+        # with the HTML report's Remediation Roadmap. Pass-status rows get an
+        # empty Horizon — the lane is a remediation concept, not a finding one.
+        $sevForLane = if ($riskSeverity.ContainsKey($baseCheckId)) { $riskSeverity[$baseCheckId] } else { 'medium' }
+        $effortForLane = if ($entry -and $entry.effort) { $entry.effort } else { 'medium' }
+        $horizon = Get-RemediationLane -Status $row.Status -Severity $sevForLane -Effort $effortForLane
+
         # Fixed columns
         $finding = [ordered]@{
             CheckId         = $row.CheckId
             Setting         = $row.Setting
             Category        = $row.Category
             Status          = $row.Status
+            Horizon         = $horizon
             RiskSeverity    = if ($riskSeverity.ContainsKey($baseCheckId)) { $riskSeverity[$baseCheckId] } else { '' }
             ImpactSeverity  = if ($entry -and $entry.impactRating) { $entry.impactRating.severity }  else { '' }
             ImpactRationale = if ($entry -and $entry.impactRating) { $entry.impactRating.rationale } else { '' }
             SCFDomain       = if ($entry -and $entry.scf)          { $entry.scf.domain }             else { '' }
             CSFFunction     = if ($entry -and $entry.scf)          { $entry.scf.csfFunction }        else { '' }
             SCFWeight       = if ($entry -and $entry.scf)          { $entry.scf.relativeWeighting }  else { '' }
+            Effort          = $effortForLane
             Source          = $c.Collector
             Remediation     = $row.Remediation
         }
@@ -508,6 +518,39 @@ if ($verificationRows.Count -gt 0) {
 }
 
 # ------------------------------------------------------------------
+# Remediation Roadmap sheet (issue #715)
+# Mirrors the HTML report's Roadmap: one row per actionable finding,
+# grouped by Now/Next/Later, sorted within each group by severity.
+# ------------------------------------------------------------------
+$severityOrder = @{ 'critical' = 0; 'high' = 1; 'medium' = 2; 'low' = 3; 'info' = 4; 'none' = 5 }
+$horizonOrder  = @{ 'now' = 0; 'soon' = 1; 'later' = 2 }
+$roadmapRows = $sortedFindings | Where-Object { $_.Horizon } | ForEach-Object {
+    [PSCustomObject]@{
+        Horizon       = switch ($_.Horizon) { 'now' { 'Now' } 'soon' { 'Next' } 'later' { 'Later' } default { $_.Horizon } }
+        CheckId       = $_.CheckId
+        Setting       = $_.Setting
+        Severity      = $_.RiskSeverity
+        Effort        = $_.Effort
+        Status        = $_.Status
+        Remediation   = $_.Remediation
+        _hOrder       = $horizonOrder[$_.Horizon]
+        _sOrder       = if ($severityOrder.ContainsKey(($_.RiskSeverity).ToLower())) { $severityOrder[($_.RiskSeverity).ToLower()] } else { 99 }
+    }
+} | Sort-Object -Property _hOrder, _sOrder, CheckId | Select-Object Horizon, CheckId, Setting, Severity, Effort, Status, Remediation
+
+if ($roadmapRows -and @($roadmapRows).Count -gt 0) {
+    $roadmapParams = @{
+        Path          = $outputFile
+        WorksheetName = 'Remediation Roadmap'
+        AutoSize      = $true
+        FreezeTopRow  = $true
+        BoldTopRow    = $true
+        TableStyle    = 'Medium4'
+    }
+    $roadmapRows | Export-Excel @roadmapParams
+}
+
+# ------------------------------------------------------------------
 # Drift sheet (if a baseline comparison was run)
 # ------------------------------------------------------------------
 if ($DriftReport -and $DriftReport.Count -gt 0) {
@@ -540,11 +583,12 @@ if ($DriftReport -and $DriftReport.Count -gt 0) {
 # ------------------------------------------------------------------
 $pkg = Open-ExcelPackage -Path $outputFile
 
-# Matrix sheet - color-code Status, RiskSeverity, and ImpactSeverity columns
+# Matrix sheet - color-code Status, Horizon, RiskSeverity, and ImpactSeverity columns
 $matrixSheet = $pkg.Workbook.Worksheets['Compliance Matrix']
 $statusCol      = 4   # Column D = Status
-$riskSevCol     = 5   # Column E = RiskSeverity
-$impactSevCol   = 6   # Column F = ImpactSeverity
+$horizonCol     = 5   # Column E = Horizon (issue #715)
+$riskSevCol     = 6   # Column F = RiskSeverity
+$impactSevCol   = 7   # Column G = ImpactSeverity
 $lastRow = $matrixSheet.Dimension.End.Row
 
 for ($r = 2; $r -le $lastRow; $r++) {
@@ -555,6 +599,14 @@ for ($r = 2; $r -le $lastRow; $r++) {
         'Warning' { $matrixSheet.Cells[$r, $statusCol].Style.Font.Color.SetColor([System.Drawing.Color]::FromArgb(146, 64, 14));  $matrixSheet.Cells[$r, $statusCol].Style.Fill.PatternType = 'Solid'; $matrixSheet.Cells[$r, $statusCol].Style.Fill.BackgroundColor.SetColor([System.Drawing.Color]::FromArgb(254, 243, 199)) }
         'Review'  { $matrixSheet.Cells[$r, $statusCol].Style.Font.Color.SetColor([System.Drawing.Color]::FromArgb(30, 64, 175));  $matrixSheet.Cells[$r, $statusCol].Style.Fill.PatternType = 'Solid'; $matrixSheet.Cells[$r, $statusCol].Style.Fill.BackgroundColor.SetColor([System.Drawing.Color]::FromArgb(219, 234, 254)) }
         'Info'    { $matrixSheet.Cells[$r, $statusCol].Style.Font.Color.SetColor([System.Drawing.Color]::FromArgb(107, 114, 128)); $matrixSheet.Cells[$r, $statusCol].Style.Fill.PatternType = 'Solid'; $matrixSheet.Cells[$r, $statusCol].Style.Fill.BackgroundColor.SetColor([System.Drawing.Color]::FromArgb(243, 244, 246)) }
+    }
+
+    # Issue #715: color the Horizon cell so consultants can scan Now/Next/Later visually
+    $horizonVal = $matrixSheet.Cells[$r, $horizonCol].Value
+    switch ($horizonVal) {
+        'now'   { $matrixSheet.Cells[$r, $horizonCol].Style.Font.Color.SetColor([System.Drawing.Color]::FromArgb(185, 28, 28));  $matrixSheet.Cells[$r, $horizonCol].Style.Fill.PatternType = 'Solid'; $matrixSheet.Cells[$r, $horizonCol].Style.Fill.BackgroundColor.SetColor([System.Drawing.Color]::FromArgb(254, 226, 226)) }
+        'soon'  { $matrixSheet.Cells[$r, $horizonCol].Style.Font.Color.SetColor([System.Drawing.Color]::FromArgb(146, 64, 14));  $matrixSheet.Cells[$r, $horizonCol].Style.Fill.PatternType = 'Solid'; $matrixSheet.Cells[$r, $horizonCol].Style.Fill.BackgroundColor.SetColor([System.Drawing.Color]::FromArgb(254, 243, 199)) }
+        'later' { $matrixSheet.Cells[$r, $horizonCol].Style.Font.Color.SetColor([System.Drawing.Color]::FromArgb(30, 64, 175));  $matrixSheet.Cells[$r, $horizonCol].Style.Fill.PatternType = 'Solid'; $matrixSheet.Cells[$r, $horizonCol].Style.Fill.BackgroundColor.SetColor([System.Drawing.Color]::FromArgb(219, 234, 254)) }
     }
 
     $sevVal = $matrixSheet.Cells[$r, $riskSevCol].Value

--- a/src/M365-Assess/Common/Get-RemediationLane.ps1
+++ b/src/M365-Assess/Common/Get-RemediationLane.ps1
@@ -1,0 +1,66 @@
+function Get-RemediationLane {
+    <#
+    .SYNOPSIS
+        Maps a finding to a Now/Next/Later remediation horizon.
+    .DESCRIPTION
+        Single source of truth for lane bucketing. The HTML report and the XLSX
+        export both read precomputed lane values from this helper so the two
+        consumption surfaces never disagree.
+
+        Rules (#709 rebalance):
+          - Non-Fail findings: critical severity -> 'now', otherwise 'later'.
+          - Fail findings:
+              * critical                              -> 'now'
+              * high + small effort (high-value quick win) -> 'now'
+              * high                                  -> 'soon'
+              * medium + (small | medium) effort      -> 'soon'
+              * medium + large effort, or low/info/none severity -> 'later'
+
+        Pass-status findings get an empty lane -- they need no remediation.
+    .PARAMETER Status
+        Finding status: Pass | Fail | Warning | Review | Info | Skipped.
+    .PARAMETER Severity
+        Risk severity: critical | high | medium | low | info | none.
+    .PARAMETER Effort
+        Remediation effort: small | medium | large. Defaults to 'medium' when omitted.
+    .EXAMPLE
+        Get-RemediationLane -Status 'Fail' -Severity 'critical' -Effort 'small'
+        # -> 'now'
+    .EXAMPLE
+        Get-RemediationLane -Status 'Fail' -Severity 'medium' -Effort 'large'
+        # -> 'later'
+    .EXAMPLE
+        Get-RemediationLane -Status 'Pass' -Severity 'high' -Effort 'small'
+        # -> ''  (Pass findings need no remediation)
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Status,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Severity,
+
+        [Parameter()]
+        [string]$Effort = 'medium'
+    )
+
+    if ($Status -eq 'Pass') { return '' }
+
+    $sev = $Severity.ToLowerInvariant()
+    $eff = if ([string]::IsNullOrWhiteSpace($Effort)) { 'medium' } else { $Effort.ToLowerInvariant() }
+
+    if ($Status -ne 'Fail') {
+        if ($sev -eq 'critical') { return 'now' }
+        return 'later'
+    }
+
+    if ($sev -eq 'critical')                              { return 'now' }
+    if ($sev -eq 'high'   -and $eff -eq 'small')          { return 'now' }
+    if ($sev -eq 'high')                                  { return 'soon' }
+    if ($sev -eq 'medium' -and $eff -ne 'large')          { return 'soon' }
+    return 'later'
+}

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -45,15 +45,14 @@ function finalizeReport({
   URL.revokeObjectURL(url);
 }
 
-// Pre-compute roadmap lane counts for sidebar sub-nav (mirrors Roadmap bucketing logic)
+// Issue #715: roadmap lane counts now read from t.lane (precomputed by
+// Get-RemediationLane.ps1 in the data bridge) so sidebar nav, Roadmap, and
+// XLSX export all agree on bucketing without parallel JS rules.
 const _RM = FINDINGS.filter(f => f.status !== 'Pass' && f.status !== 'Info');
-const _RM_NOW = _RM.filter(t => t.severity === 'critical' || t.severity === 'high' && t.effort === 'small');
-const _RM_SOON = _RM.filter(t => !_RM_NOW.includes(t) && (t.severity === 'high' || t.severity === 'medium' && t.effort !== 'large'));
-const _RM_LATER = _RM.filter(t => !_RM_NOW.includes(t) && !_RM_SOON.includes(t));
 const ROADMAP_COUNTS = {
-  now: _RM_NOW.length,
-  soon: _RM_SOON.length,
-  later: _RM_LATER.length
+  now: _RM.filter(t => t.lane === 'now').length,
+  soon: _RM.filter(t => t.lane === 'soon').length,
+  later: _RM.filter(t => t.lane === 'later' || !t.lane).length
 };
 const FRAMEWORKS = D.frameworks && D.frameworks.length ? D.frameworks : [{
   id: 'cis-m365-v6',
@@ -3270,22 +3269,11 @@ function Roadmap({
     a.click();
     URL.revokeObjectURL(url);
   };
-  const getNaturalLane = t => {
-    // Rebalance (#709). Previous rule put every medium-severity Warning and Review
-    // into Next regardless of status, ballooning Next to >100 items on realistic tenants
-    // (observed: Now 18 / Next 126 / Later 3 on dz9m). New rule treats Warnings and
-    // Reviews as informational prompts by default, so they land in Later unless their
-    // severity is critical. Only Fail-status findings earn a spot in Now / Next.
-    if (t.status !== 'Fail') {
-      return t.severity === 'critical' ? 'now' : 'later';
-    }
-    // Fail status — prioritise by severity + effort
-    if (t.severity === 'critical') return 'now';
-    if (t.severity === 'high' && t.effort === 'small') return 'now'; // high-value quick win
-    if (t.severity === 'high') return 'soon';
-    if (t.severity === 'medium' && t.effort !== 'large') return 'soon';
-    return 'later'; // medium+large-effort Fails, all low severity
-  };
+
+  // Issue #715: lane bucketing now lives in Get-RemediationLane.ps1 (the single
+  // source of truth shared by HTML + XLSX). Build-ReportData precomputes t.lane;
+  // we just read it here. Falls back to 'later' for any unexpected missing value.
+  const getNaturalLane = t => t.lane || 'later';
   const getEffectiveLane = t => roadmapOverrides[t.checkId] || getNaturalLane(t);
   const LANE_LABEL = {
     now: 'Now',

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -36,12 +36,15 @@ function finalizeReport({ hiddenFindings, roadmapOverrides }) {
   URL.revokeObjectURL(url);
 }
 
-// Pre-compute roadmap lane counts for sidebar sub-nav (mirrors Roadmap bucketing logic)
+// Issue #715: roadmap lane counts now read from t.lane (precomputed by
+// Get-RemediationLane.ps1 in the data bridge) so sidebar nav, Roadmap, and
+// XLSX export all agree on bucketing without parallel JS rules.
 const _RM = FINDINGS.filter(f => f.status !== 'Pass' && f.status !== 'Info');
-const _RM_NOW   = _RM.filter(t => t.severity === 'critical' || (t.severity === 'high' && t.effort === 'small'));
-const _RM_SOON  = _RM.filter(t => !_RM_NOW.includes(t) && (t.severity === 'high' || (t.severity === 'medium' && t.effort !== 'large')));
-const _RM_LATER = _RM.filter(t => !_RM_NOW.includes(t) && !_RM_SOON.includes(t));
-const ROADMAP_COUNTS = { now: _RM_NOW.length, soon: _RM_SOON.length, later: _RM_LATER.length };
+const ROADMAP_COUNTS = {
+  now:   _RM.filter(t => t.lane === 'now').length,
+  soon:  _RM.filter(t => t.lane === 'soon').length,
+  later: _RM.filter(t => t.lane === 'later' || !t.lane).length,
+};
 
 const FRAMEWORKS = (D.frameworks && D.frameworks.length) ? D.frameworks : [
   { id: 'cis-m365-v6',     full: 'CIS Microsoft 365 v6.0.1' },
@@ -2047,23 +2050,10 @@ function Roadmap({ onViewFinding, editMode, hiddenFindings, roadmapOverrides, on
     URL.revokeObjectURL(url);
   };
 
-  const getNaturalLane = t => {
-    // Rebalance (#709). Previous rule put every medium-severity Warning and Review
-    // into Next regardless of status, ballooning Next to >100 items on realistic tenants
-    // (observed: Now 18 / Next 126 / Later 3 on dz9m). New rule treats Warnings and
-    // Reviews as informational prompts by default, so they land in Later unless their
-    // severity is critical. Only Fail-status findings earn a spot in Now / Next.
-    if (t.status !== 'Fail') {
-      return t.severity === 'critical' ? 'now' : 'later';
-    }
-    // Fail status — prioritise by severity + effort
-    if (t.severity === 'critical') return 'now';
-    if (t.severity === 'high' && t.effort === 'small') return 'now';   // high-value quick win
-    if (t.severity === 'high') return 'soon';
-    if (t.severity === 'medium' && t.effort !== 'large') return 'soon';
-    return 'later';  // medium+large-effort Fails, all low severity
-  };
-
+  // Issue #715: lane bucketing now lives in Get-RemediationLane.ps1 (the single
+  // source of truth shared by HTML + XLSX). Build-ReportData precomputes t.lane;
+  // we just read it here. Falls back to 'later' for any unexpected missing value.
+  const getNaturalLane = t => t.lane || 'later';
   const getEffectiveLane = t => roadmapOverrides[t.checkId] || getNaturalLane(t);
   const LANE_LABEL = { now: 'Now', soon: 'Next', later: 'Later' };
 

--- a/tests/Common/Get-RemediationLane.Tests.ps1
+++ b/tests/Common/Get-RemediationLane.Tests.ps1
@@ -1,0 +1,72 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '../../src/M365-Assess/Common/Get-RemediationLane.ps1')
+}
+
+Describe 'Get-RemediationLane' {
+
+    Context 'Pass findings' {
+        It 'returns empty string for any Pass finding regardless of severity' {
+            Get-RemediationLane -Status 'Pass' -Severity 'critical' -Effort 'small' | Should -Be ''
+            Get-RemediationLane -Status 'Pass' -Severity 'low'      -Effort 'large' | Should -Be ''
+        }
+    }
+
+    Context 'Non-Fail status (Warning, Review, Info, Skipped)' {
+        It 'maps critical-severity Warnings to now' {
+            Get-RemediationLane -Status 'Warning' -Severity 'critical' -Effort 'medium' | Should -Be 'now'
+        }
+        It 'maps non-critical Warnings to later' {
+            Get-RemediationLane -Status 'Warning' -Severity 'high'   -Effort 'small' | Should -Be 'later'
+            Get-RemediationLane -Status 'Warning' -Severity 'medium' -Effort 'small' | Should -Be 'later'
+        }
+        It 'maps Review and Info similarly' {
+            Get-RemediationLane -Status 'Review' -Severity 'critical' -Effort 'medium' | Should -Be 'now'
+            Get-RemediationLane -Status 'Review' -Severity 'high'     -Effort 'medium' | Should -Be 'later'
+            Get-RemediationLane -Status 'Info'   -Severity 'low'      -Effort 'small'  | Should -Be 'later'
+        }
+    }
+
+    Context 'Fail findings -- severity + effort matrix' {
+        It 'critical Fail -> now (regardless of effort)' {
+            Get-RemediationLane -Status 'Fail' -Severity 'critical' -Effort 'small'  | Should -Be 'now'
+            Get-RemediationLane -Status 'Fail' -Severity 'critical' -Effort 'medium' | Should -Be 'now'
+            Get-RemediationLane -Status 'Fail' -Severity 'critical' -Effort 'large'  | Should -Be 'now'
+        }
+        It 'high Fail + small effort -> now (high-value quick win)' {
+            Get-RemediationLane -Status 'Fail' -Severity 'high' -Effort 'small' | Should -Be 'now'
+        }
+        It 'high Fail + medium/large effort -> soon' {
+            Get-RemediationLane -Status 'Fail' -Severity 'high' -Effort 'medium' | Should -Be 'soon'
+            Get-RemediationLane -Status 'Fail' -Severity 'high' -Effort 'large'  | Should -Be 'soon'
+        }
+        It 'medium Fail + small/medium effort -> soon' {
+            Get-RemediationLane -Status 'Fail' -Severity 'medium' -Effort 'small'  | Should -Be 'soon'
+            Get-RemediationLane -Status 'Fail' -Severity 'medium' -Effort 'medium' | Should -Be 'soon'
+        }
+        It 'medium Fail + large effort -> later' {
+            Get-RemediationLane -Status 'Fail' -Severity 'medium' -Effort 'large' | Should -Be 'later'
+        }
+        It 'low/info/none Fail -> later (regardless of effort)' {
+            Get-RemediationLane -Status 'Fail' -Severity 'low'  -Effort 'small' | Should -Be 'later'
+            Get-RemediationLane -Status 'Fail' -Severity 'info' -Effort 'small' | Should -Be 'later'
+            Get-RemediationLane -Status 'Fail' -Severity 'none' -Effort 'small' | Should -Be 'later'
+        }
+    }
+
+    Context 'Effort defaulting' {
+        It "defaults Effort to 'medium' when omitted" {
+            # high+medium -> soon (not now); confirms default is medium not small
+            Get-RemediationLane -Status 'Fail' -Severity 'high' | Should -Be 'soon'
+        }
+        It "treats whitespace Effort as 'medium'" {
+            Get-RemediationLane -Status 'Fail' -Severity 'medium' -Effort ' ' | Should -Be 'soon'
+        }
+    }
+
+    Context 'Case insensitivity' {
+        It 'normalizes severity casing' {
+            Get-RemediationLane -Status 'Fail' -Severity 'CRITICAL' -Effort 'medium' | Should -Be 'now'
+            Get-RemediationLane -Status 'Fail' -Severity 'High'     -Effort 'Small' | Should -Be 'now'
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes the last v2.6.0 sprint issue. Adds Now/Next/Later horizon visibility to the XLSX export so consultants who consume the spreadsheet (handoffs, status decks, ticket tracking) get the same prioritization the HTML report has had.

**Single source of truth for lane bucketing** now lives in \`Common/Get-RemediationLane.ps1\`. Both the HTML report and the XLSX export read the precomputed \`lane\` value -- no parallel JS rules.

## Changes

- **New helper:** \`Common/Get-RemediationLane.ps1\` ports the existing Roadmap.getNaturalLane JS rules verbatim. Inputs: \`Status\`, \`Severity\`, \`Effort\`. Output: \`now\` | \`soon\` | \`later\` | \`''\` (Pass).
- **Build-ReportData.ps1** computes \`lane\` per finding using the helper, persists it into \`window.REPORT_DATA\`. Self-sources the helper so callers don't need to.
- **report-app.jsx** Roadmap and sidebar-nav lane counts read \`t.lane\` instead of recomputing.
- **Export-ComplianceMatrix.ps1**:
  - Adds \`Horizon\` column to Compliance Matrix sheet (color-coded Now=red, Next=amber, Later=blue). Empty for Pass rows.
  - Adds \`Effort\` column surfacing registry-derived effort estimate.
  - New \`Remediation Roadmap\` sheet: one row per actionable finding, grouped by Now/Next/Later, sorted within each group by severity then CheckId.
- **Tests:** 13 new Pester tests covering the severity x effort x status matrix, effort defaulting, case insensitivity. 588/588 Common tests passing.

## Base branch note

This PR targets \`feature/v260-sprint-finish\` (PR #755), not main, because both PRs touch \`report-app.jsx\`. After PR #755 merges, this PR's base will be retargeted to main automatically by GitHub.

## Test plan

- [x] 13 new helper tests passing
- [x] 588/588 Common tests passing
- [x] PSScriptAnalyzer clean on the new helper
- [x] \`npm run build\` clean
- [ ] Manual: run an assessment, open the XLSX -- confirm Horizon column populated, Remediation Roadmap sheet present and grouped correctly, HTML and XLSX agree on lane assignment for the same CheckId.