### PR TITLE
feat(ci): block mutating cmdlets in collector folders (#771)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
           $config.Run.Path = @(
             './tests/Smoke/Script-Validation.Tests.ps1'
             './tests/Smoke/PSGallery-Readiness.Tests.ps1'
+            './tests/Smoke/Collector-ReadOnly.Tests.ps1'
             './tests/Consistency'
             './tests/Common/Export-AssessmentReport.Tests.ps1'
             './tests/Common/Import-ControlRegistry.Tests.ps1'

--- a/scripts/Test-CollectorReadOnly.ps1
+++ b/scripts/Test-CollectorReadOnly.ps1
@@ -1,0 +1,219 @@
+<#
+.SYNOPSIS
+    Verifies M365-Assess collector folders contain no tenant-mutating cmdlet calls.
+.DESCRIPTION
+    M365-Assess promises strictly read-only operation against the target tenant.
+    This script enforces that promise by AST-scanning collector folders for
+    cmdlets whose verbs suggest mutation, plus Invoke-MgGraphRequest calls using
+    non-GET methods.
+
+    Allowlist below carves out cmdlets that match a forbidden verb but operate
+    locally (Add-Member for PSObject shaping, New-Object for .NET types, etc.)
+    and the collector contract (Add-Setting, Add-SecuritySetting). Add new
+    entries with a one-line justification.
+
+    Setup/ and Common/ folders are intentionally excluded -- they host the
+    consent helpers and shared utilities, which may legitimately mutate state.
+.PARAMETER RepoRoot
+    Repository root. Defaults to the parent of the script's directory.
+.PARAMETER Path
+    Optional list of paths (files or folders) to scan instead of the default
+    collector folders. Used by tests to verify the script catches deliberate
+    violations.
+.EXAMPLE
+    PS> ./scripts/Test-CollectorReadOnly.ps1
+    Scans the default collector folders. Prints violations and exits 1, or
+    prints a green confirmation and exits 0.
+.EXAMPLE
+    PS> ./scripts/Test-CollectorReadOnly.ps1 -Path ./tests/Fixtures/violator.ps1
+    Scans a specific file (used by tests).
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$RepoRoot = (Split-Path -Parent (Split-Path -Parent $PSCommandPath)),
+
+    [Parameter()]
+    [string[]]$Path
+)
+
+function Test-CollectorReadOnly {
+    [CmdletBinding()]
+    [OutputType([psobject[]])]
+    param(
+        [Parameter()]
+        [string]$RepoRoot = (Split-Path -Parent (Split-Path -Parent $PSCommandPath)),
+
+        [Parameter()]
+        [string[]]$Path
+    )
+
+    # Forbidden cmdlet verbs -- any cmdlet whose verb matches one of these is a
+    # violation unless the full cmdlet name appears in $allowedCmdlets below.
+    $forbiddenVerbs = @(
+        'Set', 'New', 'Remove', 'Update',
+        'Grant', 'Revoke', 'Disable', 'Enable', 'Add'
+    )
+
+    # Cmdlets whose name starts with a forbidden verb but do not mutate the
+    # M365 tenant. Keep narrow; document each entry.
+    $allowedCmdlets = @(
+        'Add-Setting'                  # collector contract -- emits a finding
+        'Add-SecuritySetting'          # collector contract -- emits a finding
+        'Add-Member'                   # local PSObject shaping
+        'Add-Type'                     # in-process .NET type loading
+        'Add-Content'                  # local file write (output paths)
+        'New-Object'                   # local .NET object instantiation
+        'New-TimeSpan'                 # local timespan construction
+        'New-Guid'                     # local guid generation
+        'New-Variable'                 # local PS variable
+        'New-PSSession'                # local PS remoting (EXO transport)
+        'New-PesterConfiguration'      # test config (test scripts only)
+        'New-Item'                     # local file/folder creation (output)
+        'New-CimSession'               # local Windows CIM/WMI session (Get-LocalAdmins)
+        'Remove-CimSession'            # local Windows CIM/WMI session cleanup
+        'Remove-Item'                  # local file/temp-file cleanup
+        'Remove-Variable'              # local PS variable
+        'Set-Variable'                 # local PS variable
+        'Set-StrictMode'               # local PS strict mode
+        'Set-Location'                 # local working directory
+        'Set-Content'                  # local file write (output)
+        'Set-Item'                     # local file/registry/env write
+        'Update-TypeData'              # local PS type metadata
+        'Update-CheckProgress'         # project-internal progress callback (Common/Show-CheckProgress.ps1)
+        'Enable-PSBreakpoint'          # local debug
+        'Disable-PSBreakpoint'         # local debug
+    )
+
+    $forbiddenGraphMethods = @('POST', 'PATCH', 'DELETE', 'PUT')
+
+    # Collector folders relative to repo root. SharePoint work lives in
+    # Collaboration; there is no top-level SharePoint folder.
+    $defaultCollectorFolders = @(
+        'src/M365-Assess/Entra'
+        'src/M365-Assess/Security'
+        'src/M365-Assess/Exchange-Online'
+        'src/M365-Assess/Purview'
+        'src/M365-Assess/Intune'
+        'src/M365-Assess/PowerBI'
+        'src/M365-Assess/Collaboration'
+        'src/M365-Assess/ActiveDirectory'
+        'src/M365-Assess/Inventory'
+    )
+
+    if ($Path) {
+        $scanPaths = $Path
+    }
+    else {
+        $scanPaths = $defaultCollectorFolders | ForEach-Object {
+            Join-Path -Path $RepoRoot -ChildPath $_
+        }
+    }
+
+    $files = New-Object -TypeName System.Collections.Generic.List[System.IO.FileInfo]
+    foreach ($p in $scanPaths) {
+        if (Test-Path -LiteralPath $p -PathType Leaf) {
+            $files.Add((Get-Item -LiteralPath $p))
+        }
+        elseif (Test-Path -LiteralPath $p -PathType Container) {
+            $found = Get-ChildItem -LiteralPath $p -Recurse -Filter '*.ps1' -File
+            foreach ($f in $found) { $files.Add($f) }
+        }
+        else {
+            Write-Warning "Path not found: $p"
+        }
+    }
+
+    $violations = New-Object -TypeName System.Collections.Generic.List[psobject]
+
+    foreach ($file in $files) {
+        $tokens = $null
+        $errors = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+            $file.FullName, [ref]$tokens, [ref]$errors
+        )
+        if ($errors -and $errors.Count -gt 0) {
+            Write-Warning "Parse errors in $($file.FullName): $($errors[0].Message)"
+            continue
+        }
+
+        $commands = $ast.FindAll({
+                param($node)
+                $node -is [System.Management.Automation.Language.CommandAst]
+            }, $true)
+
+        foreach ($cmd in $commands) {
+            $nameElement = $cmd.CommandElements[0]
+            if ($nameElement -isnot [System.Management.Automation.Language.StringConstantExpressionAst]) {
+                continue
+            }
+            $name = $nameElement.Value
+
+            # Forbidden-verb match
+            if ($name -match '^([A-Z][a-z]+)-[A-Z][a-zA-Z]+$') {
+                $verb = $Matches[1]
+                if ($forbiddenVerbs -contains $verb -and $allowedCmdlets -notcontains $name) {
+                    $violations.Add([pscustomobject]@{
+                            File   = $file.FullName
+                            Line   = $cmd.Extent.StartLineNumber
+                            Column = $cmd.Extent.StartColumnNumber
+                            Cmdlet = $name
+                            Reason = "Mutating verb '$verb-' not in allowlist"
+                        })
+                    continue
+                }
+            }
+
+            # Special case: Invoke-MgGraphRequest -Method <forbidden>
+            if ($name -eq 'Invoke-MgGraphRequest') {
+                $methodValue = $null
+                $elements = $cmd.CommandElements
+                for ($i = 1; $i -lt $elements.Count - 1; $i++) {
+                    $el = $elements[$i]
+                    if ($el -is [System.Management.Automation.Language.CommandParameterAst] `
+                            -and $el.ParameterName -ieq 'Method') {
+                        $next = $elements[$i + 1]
+                        if ($next -is [System.Management.Automation.Language.StringConstantExpressionAst]) {
+                            $methodValue = $next.Value
+                        }
+                        break
+                    }
+                }
+                if ($methodValue -and $forbiddenGraphMethods -contains $methodValue.ToUpperInvariant()) {
+                    $violations.Add([pscustomobject]@{
+                            File   = $file.FullName
+                            Line   = $cmd.Extent.StartLineNumber
+                            Column = $cmd.Extent.StartColumnNumber
+                            Cmdlet = "$name -Method $methodValue"
+                            Reason = "Tenant-mutating Graph method"
+                        })
+                }
+            }
+        }
+    }
+
+    return $violations.ToArray()
+}
+
+# Script-level invocation. When dot-sourced (Pester tests), the function is
+# registered but the wrapper below is skipped.
+if ($MyInvocation.InvocationName -ne '.') {
+    $params = @{}
+    if ($PSBoundParameters.ContainsKey('RepoRoot')) { $params.RepoRoot = $RepoRoot }
+    if ($PSBoundParameters.ContainsKey('Path'))     { $params.Path     = $Path }
+
+    $result = Test-CollectorReadOnly @params
+
+    if ($null -eq $result -or $result.Count -eq 0) {
+        Write-Host '[Test-CollectorReadOnly] Clean -- no mutating cmdlet calls found in collector folders.' -ForegroundColor Green
+        exit 0
+    }
+
+    Write-Host "[Test-CollectorReadOnly] $($result.Count) violation(s) found:" -ForegroundColor Red
+    $rootForRel = if ($PSBoundParameters.ContainsKey('RepoRoot')) { $RepoRoot } else { (Split-Path -Parent (Split-Path -Parent $PSCommandPath)) }
+    foreach ($v in $result) {
+        $relativeFile = $v.File.Replace($rootForRel, '').TrimStart('\', '/')
+        Write-Host ("  {0}:{1}:{2}  {3}  -- {4}" -f $relativeFile, $v.Line, $v.Column, $v.Cmdlet, $v.Reason) -ForegroundColor Yellow
+    }
+    exit 1
+}

--- a/tests/Smoke/Collector-ReadOnly.Tests.ps1
+++ b/tests/Smoke/Collector-ReadOnly.Tests.ps1
@@ -1,0 +1,105 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '../../scripts/Test-CollectorReadOnly.ps1')
+    $script:repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
+}
+
+Describe 'Test-CollectorReadOnly' {
+
+    Context 'when scanning the current collector folders' {
+        It 'should return zero violations' {
+            $result = Test-CollectorReadOnly -RepoRoot $script:repoRoot
+            if ($result.Count -gt 0) {
+                $detail = $result | ForEach-Object { "  $($_.Cmdlet) at $($_.File):$($_.Line)" }
+                $msg = "Read-only guardrail violations:`n$($detail -join [Environment]::NewLine)"
+                throw $msg
+            }
+            $result.Count | Should -Be 0
+        }
+    }
+
+    Context 'when scanning a fixture with a tenant-mutating cmdlet' {
+        BeforeAll {
+            $script:violator = Join-Path $TestDrive 'Set-Violator.ps1'
+            Set-Content -Path $script:violator -Value @'
+[CmdletBinding()]
+param()
+Set-MgUser -UserId 'deadbeef' -DisplayName 'should fail'
+'@
+        }
+
+        It 'should flag the Set-MgUser call' {
+            $result = Test-CollectorReadOnly -Path $script:violator
+            $result.Count | Should -BeGreaterThan 0
+            $result[0].Cmdlet | Should -Be 'Set-MgUser'
+            $result[0].Reason | Should -Match "Mutating verb 'Set-'"
+        }
+    }
+
+    Context 'when scanning a fixture with each forbidden verb' {
+        It 'should flag <Cmdlet>' -ForEach @(
+            @{ Cmdlet = 'New-MgServicePrincipal' }
+            @{ Cmdlet = 'Remove-MgUser' }
+            @{ Cmdlet = 'Update-MgGroup' }
+            @{ Cmdlet = 'Grant-CsTeamsAppPermission' }
+            @{ Cmdlet = 'Revoke-MgUserSignInSession' }
+            @{ Cmdlet = 'Disable-MgUser' }
+            @{ Cmdlet = 'Enable-MgUser' }
+            @{ Cmdlet = 'Add-MgGroupMember' }
+        ) {
+            $fixture = Join-Path $TestDrive "verb-$($Cmdlet).ps1"
+            Set-Content -Path $fixture -Value "$Cmdlet -Foo bar"
+            $result = Test-CollectorReadOnly -Path $fixture
+            $result.Count | Should -Be 1
+            $result[0].Cmdlet | Should -Be $Cmdlet
+        }
+    }
+
+    Context 'when scanning a fixture with allowlisted cmdlets' {
+        It 'should not flag <Cmdlet>' -ForEach @(
+            @{ Cmdlet = 'Add-Setting' }
+            @{ Cmdlet = 'Add-SecuritySetting' }
+            @{ Cmdlet = 'Add-Member' }
+            @{ Cmdlet = 'New-Object' }
+            @{ Cmdlet = 'Set-Variable' }
+            @{ Cmdlet = 'Remove-Item' }
+            @{ Cmdlet = 'Update-CheckProgress' }
+            @{ Cmdlet = 'New-CimSession' }
+        ) {
+            $fixture = Join-Path $TestDrive "allow-$($Cmdlet).ps1"
+            Set-Content -Path $fixture -Value "$Cmdlet -Foo bar"
+            $result = Test-CollectorReadOnly -Path $fixture
+            $result.Count | Should -Be 0
+        }
+    }
+
+    Context 'when scanning a fixture with Invoke-MgGraphRequest' {
+        It 'should flag -Method <Method>' -ForEach @(
+            @{ Method = 'POST' }
+            @{ Method = 'PATCH' }
+            @{ Method = 'DELETE' }
+            @{ Method = 'PUT' }
+            @{ Method = 'post' }
+        ) {
+            $fixture = Join-Path $TestDrive "graph-$($Method).ps1"
+            Set-Content -Path $fixture -Value "Invoke-MgGraphRequest -Uri '/me' -Method '$Method' -Body @{}"
+            $result = Test-CollectorReadOnly -Path $fixture
+            $result.Count | Should -Be 1
+            $result[0].Cmdlet | Should -Match 'Invoke-MgGraphRequest'
+            $result[0].Reason | Should -Match 'Tenant-mutating Graph method'
+        }
+
+        It 'should not flag -Method GET' {
+            $fixture = Join-Path $TestDrive 'graph-GET.ps1'
+            Set-Content -Path $fixture -Value "Invoke-MgGraphRequest -Uri '/me' -Method GET"
+            $result = Test-CollectorReadOnly -Path $fixture
+            $result.Count | Should -Be 0
+        }
+
+        It 'should not flag a call without -Method (defaults to GET)' {
+            $fixture = Join-Path $TestDrive 'graph-default.ps1'
+            Set-Content -Path $fixture -Value "Invoke-MgGraphRequest -Uri '/me'"
+            $result = Test-CollectorReadOnly -Path $fixture
+            $result.Count | Should -Be 0
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a CI guardrail that AST-scans collector folders for tenant-mutating cmdlets, enforcing the read-only promise the README + badges already make. The codebase is clean today; this issue ensures it stays that way.

Closes #771 (epic #766, v2.9.0 — Trust Hardening sprint 1).

## Approach

- **`scripts/Test-CollectorReadOnly.ps1`** — standalone AST-based scanner
  - Walks every `.ps1` file under the 9 collector folders (`Entra`, `Security`, `Exchange-Online`, `Purview`, `Intune`, `PowerBI`, `Collaboration`, `ActiveDirectory`, `Inventory`)
  - Flags cmdlets matching forbidden verbs: `Set-`, `New-`, `Remove-`, `Update-`, `Grant-`, `Revoke-`, `Disable-`, `Enable-`, `Add-`
  - Flags `Invoke-MgGraphRequest -Method (POST|PATCH|DELETE|PUT)` (parameter-aware via AST)
  - Allowlist carves out 24 local-system / collector-contract cmdlets with one-line justifications inline
  - Setup/ and Common/ folders are excluded by design
  - Exit 0 clean / exit 1 violations; runnable locally as `pwsh -NoProfile -File ./scripts/Test-CollectorReadOnly.ps1`
- **`tests/Smoke/Collector-ReadOnly.Tests.ps1`** — 25 Pester tests (5.x)
  - Asserts the live codebase is clean
  - Asserts each forbidden verb is caught via TestDrive fixtures
  - Asserts each allowlisted cmdlet is NOT flagged
  - Asserts `Invoke-MgGraphRequest` `-Method` parsing for all 4 forbidden methods + GET passthrough + default-method passthrough
- **`.github/workflows/ci.yml`** — one-line addition: smoke-tests job picks up the new `Collector-ReadOnly.Tests.ps1`

## Triage on existing codebase

First run surfaced 5 false positives, all confirmed local-system operations:
- `New-CimSession` / `Remove-CimSession` (`Get-LocalAdmins.ps1`) — local Windows CIM/WMI session
- `Update-CheckProgress` (`Get-StrykerIncidentReadiness.ps1`) — project's internal progress callback
- `Remove-Item` (`Get-OneDriveInventory.ps1`, `Get-SharePointInventory.ps1`) — local temp-file cleanup

All four are now in the allowlist with inline justifications.

## Test plan

- [x] Run `./scripts/Test-CollectorReadOnly.ps1` locally — exits 0
- [x] Run `Invoke-Pester ./tests/Smoke/Collector-ReadOnly.Tests.ps1` — 25/25 pass
- [x] Run full smoke suite — 330/330 pass (was 305, added 25)
- [x] Run PSScriptAnalyzer on new files — clean
- [ ] CI quality-gates job is green
- [ ] CI Pester matrix (PS 7.4 + 7.6) is green

## Reviewer notes

The allowlist is intentionally narrow. New entries should include a one-line justification and prove the cmdlet does not mutate the M365 tenant. When a future collector legitimately needs a mutating verb (e.g., a write-back consent helper), the right answer is usually to move that helper to `Setup/` (already excluded) rather than expand the allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)