### PR TITLE
feat(defender): emit NotLicensed for Defender-for-Office license-deficient paths (closes B3 #774)

### DIFF
--- a/src/M365-Assess/Security/DefenderPresetZapChecks.ps1
+++ b/src/M365-Assess/Security/DefenderPresetZapChecks.ps1
@@ -113,7 +113,7 @@ try {
                 Setting          = 'ZAP for Teams'
                 CurrentValue     = 'Property not available on current license'
                 RecommendedValue = 'Defender for Office 365 with Teams ZAP'
-                Status           = 'Review'
+                Status           = 'NotLicensed'
                 CheckId          = 'DEFENDER-ZAP-001'
                 Remediation      = 'ZAP for Teams requires Defender for Office 365 Plan 2. Verify license and check Security admin center > Settings > Zero-hour auto purge.'
             }
@@ -126,7 +126,7 @@ try {
             Setting          = 'ZAP for Teams'
             CurrentValue     = 'Not licensed (Defender for Office 365 required)'
             RecommendedValue = 'Defender for Office 365 with Teams ZAP'
-            Status           = 'Review'
+            Status           = 'NotLicensed'
             CheckId          = 'DEFENDER-ZAP-001'
             Remediation      = 'ZAP for Teams requires Defender for Office 365. Upgrade license to enable this capability.'
         }

--- a/src/M365-Assess/Security/DefenderSafeAttLinksChecks.ps1
+++ b/src/M365-Assess/Security/DefenderSafeAttLinksChecks.ps1
@@ -110,7 +110,7 @@ try {
             Setting          = 'Safe Links Availability'
             CurrentValue     = 'Not licensed'
             RecommendedValue = 'Defender for Office 365 P1+'
-            Status           = 'Review'
+            Status           = 'NotLicensed'
             CheckId          = 'DEFENDER-SAFELINKS-001'
             Remediation      = 'Safe Links requires Defender for Office 365 Plan 1 or higher.'
         }
@@ -223,7 +223,7 @@ try {
             Setting          = 'Safe Attachments Availability'
             CurrentValue     = 'Not licensed'
             RecommendedValue = 'Defender for Office 365 P1+'
-            Status           = 'Review'
+            Status           = 'NotLicensed'
             CheckId          = 'DEFENDER-SAFEATTACH-001'
             Remediation      = 'Safe Attachments requires Defender for Office 365 Plan 1 or higher.'
         }
@@ -261,7 +261,7 @@ try {
             Setting          = 'Safe Attachments for SPO/OneDrive/Teams'
             CurrentValue     = 'Not licensed'
             RecommendedValue = 'Defender for Office 365 P1+'
-            Status           = 'Review'
+            Status           = 'NotLicensed'
             CheckId          = 'DEFENDER-SAFEATTACH-002'
             Remediation      = 'Safe Attachments for SPO/OneDrive/Teams requires Defender for Office 365 Plan 1 or higher.'
         }

--- a/tests/Security/DefenderPresetZapChecks.Tests.ps1
+++ b/tests/Security/DefenderPresetZapChecks.Tests.ps1
@@ -77,7 +77,7 @@ Describe 'DefenderPresetZapChecks - With Preset Policies' {
     }
 
     It 'All Status values are valid' {
-        $validStatuses = @('Pass', 'Fail', 'Warning', 'Review', 'Info', 'N/A')
+        $validStatuses = @('Pass', 'Fail', 'Warning', 'Review', 'Info', 'Skipped', 'Unknown', 'NotApplicable', 'NotLicensed', 'N/A')
         foreach ($s in $settings) {
             $s.Status | Should -BeIn $validStatuses `
                 -Because "Setting '$($s.Setting)' has status '$($s.Status)'"

--- a/tests/Security/DefenderSafeAttLinksChecks.Tests.ps1
+++ b/tests/Security/DefenderSafeAttLinksChecks.Tests.ps1
@@ -89,7 +89,7 @@ Describe 'DefenderSafeAttLinksChecks - With Defender License' {
     }
 
     It 'All Status values are valid' {
-        $validStatuses = @('Pass', 'Fail', 'Warning', 'Review', 'Info', 'N/A')
+        $validStatuses = @('Pass', 'Fail', 'Warning', 'Review', 'Info', 'Skipped', 'Unknown', 'NotApplicable', 'NotLicensed', 'N/A')
         foreach ($s in $settings) {
             $s.Status | Should -BeIn $validStatuses `
                 -Because "Setting '$($s.Setting)' has status '$($s.Status)'"
@@ -192,16 +192,16 @@ Describe 'DefenderSafeAttLinksChecks - No Defender License' {
         $settings.Count | Should -BeGreaterThan 0
     }
 
-    It 'Safe Links availability shows Review status when not licensed' {
+    It 'Safe Links availability shows NotLicensed when Defender for Office is unavailable' {
         $check = $settings | Where-Object { $_.Setting -eq 'Safe Links Availability' }
         $check | Should -Not -BeNullOrEmpty
-        $check.Status | Should -Be 'Review'
+        $check.Status | Should -Be 'NotLicensed'
     }
 
-    It 'Safe Attachments availability shows Review status when not licensed' {
+    It 'Safe Attachments availability shows NotLicensed when Defender for Office is unavailable' {
         $check = $settings | Where-Object { $_.Setting -eq 'Safe Attachments Availability' }
         $check | Should -Not -BeNullOrEmpty
-        $check.Status | Should -Be 'Review'
+        $check.Status | Should -Be 'NotLicensed'
     }
 
     AfterAll {

--- a/tests/Security/Get-DefenderSecurityConfig.Tests.ps1
+++ b/tests/Security/Get-DefenderSecurityConfig.Tests.ps1
@@ -293,16 +293,16 @@ Describe 'Get-DefenderSecurityConfig - No Defender License' {
         $settings.Count | Should -BeGreaterThan 0
     }
 
-    It 'Safe Links shows Review status when not licensed' {
+    It 'Safe Links shows NotLicensed when Defender for Office is unavailable' {
         $check = $settings | Where-Object { $_.Setting -like 'Safe Links*' }
         $check | Should -Not -BeNullOrEmpty
-        $check.Status | Should -Be 'Review'
+        $check.Status | Should -Be 'NotLicensed'
     }
 
-    It 'Safe Attachments shows Review status when not licensed' {
+    It 'Safe Attachments shows NotLicensed when Defender for Office is unavailable' {
         $check = $settings | Where-Object { $_.Setting -like 'Safe Attachments*' -and $_.CheckId -like 'DEFENDER-SAFEATTACH-001*' }
         $check | Should -Not -BeNullOrEmpty
-        $check.Status | Should -Be 'Review'
+        $check.Status | Should -Be 'NotLicensed'
     }
 
     AfterAll {


### PR DESCRIPTION
## Summary

Sprint 2 PR 2c — the collector migration that fully closes **B3 #774** and provides the reference example for future status-taxonomy migrations.

Migrates 5 Defender check paths from `Status='Review'` to `'NotLicensed'` where the existing `CurrentValue`/`RecommendedValue` already explicitly indicates a license deficiency. No logic changes — this is a relabel that lets the renderer (chip styles, future denominator math via #802) treat these correctly.

Closes **B3 #774**. Sprint 2 milestone work that remains: **#802** denominator audit (score-impacting; separate review pass).

## Migrations

| Check | Path | Old | New | Trigger |
|---|---|---|---|---|
| `DEFENDER-ZAP-001` | `DefenderPresetZapChecks.ps1:116` | Review | NotLicensed | `ZapEnabled` property is null (DfO P2 missing) |
| `DEFENDER-ZAP-001` | `DefenderPresetZapChecks.ps1:129` | Review | NotLicensed | `Get-AtpPolicyForO365` cmdlet doesn't exist |
| `DEFENDER-SAFELINKS-001` | `DefenderSafeAttLinksChecks.ps1:113` | Review | NotLicensed | `Get-SafeLinksPolicy` unavailable |
| `DEFENDER-SAFEATTACH-001` | `DefenderSafeAttLinksChecks.ps1:226` | Review | NotLicensed | `Get-SafeAttachmentPolicy` unavailable |
| `DEFENDER-SAFEATTACH-002` | `DefenderSafeAttLinksChecks.ps1:264` | Review | NotLicensed | `Get-AtpPolicyForO365` SPO/OneDrive/Teams branch unavailable |

Each path's `CurrentValue` already says "Not licensed" or "Property not available on current license" — the user-facing message was already correct; the `Status` field just lagged.

## Out-of-scope (deliberate)

- **`DEFENDER-PRIORITY-001/002`** stay as `Review` when no preset rules are found. These could indicate either unlicensed *or* unconfigured tenants; distinguishing requires actual license probing (a separate refactor).
- **No new license-probing infrastructure.** This PR follows the doc decision tree's guidance: only emit `NotLicensed` when the data path *explicitly* signals license deficiency. Broader license-context detection co-evolves with D2 #786 license-adjusted scoring.

## Reference pattern for future collector migrations

Documented here so the next migration is mechanical:

1. Search the collector for explicit `'Not licensed'` / `'not available on current license'` `CurrentValue` strings paired with `Status='Review'`
2. Change `Status` to `'NotLicensed'` (only those exact paths)
3. Update test expectations and test names (`"Review"` → `"NotLicensed"`)
4. Update `validStatuses` arrays in test files

## Tests

- [x] `Invoke-Pester ./tests/Security/*` — 178/178 pass
- [x] `Invoke-Pester ./tests/Security/DefenderPresetZapChecks.Tests.ps1 ./tests/Security/DefenderSafeAttLinksChecks.Tests.ps1` — 23/23 pass
- [x] PSScriptAnalyzer on changed files — clean
- [x] CI matrix (PS 7.4 + 7.6) green

## Sprint 2 standings after this lands

| Issue | Status |
|---|---|
| F4 #793 (status doc) | ✅ #801 |
| B3 #774 (helper enum + collector migration) | ✅ #801 + this PR |
| B8 #779 (renderer audit) | ✅ #803 + #804 (XLSX); denominator follow-up #802 |
| #802 (denominator audit) | ⏳ Score-impacting; final Sprint 2 piece |
| C3 #782 (wrapper API ratification) | ⏳ Pending your call on PR #800's recommendation |

🤖 Generated with [Claude Code](https://claude.com/claude-code)