### PR TITLE
feat(trust): quick-wins bundle (#767, #790, #692)

### DIFF
--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -2,6 +2,8 @@
 
 M365 Assess supports multiple authentication methods for connecting to Microsoft 365 services.
 
+> **Recommended for unattended assessments:** certificate-based authentication. Client secret authentication is supported only where the underlying Microsoft module supports it (Microsoft Graph, Power BI). Exchange Online and Purview reject client-secret auth by design — use `-CertificateThumbprint` for non-interactive runs against those services.
+
 ## Interactive (Default)
 
 A browser window opens for each service (Graph, Exchange Online, etc.). Best for one-time or ad-hoc assessments.

--- a/README.md
+++ b/README.md
@@ -35,13 +35,14 @@
 
 Run a single command to produce CSV reports, a branded HTML assessment report, and an XLSX compliance matrix covering identity, email, security, devices, collaboration, and compliance baselines. **274 security checks** mapped across **15 compliance frameworks**.
 
-## What's New in v2.2.0
+## What's New in v2.6.0
 
 | Feature | Description |
 |---------|-------------|
-| **Roadmap CSV Export** | "Download CSV" button in the Remediation Roadmap exports your prioritized task list — reflecting any custom lane assignments — ready to paste into a project tracker |
-| **Evidence Field** | Five key checks (CA MFA admin policy, security defaults, Defender anti-phishing, EXO modern auth, SharePoint sharing) now embed structured evidence data in the report, viewable in an expandable panel per finding |
-| **AD/Hybrid Dashboard Panel** | When the ActiveDirectory section is included, the report home view shows hybrid sync status, last sync time, password hash sync state, and AD security finding counts |
+| **Smart Search in Findings** | Press Enter in the findings filter to cycle through matches (Shift+Enter reverses), with an inline `N/M` counter showing position. Active match auto-expands and scrolls into view; previously cycled rows auto-collapse to keep the table tidy |
+| **Collapsible Report Sections** | Every top-level section header (Posture trend, Framework coverage, Findings, Roadmap, Stryker, Appendix) now collapses to focus the view. Print/PDF exports automatically expand all sections so nothing is lost |
+| **XLSX Roadmap Sheet + Horizon Column** | The compliance matrix XLSX gains a dedicated **Remediation Roadmap** sheet (one row per actionable finding, grouped Now/Next/Later) plus a color-coded **Horizon** column on the matrix sheet — closes the parity gap with the HTML report's roadmap |
+| **CMMC L2 / L3 + CIS E3 / E5 Profile Filtering** | Clickable profile chips in the Framework Quilt panel filter findings by license tier; the same filter is mirrored in the FilterBar so selections in either place stay in sync |
 
 ## Installation
 

--- a/src/M365-Assess/Common/Build-ReportData.ps1
+++ b/src/M365-Assess/Common/Build-ReportData.ps1
@@ -364,11 +364,22 @@ function Build-ReportDataJson {
 
     $tenantRows = @($tenantRows | ForEach-Object {
         $ageYears = $null
-        if ($_.CreatedDateTime) {
-            try { $ageYears = [math]::Round(((Get-Date) - [datetime]$_.CreatedDateTime).TotalDays / 365.25, 1) }
-            catch { Write-Verbose "Could not parse tenant CreatedDateTime: $_" }
+        $isoCreated = $null
+        $rawCreated = $_.CreatedDateTime  # capture before try -- in catch, $_ is the error record
+        if ($rawCreated) {
+            try {
+                $parsed = [datetime]$rawCreated
+                $ageYears = [math]::Round(((Get-Date) - $parsed).TotalDays / 365.25, 1)
+                $isoCreated = $parsed.ToString('yyyy-MM-dd')
+            }
+            catch {
+                Write-Verbose "Could not parse tenant CreatedDateTime: $rawCreated"
+                # Fallback: emit the original string so the report still shows a value
+                $isoCreated = $rawCreated
+            }
         }
-        $_ | Select-Object OrgDisplayName, TenantId, DefaultDomain, CreatedDateTime,
+        $_ | Select-Object OrgDisplayName, TenantId, DefaultDomain,
+            @{ N = 'CreatedDateTime'; E = { $isoCreated } },
             @{ N = 'tenantAgeYears'; E = { $ageYears } }
     })
 

--- a/src/M365-Assess/Common/Connect-Service.ps1
+++ b/src/M365-Assess/Common/Connect-Service.ps1
@@ -156,6 +156,7 @@ try {
             elseif ($ClientId -and $ClientSecret) {
                 $credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $ClientId, $ClientSecret
                 $connectParams['ClientSecretCredential'] = $credential
+                Write-Warning 'Graph: client secret authentication is supported but certificate authentication is recommended for unattended assessments. Pass -CertificateThumbprint where possible.'
             }
             else {
                 $connectParams['Scopes'] = $Scopes
@@ -259,6 +260,7 @@ try {
                 $credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $ClientId, $ClientSecret
                 $connectParams['ServicePrincipal'] = $true
                 $connectParams['Credential'] = $credential
+                Write-Warning 'Power BI: client secret authentication is supported but certificate authentication is recommended for unattended assessments. Pass -CertificateThumbprint where possible.'
             }
 
             Connect-PowerBIServiceAccount @connectParams -WarningAction SilentlyContinue

--- a/tests/Common/Build-ReportData.Tests.ps1
+++ b/tests/Common/Build-ReportData.Tests.ps1
@@ -496,6 +496,27 @@ Describe 'Build-ReportData' {
             $d.tenant[0].OrgDisplayName | Should -Be 'Contoso'
         }
 
+        It 'should emit CreatedDateTime in ISO yyyy-MM-dd form for ISO input' {
+            $tenant = [PSCustomObject]@{ OrgDisplayName='Contoso'; TenantId='abc'; DefaultDomain='contoso.com'; CreatedDateTime='2020-01-15T08:30:00Z' }
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -SectionData @{ tenant = @($tenant) })
+            $d.tenant[0].CreatedDateTime | Should -Be '2020-01-15'
+        }
+
+        It 'should normalize US-locale CreatedDateTime to ISO yyyy-MM-dd (#692)' {
+            # Reproduces the dz9m.com bug: US-locale "M/D/YYYY H:MM:SS" was sliced to 10 chars
+            # in the report, yielding "2/3/2024 8" (mid-hour truncation). After normalization,
+            # the data bridge always emits ISO so slice(0,10) is safe.
+            $tenant = [PSCustomObject]@{ OrgDisplayName='Contoso'; TenantId='abc'; DefaultDomain='contoso.com'; CreatedDateTime='2/3/2024 8:30:00 AM' }
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -SectionData @{ tenant = @($tenant) })
+            $d.tenant[0].CreatedDateTime | Should -Be '2024-02-03'
+        }
+
+        It 'should fall back to the original string when CreatedDateTime cannot be parsed' {
+            $tenant = [PSCustomObject]@{ OrgDisplayName='Contoso'; TenantId='abc'; DefaultDomain='contoso.com'; CreatedDateTime='not-a-date' }
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -SectionData @{ tenant = @($tenant) })
+            $d.tenant[0].CreatedDateTime | Should -Be 'not-a-date'
+        }
+
         It 'should include license rows with License, Assigned, Total' {
             $lic = [PSCustomObject]@{ License='Microsoft 365 E5'; Assigned=10; Total=25 }
             $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -SectionData @{ licenses = @($lic) })

--- a/tests/Common/Connect-Service.Tests.ps1
+++ b/tests/Common/Connect-Service.Tests.ps1
@@ -44,4 +44,38 @@ Describe 'Connect-Service' {
             { & $script:scriptPath -Service 'Graph' -ErrorAction Stop } | Should -Throw -ExpectedMessage "*not installed*"
         }
     }
+
+    Context 'client-secret warning (#790)' {
+        BeforeAll {
+            # Modules appear installed
+            Mock Get-Module { @{ Name = 'Microsoft.Graph.Authentication' } }
+            # No-op the actual connections so we don't reach out to a tenant
+            Mock Connect-MgGraph { }
+            Mock Connect-PowerBIServiceAccount { }
+            # Get-Command introspection for the Graph NoWelcome check
+            Mock Get-Command {
+                [pscustomobject]@{ Parameters = @{ NoWelcome = $true } }
+            } -ParameterFilter { $Name -eq 'Connect-MgGraph' }
+        }
+
+        It 'Graph client-secret path emits a warning recommending certificate auth' {
+            $secret = ConvertTo-SecureString 'fake-secret-value' -AsPlainText -Force
+            $warningVar = $null
+            & $script:scriptPath -Service 'Graph' -ClientId 'fake-app-id' -ClientSecret $secret -WarningVariable warningVar -WarningAction SilentlyContinue
+            ($warningVar -join ' ') | Should -Match '(?i)certificate'
+        }
+
+        It 'Power BI client-secret path emits a warning recommending certificate auth' {
+            $secret = ConvertTo-SecureString 'fake-secret-value' -AsPlainText -Force
+            $warningVar = $null
+            & $script:scriptPath -Service 'PowerBI' -ClientId 'fake-app-id' -ClientSecret $secret -WarningVariable warningVar -WarningAction SilentlyContinue
+            ($warningVar -join ' ') | Should -Match '(?i)certificate'
+        }
+
+        It 'Graph certificate path does not emit the client-secret warning' {
+            $warningVar = $null
+            & $script:scriptPath -Service 'Graph' -ClientId 'fake-app-id' -CertificateThumbprint 'AB12CD34EF56' -WarningVariable warningVar -WarningAction SilentlyContinue
+            ($warningVar -join ' ') | Should -Not -Match '(?i)client secret'
+        }
+    }
 }

--- a/tests/Common/Connect-Service.Tests.ps1
+++ b/tests/Common/Connect-Service.Tests.ps1
@@ -47,6 +47,16 @@ Describe 'Connect-Service' {
 
     Context 'client-secret warning (#790)' {
         BeforeAll {
+            # CI runners may not have Microsoft.Graph.Authentication or MicrosoftPowerBIMgmt
+            # installed -- Pester's Mock requires the command to exist before it can shim it.
+            # Stub the connect cmdlets globally if missing so Mock has something to replace.
+            if (-not (Get-Command -Name Connect-MgGraph -ErrorAction SilentlyContinue)) {
+                function global:Connect-MgGraph { param() }
+            }
+            if (-not (Get-Command -Name Connect-PowerBIServiceAccount -ErrorAction SilentlyContinue)) {
+                function global:Connect-PowerBIServiceAccount { param() }
+            }
+
             # Modules appear installed
             Mock Get-Module { @{ Name = 'Microsoft.Graph.Authentication' } }
             # No-op the actual connections so we don't reach out to a tenant
@@ -56,6 +66,12 @@ Describe 'Connect-Service' {
             Mock Get-Command {
                 [pscustomobject]@{ Parameters = @{ NoWelcome = $true } }
             } -ParameterFilter { $Name -eq 'Connect-MgGraph' }
+        }
+
+        AfterAll {
+            # Tear down any global stubs we created so they don't leak into other tests
+            Remove-Item -Path 'function:global:Connect-MgGraph' -ErrorAction SilentlyContinue
+            Remove-Item -Path 'function:global:Connect-PowerBIServiceAccount' -ErrorAction SilentlyContinue
         }
 
         It 'Graph client-secret path emits a warning recommending certificate auth' {


### PR DESCRIPTION
## Summary

Three v2.9.0 — Trust Hardening sprint-1 quick wins bundled into a single PR.

Closes #767, #790, #692. Epic #766.

## Issues addressed

### A1 #767 — README "What's New" header refresh
Replaces the stale v2.2.0 section with a v2.6.0 highlight table (smart search, collapsible sections, XLSX roadmap sheet, CMMC L2/L3 + CIS E3/E5 profile filtering). Sourced from `M365-Assess.psd1` `ReleaseNotes` and `CHANGELOG.md`.

### E1 #790 — Client-secret labeled as least-preferred
- `AUTHENTICATION.md` gains a top banner recommending certificate auth and reminding users that EXO + Purview reject client-secret by design
- `Connect-Service.ps1` Graph and Power BI client-secret paths now emit `Write-Warning` suggesting cert auth (suppressible via `-WarningAction SilentlyContinue` like the existing PowerBI handling)
- 3 new Pester tests verify the warning fires for both services and stays silent on the cert path
- AUTHENTICATION.md is already linked from README (lines 191, 403); no new link needed

### #692 — Tenant appendix CreatedDateTime truncates mid-hour
**Root cause:** ``report-app.jsx`` does `\`{TENANT.CreatedDateTime.slice(0,10)}\`` which assumes ISO-8601. Upstream may emit US-locale (`'M/D/YYYY H:MM:SS'`) — slicing then yields strings like `'2/3/2024 8'`.

**Fix at the data bridge** (per the issue's preferred direction): `Build-ReportData.ps1` now parses CreatedDateTime as `[datetime]` and emits ISO `'yyyy-MM-dd'`. Falls back to the raw string if parsing fails so the report still has a value.

4 new Pester tests cover: existing OrgDisplayName passthrough (regression), ISO input, US-locale input, unparseable input fallback.

## Test plan

- [x] Targeted Pester (Build-ReportData + Connect-Service): 90/90 pass
- [x] Smoke suite: 303/303 pass
- [x] PSScriptAnalyzer on changed files: clean
- [x] Version-consistency check: green (README badge still 2.6.0)
- [x] CI quality-gates job is green
- [x] CI Pester matrix (PS 7.4 + 7.6) is green

## Notes for reviewer

- The Connect-Service warning's wording is intentionally specific and actionable: "Pass `-CertificateThumbprint` where possible." — not a generic security lecture.
- The Build-ReportData fix uses a separate `\$rawCreated` variable because inside the catch block, `\$_` becomes the error record (not the pipeline object). Easy to overlook.
- Sprint context: this PR is one of 9 issues on the `sprint-current` label. Companion PR #797 (A5 read-only CI guardrail) is in CI now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)