### PR TITLE
ci: pin third-party action by SHA + docs-gates job (#768, #776)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      docs: ${{ steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
+      # Third-party action pinned by commit SHA for supply-chain hardening (#768).
+      # First-party actions/* stay on tag pins.
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
         id: filter
         with:
           filters: |
@@ -34,6 +37,53 @@ jobs:
               - 'tests/**'
               - '.github/workflows/ci.yml'
               - 'PSScriptAnalyzerSettings.psd1'
+            docs:
+              - 'README.md'
+              - 'CHANGELOG.md'
+              - 'AUTHENTICATION.md'
+              - 'SECURITY.md'
+              - 'COMPLIANCE.md'
+              - 'REPORT.md'
+              - 'docs/**'
+              - 'package.json'
+              - 'package-lock.json'
+
+  # Lightweight job that runs only the version-consistency check when a PR
+  # touches docs that gate version messaging but does NOT touch code (#776).
+  # When code changes, the full quality-gates job runs version-consistency
+  # itself, so we skip this job to avoid duplicating the check.
+  docs-gates:
+    needs: changes
+    if: needs.changes.outputs.docs == 'true' && needs.changes.outputs.code != 'true'
+    name: Docs Gates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Version consistency
+        shell: pwsh
+        run: |
+          $manifest = Import-PowerShellDataFile -Path ./src/M365-Assess/M365-Assess.psd1
+          $expected = $manifest.ModuleVersion
+          Write-Host "Manifest version: $expected"
+
+          $failures = @()
+          $esc = [regex]::Escape($expected)
+
+          # README badge
+          $readme = Get-Content ./README.md -Raw
+          if ($readme -notmatch "version-$esc-") {
+            $failures += 'README.md badge'
+          }
+
+          if ($failures.Count -gt 0) {
+            Write-Host "`nVersion issues:" -ForegroundColor Red
+            $failures | ForEach-Object { Write-Host "  - $_" -ForegroundColor Yellow }
+            Write-Error "$($failures.Count) version issue(s) found"
+            exit 1
+          }
+
+          Write-Host "Version consistency: manifest=$expected, README badge matches" -ForegroundColor Green
 
   quality-gates:
     needs: changes
@@ -259,7 +309,7 @@ jobs:
 
   ci-status:
     name: CI
-    needs: [quality-gates, test]
+    needs: [quality-gates, test, docs-gates]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -267,11 +317,13 @@ jobs:
         run: |
           qg="${{ needs.quality-gates.result }}"
           t="${{ needs.test.result }}"
+          d="${{ needs.docs-gates.result }}"
           if [[ "$qg" == "success" || "$qg" == "skipped" ]] && \
-             [[ "$t" == "success" || "$t" == "skipped" ]]; then
-            echo "CI passed (quality-gates=$qg, test=$t)"
+             [[ "$t"  == "success" || "$t"  == "skipped" ]] && \
+             [[ "$d"  == "success" || "$d"  == "skipped" ]]; then
+            echo "CI passed (quality-gates=$qg, test=$t, docs-gates=$d)"
           else
-            echo "CI failed (quality-gates=$qg, test=$t)"
+            echo "CI failed (quality-gates=$qg, test=$t, docs-gates=$d)"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

Two v2.9.0 — Trust Hardening sprint-1 CI hardenings, bundled because both touch `.github/workflows/ci.yml`.

Closes #768, #776. Epic #766.

## A2 #768 — Pin third-party action by commit SHA

Replaces:
```yaml
- uses: dorny/paths-filter@v4
```
with:
```yaml
- uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
```

**Policy** (documented in the inline comment):
- Third-party actions: pin by commit SHA — protects against tag-mutation attacks
- First-party `actions/*`: stay on tag pins — GitHub-maintained, Dependabot can update them

`dorny/paths-filter@v4` is the only third-party action in any workflow on this repo.

## B5 #776 — Lightweight `docs-gates` job for doc-only PRs

The version-consistency check runs in `quality-gates`, which only fires when `code`-filtered files change. A README-only PR can drift the version badge without CI catching it.

**New job:**
- Triggers when `docs` filter matches AND `code` does NOT (avoids duplicating the check, which already runs in `quality-gates` on code PRs)
- Runs on `ubuntu-latest` (faster + cheaper than windows-latest; the PowerShell snippet has no Windows-only dependencies)
- Runs only the version-consistency check (manifest -> README badge regex)
- `ci-status` now requires `docs-gates` to be `success` or `skipped`, alongside `quality-gates` and `test`

**`docs` filter scope:** `README.md`, `CHANGELOG.md`, `AUTHENTICATION.md`, `SECURITY.md`, `COMPLIANCE.md`, `REPORT.md`, `docs/**`, `package.json`, `package-lock.json`

**Trigger matrix:**

| PR touches | code filter | docs filter | quality-gates | test | docs-gates |
|---|---|---|---|---|---|
| only code | ✅ | ❌ | runs | runs | skips |
| only docs | ❌ | ✅ | skips | skips | runs |
| both | ✅ | ✅ | runs | runs | skips (code path covers it) |
| neither | ❌ | ❌ | skips | skips | skips |

## Test plan

- [x] YAML parses cleanly (`python -c 'import yaml; yaml.safe_load(open(...))'`)
- [x] Positive case: version-consistency snippet passes on current state (manifest=2.6.0, README badge matches)
- [x] Negative case: deliberately mangling the README badge to `version-9.99.9-blue` causes the snippet to exit 1 with `README.md badge` — confirms the gate works
- [x] CI quality-gates job is green
- [x] CI Pester matrix (PS 7.4 + 7.6) is green
- [ ] Future doc-only PR exercises the new `docs-gates` lane

## Notes for reviewer

- The version-consistency snippet in `docs-gates` is intentionally a *subset* of the `quality-gates` version check — only the manifest -> README badge regex. The runtime-reader checks (`Invoke-M365Assessment.ps1` / `Export-AssessmentReport.ps1` should use `Import-PowerShellDataFile`) only matter when source code changes, so they stay in `quality-gates`.
- This PR itself touches `ci.yml`, which is in the `code` filter, so the full `quality-gates` + Pester matrix runs on it. `docs-gates` correctly skips. The new lane will first fire on the next doc-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)