### PR TITLE
feat(status): wire NotApplicable/NotLicensed/Skipped/Unknown through React app + CSS (B8 #779 partial)

### DIFF
--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -48,7 +48,14 @@ function finalizeReport({
 // Issue #715: roadmap lane counts now read from t.lane (precomputed by
 // Get-RemediationLane.ps1 in the data bridge) so sidebar nav, Roadmap, and
 // XLSX export all agree on bucketing without parallel JS rules.
-const _RM = FINDINGS.filter(f => f.status !== 'Pass' && f.status !== 'Info');
+// Statuses that should NOT become remediation tasks. See docs/CHECK-STATUS-MODEL.md
+//   Pass / Info       — no remediation needed
+//   Skipped           — user intentionally didn't run this check
+//   Unknown           — data couldn't be collected; remediation is "fix permissions", not the check itself
+//   NotApplicable     — service not in use in this tenant
+//   NotLicensed       — surfaced separately as "Requires Licensing", not as a Now/Next/Later task
+const NON_REMEDIATION_STATUSES = new Set(['Pass', 'Info', 'Skipped', 'Unknown', 'NotApplicable', 'NotLicensed']);
+const _RM = FINDINGS.filter(f => !NON_REMEDIATION_STATUSES.has(f.status));
 const ROADMAP_COUNTS = {
   now: _RM.filter(t => t.lane === 'now').length,
   soon: _RM.filter(t => t.lane === 'soon').length,
@@ -298,12 +305,18 @@ const Icon = {
     d: "M3 3l10 10M13 3L3 13"
   }))
 };
+
+// Status -> CSS chip class name. See docs/CHECK-STATUS-MODEL.md for semantics.
 const STATUS_COLORS = {
   Fail: 'fail',
   Warning: 'warn',
   Pass: 'pass',
   Review: 'review',
-  Info: 'info'
+  Info: 'info',
+  Skipped: 'skipped',
+  Unknown: 'unknown',
+  NotApplicable: 'notapplicable',
+  NotLicensed: 'notlicensed'
 };
 const SEV_LABEL = {
   critical: 'Critical',
@@ -2442,7 +2455,9 @@ function FilterBar({
   };
   const active = filters.status.length + filters.severity.length + filters.framework.length + filters.domain.length + (filters.profile || []).length;
   const isActive = search.length > 0 || active > 0;
-  const statusChips = [['Fail', 'fail'], ['Warning', 'warn'], ['Review', 'review'], ['Pass', 'pass'], ['Info', 'info']];
+
+  // [data-value, css-class, optional-display-label]
+  const statusChips = [['Fail', 'fail'], ['Warning', 'warn'], ['Review', 'review'], ['Pass', 'pass'], ['Info', 'info'], ['Skipped', 'skipped'], ['Unknown', 'unknown'], ['NotApplicable', 'notapplicable', 'Not Applicable'], ['NotLicensed', 'notlicensed', 'Not Licensed']];
   const sevChips = [['critical', 'crit', 'Critical'], ['high', 'high', 'High'], ['medium', 'med', 'Medium'], ['low', 'low', 'Low']];
   const DOM_ORDER = ['Entra ID', 'Conditional Access', 'Enterprise Apps', 'Exchange Online', 'Intune', 'Defender', 'Purview / Compliance', 'SharePoint & OneDrive', 'Teams', 'Forms', 'Power BI', 'Active Directory', 'SOC 2', 'Value Opportunity'];
   const domainList = DOM_ORDER.filter(d => counts.domain[d]).concat(Object.keys(counts.domain).filter(d => !DOM_ORDER.includes(d)).sort());
@@ -2479,13 +2494,13 @@ function FilterBar({
     className: "filter-group"
   }, /*#__PURE__*/React.createElement("span", {
     className: "filter-group-label"
-  }, "Status"), statusChips.map(([v, cls]) => /*#__PURE__*/React.createElement("button", {
+  }, "Status"), statusChips.map(([v, cls, label]) => /*#__PURE__*/React.createElement("button", {
     key: v,
     className: 'chip ' + cls + (filters.status.includes(v) ? ' selected' : ''),
     onClick: () => update('status', v)
   }, /*#__PURE__*/React.createElement("span", {
     className: "dot"
-  }), v, /*#__PURE__*/React.createElement("span", {
+  }), label || v, /*#__PURE__*/React.createElement("span", {
     className: "ct"
   }, counts.status[v] || 0)))), /*#__PURE__*/React.createElement("div", {
     className: "filter-divider"
@@ -3223,7 +3238,7 @@ function Roadmap({
     });
     onRoadmapChange(next);
   };
-  const tasks = FINDINGS.filter(f => f.status !== 'Pass' && f.status !== 'Info' && !hiddenFindings?.has(f.checkId)).map(f => ({
+  const tasks = FINDINGS.filter(f => !NON_REMEDIATION_STATUSES.has(f.status) && !hiddenFindings?.has(f.checkId)).map(f => ({
     ...f
   }));
   const score = f => {

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -39,7 +39,14 @@ function finalizeReport({ hiddenFindings, roadmapOverrides }) {
 // Issue #715: roadmap lane counts now read from t.lane (precomputed by
 // Get-RemediationLane.ps1 in the data bridge) so sidebar nav, Roadmap, and
 // XLSX export all agree on bucketing without parallel JS rules.
-const _RM = FINDINGS.filter(f => f.status !== 'Pass' && f.status !== 'Info');
+// Statuses that should NOT become remediation tasks. See docs/CHECK-STATUS-MODEL.md
+//   Pass / Info       — no remediation needed
+//   Skipped           — user intentionally didn't run this check
+//   Unknown           — data couldn't be collected; remediation is "fix permissions", not the check itself
+//   NotApplicable     — service not in use in this tenant
+//   NotLicensed       — surfaced separately as "Requires Licensing", not as a Now/Next/Later task
+const NON_REMEDIATION_STATUSES = new Set(['Pass', 'Info', 'Skipped', 'Unknown', 'NotApplicable', 'NotLicensed']);
+const _RM = FINDINGS.filter(f => !NON_REMEDIATION_STATUSES.has(f.status));
 const ROADMAP_COUNTS = {
   now:   _RM.filter(t => t.lane === 'now').length,
   soon:  _RM.filter(t => t.lane === 'soon').length,
@@ -112,7 +119,18 @@ const Icon = {
   close: () => (<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M3 3l10 10M13 3L3 13"/></svg>),
 };
 
-const STATUS_COLORS = { Fail:'fail', Warning:'warn', Pass:'pass', Review:'review', Info:'info' };
+// Status -> CSS chip class name. See docs/CHECK-STATUS-MODEL.md for semantics.
+const STATUS_COLORS = {
+  Fail:          'fail',
+  Warning:       'warn',
+  Pass:          'pass',
+  Review:        'review',
+  Info:          'info',
+  Skipped:       'skipped',
+  Unknown:       'unknown',
+  NotApplicable: 'notapplicable',
+  NotLicensed:   'notlicensed',
+};
 const SEV_LABEL = { critical:'Critical', high:'High', medium:'Medium', low:'Low', none:'—', info:'Info' };
 
 // --------------------- Helpers ---------------------
@@ -1471,8 +1489,12 @@ function FilterBar({ filters, setFilters, counts, total, search, setSearch }) {
   const active = filters.status.length + filters.severity.length + filters.framework.length + filters.domain.length + (filters.profile||[]).length;
   const isActive = search.length > 0 || active > 0;
 
+  // [data-value, css-class, optional-display-label]
   const statusChips = [
-    ['Fail','fail'], ['Warning','warn'], ['Review','review'], ['Pass','pass'], ['Info','info']
+    ['Fail','fail'], ['Warning','warn'], ['Review','review'], ['Pass','pass'], ['Info','info'],
+    ['Skipped','skipped'], ['Unknown','unknown'],
+    ['NotApplicable','notapplicable','Not Applicable'],
+    ['NotLicensed','notlicensed','Not Licensed'],
   ];
   const sevChips = [ ['critical','crit','Critical'],['high','high','High'],['medium','med','Medium'],['low','low','Low'] ];
 
@@ -1493,9 +1515,9 @@ function FilterBar({ filters, setFilters, counts, total, search, setSearch }) {
       <div className="fb-row fb-row-chips">
       <div className="filter-group">
         <span className="filter-group-label">Status</span>
-        {statusChips.map(([v,cls])=>(
+        {statusChips.map(([v,cls,label])=>(
           <button key={v} className={'chip '+cls+(filters.status.includes(v)?' selected':'')} onClick={()=>update('status',v)}>
-            <span className="dot"/>{v}<span className="ct">{counts.status[v]||0}</span>
+            <span className="dot"/>{label || v}<span className="ct">{counts.status[v]||0}</span>
           </button>
         ))}
       </div>
@@ -2015,7 +2037,7 @@ function Roadmap({ onViewFinding, editMode, hiddenFindings, roadmapOverrides, on
     onRoadmapChange(next);
   };
 
-  const tasks = FINDINGS.filter(f => f.status !== 'Pass' && f.status !== 'Info' && !hiddenFindings?.has(f.checkId)).map(f => ({ ...f }));
+  const tasks = FINDINGS.filter(f => !NON_REMEDIATION_STATUSES.has(f.status) && !hiddenFindings?.has(f.checkId)).map(f => ({ ...f }));
   const score = f => {
     const sev = { critical:100, high:60, medium:30, low:10, none:0, info:5 }[f.severity];
     const eff = { small:3, medium:2, large:1 }[f.effort];

--- a/src/M365-Assess/assets/report-shell.css
+++ b/src/M365-Assess/assets/report-shell.css
@@ -646,6 +646,11 @@ section.block { margin-bottom: 52px; scroll-margin-top: 20px; }
 .chip.pass .dot { background: var(--success); }
 .chip.review .dot { background: var(--accent); }
 .chip.info .dot { background: var(--muted); }
+/* See docs/CHECK-STATUS-MODEL.md for semantics. */
+.chip.skipped .dot       { background: var(--muted); opacity: 0.6; }
+.chip.unknown .dot       { background: var(--warn); box-shadow: 0 0 0 2px var(--warn-soft); }
+.chip.notapplicable .dot { background: var(--text-soft); opacity: 0.5; }
+.chip.notlicensed .dot   { background: var(--accent); opacity: 0.6; }
 .chip.crit .dot { background: var(--danger); box-shadow: 0 0 0 3px var(--danger-ring); }
 .chip.high .dot { background: #ff7a45; }
 .chip.med .dot { background: var(--warn); }
@@ -798,6 +803,18 @@ mark.search-hl {
 .status-badge.review .dot { background: var(--accent); }
 .status-badge.info { background: var(--chip); color: var(--text-soft); }
 .status-badge.info .dot { background: var(--muted); }
+/* Non-collected / non-applicable states. See docs/CHECK-STATUS-MODEL.md.
+   Skipped, NotApplicable, NotLicensed share a muted treatment with
+   distinct dots; Unknown uses warn-style coloring because it represents
+   a collection failure (permissions / API error) the user should fix. */
+.status-badge.skipped { background: var(--chip); color: var(--muted); }
+.status-badge.skipped .dot { background: var(--muted); }
+.status-badge.unknown { background: var(--warn-soft); color: var(--warn-text); }
+.status-badge.unknown .dot { background: var(--warn); }
+.status-badge.notapplicable { background: var(--chip); color: var(--text-soft); }
+.status-badge.notapplicable .dot { background: var(--text-soft); opacity: 0.6; }
+.status-badge.notlicensed { background: var(--chip); color: var(--accent-text); }
+.status-badge.notlicensed .dot { background: var(--accent); }
 
 .sev-badge {
   display: inline-flex; gap: 4px; align-items: center;


### PR DESCRIPTION
## Summary

Sprint 2 PR 2b — renderer wiring slice for the status taxonomy. Threads the four "non-collected / non-applicable" statuses through every status-rendering path in the React report and adds matching CSS chip styles.

Partial advance on B8 #779. Does NOT close it — see "Defensible scope cuts" below for what's deferred.

## What changed

### JSX (`report-app.jsx`)
- **`STATUS_COLORS` map** extended from 5 to 9 entries — one CSS class per status, sourced from `docs/CHECK-STATUS-MODEL.md`
- **`statusChips` filter array** gains 4 new chips. Data values stay identifier-form (`NotApplicable`) so filter logic still works; display labels are friendly (`Not Applicable`, `Not Licensed`) via an optional third element on the tuple
- **New `NON_REMEDIATION_STATUSES` Set** centralizes the "what counts as a remediation task" decision. Both the `_RM` sidebar nav counter and the Remediation Roadmap task list use it, so they stay in sync. Statuses excluded from remediation: `Pass`, `Info`, `Skipped`, `Unknown`, `NotApplicable`, `NotLicensed`

### CSS (`report-shell.css`)
- **4 new `.chip.{skipped,unknown,notapplicable,notlicensed}`** rules for the filter chip dots
- **4 new `.status-badge.{skipped,unknown,notapplicable,notlicensed}`** rules for the inline status badges. Visual treatment:
  - `skipped` → muted gray (user intentionally didn't run)
  - `unknown` → warn-soft yellow (couldn't collect; fix permissions)
  - `notapplicable` → soft text muted (service not in use)
  - `notlicensed` → accent-tinted (hint at upgrade path)

### Compiled `report-app.js`
- Regenerated via `npm run build`
- `node --check` passes; CI's full Babel build gate validates JSX → JS drift

## Defensible scope cuts (transparency)

This PR is intentionally smaller than B8 #779's full AC list. The cuts are tracked as follow-ups:

| Cut | Why deferred | Tracked as |
|---|---|---|
| **Denominator math** (`Pass% = Pass / (Pass + Fail + Warning)`) | Score-impacting behavioral change. Today the React app uses `FINDINGS.length`, `spo.length`, `adFindings.length` etc. as denominators (every status counts). The doc commits to a stricter rule, but the change deserves explicit before/after disclosure | #802 |
| **XLSX cell formatting** for new statuses | Separate file (`Export-ComplianceMatrix.ps1`), no JSX coupling, cleaner as a standalone PR | TBD next PR |
| **Browser live test** | Playwright sandbox blocks `file://`; HTTP server bind permission denied. The new code paths are purely additive — no existing render path is modified — so the risk is bounded | See note below |

## Browser live test

The project's "live test report before merging" rule applies to any change touching `report-app.js`/`.jsx`/CSS. I attempted to do this via Playwright but hit two sandbox boundaries:

- `file://` is blocked by Playwright's safety policy
- `python -m http.server --bind 127.0.0.1` is blocked by the runtime's "expose local services" restriction

To live-test before merging, you can:
1. Build a swap-in test HTML: `(head -n 21202 docs/sample-report/_Example-Report.html; cat src/M365-Assess/assets/report-app.js; tail -n +24526 docs/sample-report/_Example-Report.html) > _test.html`
2. Open `_test.html` directly in a browser
3. Verify console is clean and the existing report still renders (the new chips don't appear yet because no collector emits the new statuses — that's PR 2c)

The change is otherwise low-risk: every edit is additive, the existing 5-status `STATUS_COLORS` lookups produce the same result for any input the data layer can currently produce, and `NON_REMEDIATION_STATUSES` adds 4 new exclusions to a filter that's never hit by any collector today.

## Test plan

- [x] `Invoke-Pester ./tests/Smoke ./tests/Common/Build-ReportData.Tests.ps1` — 410/410 pass
- [x] `npm run build` — succeeds, `report-app.js` regenerated
- [x] `node --check src/M365-Assess/assets/report-app.js` — clean
- [x] CI full Pester matrix passes
- [ ] (Manual) browser smoke test on `_test.html` swap-in (see above)

## What still owes B3 #774 / B8 #779

After this PR, the remaining sprint-2 work is:

- **#802** denominator audit — score-impacting; needs disclosure
- **B8 XLSX slice** — cell formatting in `Export-ComplianceMatrix.ps1`
- **PR 2c (B3 collector migration)** — Defender preset policies emit `NotLicensed` when E5 absent; closes B3 #774 fully

🤖 Generated with [Claude Code](https://claude.com/claude-code)