### PR TITLE
docs(architecture): record loader + API-surface decisions (#775, #782)

### DIFF
--- a/docs/architecture/api-surface.md
+++ b/docs/architecture/api-surface.md
@@ -1,0 +1,105 @@
+# Public API surface decision (C3)
+
+**Status:** Recommendation pending user ratification. 2026-04-25 (Issue #782, milestone v2.9.0 — Trust Hardening).
+
+**Recommendation:** Adopt model (a) **Invoke-only collectors** — remove the 13 `Get-M365*SecurityConfig` / `Get-M365*RetentionConfig` wrappers and route all collector access through `Invoke-M365Assessment -Section`. Operational cmdlets (Invoke, Compare-Baseline, Grant-Consent, the four profile cmdlets) stay public.
+
+---
+
+## Problem
+
+The current public API has uneven coverage of the underlying collector surface:
+
+| Surface | Count |
+|---|---|
+| Collector `.ps1` files in domain folders | 69 |
+| Public collector wrappers in `M365-Assess.psm1` | 13 |
+| Coverage | 19% |
+
+The 13 wrappers are thin pass-throughs — each is a `[CmdletBinding()]` shell that splats `$PSBoundParameters` into `& "$PSScriptRoot\<domain>\<script>.ps1"`. They expose only `-OutputPath` (and in one case `-AcceptedDomains` / `-DkimConfigs`).
+
+The middle ground is hard to defend:
+
+- Users can't tell which collectors have wrappers without reading the manifest
+- Wrappers don't add value beyond what `Invoke-M365Assessment -Section <X>` already provides
+- Every wrapper is a versioning commitment — its parameter set becomes part of the public API
+- Adding a new collector creates a tooling-versus-policy decision: do we wrap it? what's the rule?
+
+The 2026-04-25 external review (§13) flagged this and asked for a clear model.
+
+## Two viable models
+
+### (a) Invoke-only collectors *(recommended)*
+
+Remove the 13 collector wrappers. The public API becomes:
+
+- `Invoke-M365Assessment` — single entry point; `-Section <Identity|Email|Security|...>` selects collector groups
+- `Compare-M365Baseline` — drift comparison
+- `Grant-M365AssessConsent` — setup helper
+- `Get-M365ConnectionProfile`, `New-M365ConnectionProfile`, `Set-M365ConnectionProfile`, `Remove-M365ConnectionProfile` — connection profile management
+
+7 public cmdlets. Collectors are internal scripts only.
+
+**Pros**
+- One supported entry point reduces docs surface, test surface, and PSGallery release-note surface
+- `-Section` is already the documented public path for "run a subset of collectors"
+- Removes 13 wrappers + 13 wrapper-test scaffolds
+- Adding a new collector is purely internal; no public-API decision
+
+**Cons**
+- Breaking change for anyone calling `Get-M365EntraSecurityConfig` etc. directly (population unknown — likely small)
+- Loses ability to invoke a single collector with no orchestration overhead (connection prefetch, registry load) — a use case more relevant to internal debugging than end-user workflows
+
+**Migration path**
+1. Publish a deprecation notice in v2.9.0 release notes
+2. Keep the wrappers in v2.9.x with a `Write-Warning` directing users to `Invoke-M365Assessment -Section`
+3. Remove wrappers in v3.0.0 (next major)
+
+### (b) Full collector coverage
+
+Generate a `Get-M365*` wrapper for every collector — ~56 new wrappers added to the existing 13.
+
+**Pros**
+- Consistent: every collector is reachable as a module-level cmdlet
+- Power users / consultants get fine-grained access without `Invoke-M365Assessment`'s orchestration
+
+**Cons**
+- ~56 new wrappers to write, document, test, and maintain
+- Each wrapper is a public API commitment forever
+- Most wrappers will have identical signatures (`-OutputPath` only) so the duplication is mechanical rather than informative
+- Adding a new collector requires shipping a wrapper alongside it — slows feature work
+
+## Why we recommend (a)
+
+1. **The 13 existing wrappers don't add user value.** They're equivalent to `Invoke-M365Assessment -Section <one collector>`. The orchestrator path is the documented public path; the wrappers compete with it.
+
+2. **Population of users calling wrappers directly is small.** The dominant usage pattern is `Invoke-M365Assessment` (interactive wizard or non-interactive consultant runs). Wrappers exist mostly because they were added incrementally without a model decision.
+
+3. **Maintenance asymmetry.** Removing 13 is small, well-scoped work. Adding 56 is a refactor that introduces 56 new public-API commitments without a clear consumer.
+
+4. **`-Section` is more flexible than wrappers.** A wrapper exposes one collector; `-Section Identity` runs the whole identity batch with shared connection setup, registry loading, and reporting plumbing.
+
+## Open questions for ratification
+
+1. **Are there known external consumers of the 13 wrappers?** If so, the v2.9.x deprecation window may need to be longer than one release.
+
+2. **Should the wrappers be deprecated immediately or carry the warning for a full minor cycle?** Recommendation: warn in v2.9.0, remove in v3.0.0.
+
+3. **Should `Compare-M365Baseline` stay public, or fold into `Invoke-M365Assessment -Compare`?** Out of scope for this issue, but worth noting — the same uneven-surface argument applies.
+
+## Implementation plan (if (a) is ratified)
+
+1. Add a `Write-Warning` deprecation banner to each of the 13 wrapper functions in `M365-Assess.psm1`
+2. Remove wrapper entries from `FunctionsToExport` in `M365-Assess.psd1`
+3. Remove wrapper entries from `Export-ModuleMember` in `M365-Assess.psm1`
+4. Remove the wrapper definitions themselves
+5. Update `tests/` — remove wrapper-specific tests; keep collector-script tests intact
+6. Update `cmdlet-reference.md` to reflect the trimmed public surface
+7. Update README "Public Cmdlets" section
+8. Note the deprecation in `CHANGELOG.md` v3.0.0 entry
+
+## Related
+
+- Issue #782
+- External review at `M365-Assessment/reviews/2026-04-25_repo-review.md`, §13
+- Module loader decision: `loader.md` (companion)

--- a/docs/architecture/loader.md
+++ b/docs/architecture/loader.md
@@ -1,0 +1,57 @@
+# Module loader architecture (B4)
+
+**Decision:** Keep the current explicit-named loader. Do not restructure into `Public/Private` folders.
+
+**Status:** Decided. 2026-04-25 (Issue #775, milestone v2.9.0 — Trust Hardening).
+
+---
+
+## Background
+
+The 2026-04-25 external repo review claimed the module loader "dot-sources broad script sets" and recommended a `Public/`, `Private/`, manifest-controlled-list layout. Issue #775 was filed to evaluate that recommendation.
+
+Verification before triage found the claim was inaccurate. The current loader at `src/M365-Assess/M365-Assess.psm1` is already explicit:
+
+- 17 named `. "$PSScriptRoot\<folder>\<name>.ps1"` dot-sources
+- One controlled `Get-ChildItem -Path "$PSScriptRoot\Orchestrator\*.ps1"` sweep over a single folder (the orchestrator's helper modules)
+- 13 inline collector wrapper functions defined directly in the `.psm1`
+- An explicit `Export-ModuleMember -Function @(...)` list naming 20 public cmdlets
+
+There is no recursive wildcard sweep. There are no implicit module loads.
+
+## Why we keep the current layout
+
+### 1. The reviewer's premise was inaccurate
+
+The reviewer's stated benefits — "function name collisions," "accidental public/private leakage," "load-time side effects," "slower imports," "difficult test isolation" — apply to layouts that use recursive `Get-ChildItem -Recurse | Foreach { . $_ }` patterns. This module does not. The risks the reviewer described are already mitigated by the explicit-named approach.
+
+### 2. The proposed restructure is high-cost / low-benefit for this codebase
+
+A `Public/Private` split would:
+
+- Move ~80 `.ps1` files into new folder paths
+- Update every relative path reference in the loader, tests, and documentation
+- Require a corresponding update to the manifest's `FileList`
+- Break any external consumer that imports collector scripts by direct path (consultants who dot-source individual collectors outside `Invoke-M365Assessment`)
+
+The benefit is purely organizational — there is no functional gain. The convention is associated with PowerShell modules that have unstable internal/external boundaries, which this module does not.
+
+### 3. The actual public surface is already enforced
+
+`FunctionsToExport` in `M365-Assess.psd1` is the source of truth for the public API. Any function not in that list is internal regardless of where its file lives. Pester smoke tests validate that `FunctionsToExport` matches `Export-ModuleMember`. Folder structure is not a substitute for an export list.
+
+## What we would reconsider
+
+This decision is reversible. We would revisit if any of the following becomes true:
+
+- Test isolation problems trace back to the loader sweep
+- A new collector pattern emerges that needs first-class internal/external separation (e.g., per-collector classes)
+- The module surface grows large enough that contributors get confused about what's public vs. internal — at which point a `Public/Private` split becomes a documentation aid
+
+Until then, the existing layout is appropriate.
+
+## Related
+
+- Issue #775 (closed by this doc)
+- External review at `M365-Assessment/reviews/2026-04-25_repo-review.md`, §5
+- Verification record in `~/.claude/projects/C--git-M365-Assess/memory/project_v29_trust_hardening.md`


### PR DESCRIPTION
## Summary

Two architectural decision docs in `docs/architecture/`, surfaced by the 2026-04-25 external review and tracked in v2.9.0 — Trust Hardening sprint 1.

Closes #775 (decided). #782 is a recommendation pending your ratification — see below.

## What's in this PR

### `docs/architecture/loader.md` — B4 #775

**Decision: keep the current loader. Decided.**

Reviewer claimed the loader "dot-sources broad script sets." Verified inaccurate: 17 named dot-sources + one controlled `Get-ChildItem` over a single `Orchestrator/` folder. No recursive wildcard sweep. The proposed `Public/Private` restructure would touch ~80 files and break path-based external consumers for purely organizational gain.

Doc covers the verification, the cost/benefit analysis, and explicit reversibility conditions (what would make us reconsider).

### `docs/architecture/api-surface.md` — C3 #782

**Recommendation: adopt (a) invoke-only collectors. PENDING RATIFICATION.**

Today: 13 thin `Get-M365*SecurityConfig` / `Get-M365*RetentionConfig` wrappers in the manifest. They're pass-throughs into the underlying scripts and overlap with `Invoke-M365Assessment -Section`.

Two viable models documented with pros/cons:
- **(a) Invoke-only collectors** — remove the 13 wrappers; collectors become internal scripts
- **(b) Full coverage** — generate ~56 more wrappers to match every collector

Recommendation goes to **(a)** because the wrappers don't add user value over `-Section`, removal is small + scoped, and adding 56 more is a long maintenance commitment with no clear consumer.

**This PR doesn't remove anything.** Implementation plan is in the doc, gated on your ratification.

## Open questions for you

1. Known external consumers of the 13 collector wrappers?
2. Deprecate immediately or carry the warning for a full minor cycle (v2.9.x → v3.0.0)?
3. Should `Compare-M365Baseline` stay public or fold into `Invoke-M365Assessment -Compare`? (Out of scope for #782 but the same uneven-surface argument applies — flagged for a future grooming pass.)

## Test plan

- [x] Both docs render correctly in Markdown
- [x] No code changes — no test impact
- [x] PR is doc-only — should exercise the new `docs-gates` lane once #799 merges (this PR's `docs/**` paths match the new docs filter)
- [x] CI passes

## Sprint context

This is the third (and last) Sprint 1 PR for v2.9.0 — Trust Hardening:
- PR #797 — A5 read-only CI guardrail (merged)
- PR #798 — A1 README + E1 client-secret + #692 appendix date (merged)
- PR #799 — A2 SHA pin + B5 docs-gates (in CI)
- PR (this one) — B4 + C3 architectural decisions

After this lands, only #782's ratification + cleanup remains as Sprint 1 follow-up. Sprint 2 candidates: status taxonomy cluster (B3 #774 + B8 #779 + F4 #793).

🤖 Generated with [Claude Code](https://claude.com/claude-code)