### PR TITLE
feat(score): apply strict Pass% denominator across renderers (closes #802)

### DIFF
--- a/src/M365-Assess/Common/Export-ComplianceMatrix.ps1
+++ b/src/M365-Assess/Common/Export-ComplianceMatrix.ps1
@@ -208,7 +208,10 @@ foreach ($fwDef in $allFrameworks) {
     $fail   = @($mapped | Where-Object { $_.Status -eq 'Fail' }).Count
     $warn   = @($mapped | Where-Object { $_.Status -eq 'Warning' }).Count
     $review = @($mapped | Where-Object { $_.Status -eq 'Review' }).Count
-    $pct    = [math]::Round(($pass / $totalMapped) * 100, 1)
+    # #802: strict denominator -- Pass / (Pass + Fail + Warning) per CHECK-STATUS-MODEL.md.
+    # Review / Skipped / Unknown / NotApplicable / NotLicensed are excluded.
+    $scoreDenom = $pass + $fail + $warn
+    $pct = if ($scoreDenom -gt 0) { [math]::Round(($pass / $scoreDenom) * 100, 1) } else { 0 }
 
     $summaryData.Add([PSCustomObject][ordered]@{
         Framework      = $colLabel
@@ -289,7 +292,9 @@ foreach ($summaryRow in $summaryData) {
         $emittedTiers = [System.Collections.Generic.HashSet[string]]::new()
         foreach ($group in $grpResult.Groups) {
             if ($group.IsGap) { continue }
-            $subRate = if ($group.Mapped -gt 0) { [math]::Round(($group.Passed / $group.Mapped) * 100, 1) } else { 0 }
+            # #802: strict denominator -- Pass / (Pass + Fail + Warning).
+            $subDenom = $group.Passed + $group.Failed + $group.Warning
+            $subRate = if ($subDenom -gt 0) { [math]::Round(($group.Passed / $subDenom) * 100, 1) } else { 0 }
             $summaryExpanded.Add([PSCustomObject][ordered]@{
                 Framework      = "    $($group.Key) — $($group.Label)"
                 'Total Mapped' = $group.Mapped
@@ -337,7 +342,9 @@ foreach ($summaryRow in $summaryData) {
         # maturity-level: CMMC is already cumulative per level, emit groups as-is
         foreach ($group in $grpResult.Groups) {
             if ($group.IsGap) { continue }
-            $subRate = if ($group.Mapped -gt 0) { [math]::Round(($group.Passed / $group.Mapped) * 100, 1) } else { 0 }
+            # #802: strict denominator -- Pass / (Pass + Fail + Warning).
+            $subDenom = $group.Passed + $group.Failed + $group.Warning
+            $subRate = if ($subDenom -gt 0) { [math]::Round(($group.Passed / $subDenom) * 100, 1) } else { 0 }
             $summaryExpanded.Add([PSCustomObject][ordered]@{
                 Framework      = "    $($group.Key) — $($group.Label)"
                 'Total Mapped' = $group.Mapped

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -329,6 +329,14 @@ const SEV_LABEL = {
 
 // --------------------- Helpers ---------------------
 const pct = (n, d) => d ? Math.round(n / d * 100) : 0;
+
+// Pass% denominator per docs/CHECK-STATUS-MODEL.md (#802):
+//   Pass% = Pass / (Pass + Fail + Warning)
+// All other statuses (Review, Info, Skipped, Unknown, NotApplicable, NotLicensed)
+// are excluded from BOTH numerator and denominator -- not-collected results
+// can never inflate or deflate the score.
+const SCORED_STATUSES = new Set(['Pass', 'Fail', 'Warning']);
+const scoreDenom = arr => (arr || []).filter(f => SCORED_STATUSES.has(f.status)).length;
 const fmt = n => Number(n).toLocaleString();
 
 // ======================== Sidebar ========================
@@ -838,7 +846,7 @@ function Posture() {
     className: "tiny-bar"
   }, /*#__PURE__*/React.createElement("span", {
     style: {
-      width: pct(fail, FINDINGS.length) + '%',
+      width: pct(fail, scoreDenom(FINDINGS)) + '%',
       background: 'var(--danger)'
     }
   }))), /*#__PURE__*/React.createElement("div", {
@@ -853,7 +861,7 @@ function Posture() {
     className: "tiny-bar"
   }, /*#__PURE__*/React.createElement("span", {
     style: {
-      width: pct(warn, FINDINGS.length) + '%',
+      width: pct(warn, scoreDenom(FINDINGS)) + '%',
       background: 'var(--warn)'
     }
   }))), /*#__PURE__*/React.createElement("div", {
@@ -868,7 +876,7 @@ function Posture() {
     className: "tiny-bar"
   }, /*#__PURE__*/React.createElement("span", {
     style: {
-      width: pct(pass, FINDINGS.length) + '%',
+      width: pct(pass, scoreDenom(FINDINGS)) + '%',
       background: 'var(--success)'
     }
   })))), /*#__PURE__*/React.createElement(MFABreakdown, null))), /*#__PURE__*/React.createElement(ExecSummaryRow, null), critical > 0 && /*#__PURE__*/React.createElement("div", {
@@ -1407,7 +1415,7 @@ function IntuneCategoryGrid() {
       pass,
       fail,
       warn,
-      score: pct(pass, fs.length)
+      score: pct(pass, scoreDenom(fs))
     };
   }).filter(Boolean);
   const seen = new Set(buckets.flatMap(b => b.fs.map(f => f.checkId)));
@@ -1421,7 +1429,7 @@ function IntuneCategoryGrid() {
       pass,
       fail: other.filter(f => f.status === 'Fail').length,
       warn: other.filter(f => f.status === 'Warning').length,
-      score: pct(pass, other.length)
+      score: pct(pass, scoreDenom(other))
     });
   }
   return /*#__PURE__*/React.createElement("div", {
@@ -1570,7 +1578,7 @@ function SharePointSummaryPanel() {
     className: "kpi-label"
   }, "Pass rate"), /*#__PURE__*/React.createElement("div", {
     className: "kpi-value"
-  }, pct(pass, spo.length), /*#__PURE__*/React.createElement("span", {
+  }, pct(pass, scoreDenom(spo)), /*#__PURE__*/React.createElement("span", {
     style: {
       fontSize: 14
     }
@@ -1580,7 +1588,7 @@ function SharePointSummaryPanel() {
     className: "tiny-bar"
   }, /*#__PURE__*/React.createElement("span", {
     style: {
-      width: pct(pass, spo.length) + '%',
+      width: pct(pass, scoreDenom(spo)) + '%',
       background: 'var(--success)'
     }
   }))), /*#__PURE__*/React.createElement("div", {
@@ -1595,7 +1603,7 @@ function SharePointSummaryPanel() {
     className: "tiny-bar"
   }, /*#__PURE__*/React.createElement("span", {
     style: {
-      width: pct(fail, spo.length) + '%',
+      width: pct(fail, scoreDenom(spo)) + '%',
       background: 'var(--danger)'
     }
   }))), sharingLevel && /*#__PURE__*/React.createElement("div", {
@@ -1741,7 +1749,7 @@ function AdHybridPanel() {
     className: "kpi-label"
   }, "AD checks"), /*#__PURE__*/React.createElement("div", {
     className: "kpi-value"
-  }, pct(pass, adFindings.length), /*#__PURE__*/React.createElement("span", {
+  }, pct(pass, scoreDenom(adFindings)), /*#__PURE__*/React.createElement("span", {
     style: {
       fontSize: 14
     }
@@ -1751,7 +1759,7 @@ function AdHybridPanel() {
     className: "tiny-bar"
   }, /*#__PURE__*/React.createElement("span", {
     style: {
-      width: pct(pass, adFindings.length) + '%',
+      width: pct(pass, scoreDenom(adFindings)) + '%',
       background: 'var(--success)'
     }
   }))), !ad.entraOnly && ad.highRiskFindings > 0 && /*#__PURE__*/React.createElement("div", {
@@ -1808,8 +1816,10 @@ function DomainRollup({
   }, DOMAIN_ORDER.map(name => {
     const d = DOMAIN_STATS[name];
     if (!d) return null;
-    const total = d.total;
-    const score = Math.round((d.pass + d.info * 0.5) / total * 100);
+    // #802: strict denominator -- removed previous (pass + info*0.5) / total
+    // weighting in favor of the doc's Pass / (Pass + Fail + Warning).
+    const denom = d.pass + d.fail + d.warn;
+    const score = denom > 0 ? Math.round(d.pass / denom * 100) : 0;
     return /*#__PURE__*/React.createElement("div", {
       key: name,
       className: "domain-card",
@@ -2106,7 +2116,8 @@ function FrameworkQuilt({
     className: "quilt"
   }, displayFws.map(f => {
     const d = byFw[f.id];
-    const score = pct(d.pass + Math.round(d.info * 0.5), d.total);
+    // #802: strict denominator -- removed (pass + info*0.5) weighting per doc rule.
+    const score = pct(d.pass, d.pass + d.fail + d.warn);
     const isExpanded = expandedFw === f.id;
     return /*#__PURE__*/React.createElement("div", {
       key: f.id,
@@ -3616,7 +3627,7 @@ function StrykerBlock() {
       fontFamily: 'var(--font-display)',
       letterSpacing: '-.02em'
     }
-  }, pct(pass, stryker.length), /*#__PURE__*/React.createElement("span", {
+  }, pct(pass, scoreDenom(stryker)), /*#__PURE__*/React.createElement("span", {
     style: {
       fontSize: 18,
       color: 'var(--muted)'

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -135,6 +135,14 @@ const SEV_LABEL = { critical:'Critical', high:'High', medium:'Medium', low:'Low'
 
 // --------------------- Helpers ---------------------
 const pct = (n,d) => d ? Math.round((n/d)*100) : 0;
+
+// Pass% denominator per docs/CHECK-STATUS-MODEL.md (#802):
+//   Pass% = Pass / (Pass + Fail + Warning)
+// All other statuses (Review, Info, Skipped, Unknown, NotApplicable, NotLicensed)
+// are excluded from BOTH numerator and denominator -- not-collected results
+// can never inflate or deflate the score.
+const SCORED_STATUSES = new Set(['Pass', 'Fail', 'Warning']);
+const scoreDenom = arr => (arr || []).filter(f => SCORED_STATUSES.has(f.status)).length;
 const fmt = n => Number(n).toLocaleString();
 
 // ======================== Sidebar ========================
@@ -457,19 +465,19 @@ function Posture() {
               <div className="kpi-label">Fails</div>
               <div className="kpi-value">{fail}</div>
               <div className="kpi-hint">of {FINDINGS.length} checks</div>
-              <div className="tiny-bar"><span style={{width: pct(fail, FINDINGS.length)+'%', background:'var(--danger)'}}/></div>
+              <div className="tiny-bar"><span style={{width: pct(fail, scoreDenom(FINDINGS))+'%', background:'var(--danger)'}}/></div>
             </div>
             <div className="kpi warn">
               <div className="kpi-label">Warnings</div>
               <div className="kpi-value">{warn}</div>
               <div className="kpi-hint">Review & harden</div>
-              <div className="tiny-bar"><span style={{width: pct(warn, FINDINGS.length)+'%', background:'var(--warn)'}}/></div>
+              <div className="tiny-bar"><span style={{width: pct(warn, scoreDenom(FINDINGS))+'%', background:'var(--warn)'}}/></div>
             </div>
             <div className="kpi good">
               <div className="kpi-label">Passing</div>
               <div className="kpi-value">{pass}</div>
               <div className="kpi-hint">Controls validated</div>
-              <div className="tiny-bar"><span style={{width: pct(pass, FINDINGS.length)+'%', background:'var(--success)'}}/></div>
+              <div className="tiny-bar"><span style={{width: pct(pass, scoreDenom(FINDINGS))+'%', background:'var(--success)'}}/></div>
             </div>
           </div>
           <MFABreakdown />
@@ -843,13 +851,13 @@ function IntuneCategoryGrid() {
     const pass = fs.filter(f => f.status==='Pass').length;
     const fail = fs.filter(f => f.status==='Fail').length;
     const warn = fs.filter(f => f.status==='Warning').length;
-    return { ...cat, fs, pass, fail, warn, score: pct(pass, fs.length) };
+    return { ...cat, fs, pass, fail, warn, score: pct(pass, scoreDenom(fs)) };
   }).filter(Boolean);
   const seen = new Set(buckets.flatMap(b => b.fs.map(f => f.checkId)));
   const other = intune.filter(f => !seen.has(f.checkId));
   if (other.length) {
     const pass = other.filter(f => f.status==='Pass').length;
-    buckets.push({ id:'OTHER', label:'Other', fs:other, pass, fail:other.filter(f=>f.status==='Fail').length, warn:other.filter(f=>f.status==='Warning').length, score:pct(pass, other.length) });
+    buckets.push({ id:'OTHER', label:'Other', fs:other, pass, fail:other.filter(f=>f.status==='Fail').length, warn:other.filter(f=>f.status==='Warning').length, score:pct(pass, scoreDenom(other)) });
   }
   return (
     <div className="intune-cat-section">
@@ -937,15 +945,15 @@ function SharePointSummaryPanel() {
       <div className="spo-summary-row">
         <div className="spo-stat-card">
           <div className="kpi-label">Pass rate</div>
-          <div className="kpi-value">{pct(pass, spo.length)}<span style={{fontSize:14}}>%</span></div>
+          <div className="kpi-value">{pct(pass, scoreDenom(spo))}<span style={{fontSize:14}}>%</span></div>
           <div className="kpi-hint">{pass} of {spo.length} checks</div>
-          <div className="tiny-bar"><span style={{width: pct(pass, spo.length)+'%', background:'var(--success)'}}/></div>
+          <div className="tiny-bar"><span style={{width: pct(pass, scoreDenom(spo))+'%', background:'var(--success)'}}/></div>
         </div>
         <div className={'spo-stat-card' + (fail>0?' spo-stat-bad':'')}>
           <div className="kpi-label">Failures</div>
           <div className="kpi-value">{fail}</div>
           <div className="kpi-hint">{warn} warnings</div>
-          <div className="tiny-bar"><span style={{width: pct(fail, spo.length)+'%', background:'var(--danger)'}}/></div>
+          <div className="tiny-bar"><span style={{width: pct(fail, scoreDenom(spo))+'%', background:'var(--danger)'}}/></div>
         </div>
         {sharingLevel && (
           <div className="spo-stat-card">
@@ -1027,9 +1035,9 @@ function AdHybridPanel() {
         {!ad.entraOnly && adFindings.length > 0 && (
           <div className={'spo-stat-card' + (fail>0?' spo-stat-bad':'')}>
             <div className="kpi-label">AD checks</div>
-            <div className="kpi-value">{pct(pass, adFindings.length)}<span style={{fontSize:14}}>%</span></div>
+            <div className="kpi-value">{pct(pass, scoreDenom(adFindings))}<span style={{fontSize:14}}>%</span></div>
             <div className="kpi-hint">{pass} pass · {fail} fail</div>
-            <div className="tiny-bar"><span style={{width: pct(pass, adFindings.length)+'%', background:'var(--success)'}}/></div>
+            <div className="tiny-bar"><span style={{width: pct(pass, scoreDenom(adFindings))+'%', background:'var(--success)'}}/></div>
           </div>
         )}
         {!ad.entraOnly && ad.highRiskFindings > 0 && (
@@ -1077,8 +1085,10 @@ function DomainRollup({ onJump }) {
             {DOMAIN_ORDER.map(name => {
               const d = DOMAIN_STATS[name];
               if (!d) return null;
-              const total = d.total;
-              const score = Math.round(((d.pass + d.info*0.5) / total) * 100);
+              // #802: strict denominator -- removed previous (pass + info*0.5) / total
+              // weighting in favor of the doc's Pass / (Pass + Fail + Warning).
+              const denom = d.pass + d.fail + d.warn;
+              const score = denom > 0 ? Math.round((d.pass / denom) * 100) : 0;
               return (
                 <div key={name} className="domain-card" onClick={()=>onJump(name)}>
                   <div className="dc-head">
@@ -1298,7 +1308,8 @@ function FrameworkQuilt({ onSelect, selected, onProfileSelect, activeProfiles })
       <div className="quilt">
         {displayFws.map(f => {
           const d = byFw[f.id];
-          const score = pct(d.pass + Math.round(d.info*0.5), d.total);
+          // #802: strict denominator -- removed (pass + info*0.5) weighting per doc rule.
+          const score = pct(d.pass, d.pass + d.fail + d.warn);
           const isExpanded = expandedFw === f.id;
           return (
             <div key={f.id} className={'quilt-cell' + (isExpanded?' expanded':'') + (selected===f.id?' selected':'')}
@@ -2263,7 +2274,7 @@ function StrykerBlock() {
         <div>
           <div style={{fontSize:12, color:'var(--muted)', textTransform:'uppercase', letterSpacing:'.1em', fontWeight:600}}>Coverage</div>
           <div style={{fontSize:34, fontWeight:700, fontFamily:'var(--font-display)', letterSpacing:'-.02em'}}>
-            {pct(pass, stryker.length)}<span style={{fontSize:18, color:'var(--muted)'}}>%</span>
+            {pct(pass, scoreDenom(stryker))}<span style={{fontSize:18, color:'var(--muted)'}}>%</span>
           </div>
         </div>
         <div style={{flex:1, minWidth:200, fontSize:13, color:'var(--text-soft)', lineHeight:1.55}}>


### PR DESCRIPTION
## Summary

Final Sprint 2 piece. Aligns every rendering surface (React app + XLSX) with the doc rule from `docs/CHECK-STATUS-MODEL.md`:

> **Pass% = Pass / (Pass + Fail + Warning)**
>
> All other statuses (Review, Info, Skipped, Unknown, NotApplicable, NotLicensed) are excluded from BOTH numerator and denominator.

Closes **#802**. After this lands, the v2.9.0 milestone has only **C3 #782** open by design (awaiting your ratification of PR #800's recommendation).

## ⚠️ This is a SCORE-IMPACTING change

Visible Pass% values shift in any tenant where Review/Info findings exist. Below is the static disclosure against the existing committed sample report (246 findings: **90 Pass, 64 Fail, 41 Warning, 42 Review, 9 Info**, 0 of the new v2.9.0 statuses):

| Surface | OLD | NEW | Delta |
|---|---|---|---|
| KPI tiles, SharePoint, AD, Stryker pass-rates | 90 / 246 = **36.6%** | 90 / 195 = **46.2%** | +9.6 pts |
| Domain card / Framework Quilt (had `info*0.5` weighting) | (90 + 9*0.5) / 246 = **38.4%** | 90 / 195 = **46.2%** | +7.7 pts |

The shift is honest — the OLD denominators rolled non-posture findings (Review, Info) into the score's denominator, dragging Pass% down for any tenant with significant manual-review or informational findings. The new denominator measures "of the things we actually scored, what % passed?"

The Domain card had a separate quirk: it weighted `Info` at half-credit (`(pass + info*0.5) / total`). The doc rule excludes Info entirely; this PR removes the half-credit weighting in favor of the doc.

## Files

### `src/M365-Assess/assets/report-app.jsx`
- New `SCORED_STATUSES = Set(['Pass','Fail','Warning'])` constant
- New `scoreDenom(arr)` helper next to `pct()` at the top of the file
- 11 call sites updated from `arr.length` / `FINDINGS.length` to `scoreDenom(arr)`:
  - KPI tile bars (Fail, Warning, Pass)
  - Section bucket score, "Other" bucket score
  - SharePoint pass rate + 2 tiny bars
  - AD pass rate + tiny bar
  - Stryker pass rate
- `DomainRollup` and Framework Quilt: removed `(pass + info*0.5) / total` in favor of `pass / (pass + fail + warn)` with zero-guard

### `src/M365-Assess/Common/Export-ComplianceMatrix.ps1`
- Per-framework `Pass Rate %`: now `$pass / ($pass + $fail + $warn)` with zero-guard (was `$pass / $totalMapped`)
- Per-group sub-row `Pass Rate %`: same fix in two locations (lines 295, 343)

### `src/M365-Assess/assets/report-app.js`
- Regenerated via `npm run build`; `node --check` clean

## Test plan

- [x] `Invoke-Pester` smoke + Build-ReportData + Export-ComplianceMatrix: **412/412 pass**
- [x] PSScriptAnalyzer on changed PS file: clean
- [x] `node --check` on regenerated JS: clean
- [x] Static disclosure computed from the committed sample report (above)
- [x] CI matrix (PS 7.4 + 7.6) green
- [x] (Optional) Browser test of regenerated report — see PR #803's swap-in instructions if you want to verify visually

## Reviewer notes

- The Domain card change is the most visible to existing report viewers. It removes a long-standing implicit policy (Info worth half a Pass) in favor of the explicit doc rule (Info excluded entirely). Worth a careful read of `docs/CHECK-STATUS-MODEL.md` before approving if Info-as-half-credit was load-bearing for any consultant workflow you've documented.
- `SCORED_STATUSES` is intentionally a `Set` rather than an array for O(1) membership checks (the helper runs over every finding on every render).
- The shift is asymmetric: tenants with many Review/Info findings see the largest jump, tenants with few see almost no change. The disclosure number above (+9.6 pts on the sample) is from a tenant with 51/246 = 20.7% Review+Info — a fairly review-heavy distribution.

## What this closes

- Closes **#802** (denominator audit)
- Closes the last Sprint 2 ticket
- v2.9.0 milestone state after merge: only **C3 #782** (wrapper API surface ratification) open

🤖 Generated with [Claude Code](https://claude.com/claude-code)