### PR TITLE
fix(report): shorter status badge labels + hide zero-count filter chips

### DIFF
--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -318,6 +318,16 @@ const STATUS_COLORS = {
   NotApplicable: 'notapplicable',
   NotLicensed: 'notlicensed'
 };
+
+// Short display label for the inline status-badge in narrow table columns.
+// The data value (status key) is unchanged; only the rendered text differs.
+// Filter chips use longer friendly labels via the statusChips array's third
+// element (see FilterBar).
+const STATUS_LABEL = {
+  NotApplicable: 'N/A',
+  NotLicensed: 'No License'
+};
+const statusLabel = s => STATUS_LABEL[s] || s;
 const SEV_LABEL = {
   critical: 'Critical',
   high: 'High',
@@ -2505,7 +2515,7 @@ function FilterBar({
     className: "filter-group"
   }, /*#__PURE__*/React.createElement("span", {
     className: "filter-group-label"
-  }, "Status"), statusChips.map(([v, cls, label]) => /*#__PURE__*/React.createElement("button", {
+  }, "Status"), statusChips.filter(([v]) => (counts.status[v] || 0) > 0 || filters.status.includes(v)).map(([v, cls, label]) => /*#__PURE__*/React.createElement("button", {
     key: v,
     className: 'chip ' + cls + (filters.status.includes(v) ? ' selected' : ''),
     onClick: () => update('status', v)
@@ -2867,7 +2877,7 @@ function FindingsTable({
           className: 'status-badge ' + STATUS_COLORS[f.status]
         }, /*#__PURE__*/React.createElement("span", {
           className: "dot"
-        }), f.status), f.intentDesign && /*#__PURE__*/React.createElement("span", {
+        }), statusLabel(f.status)), f.intentDesign && /*#__PURE__*/React.createElement("span", {
           className: "badge-intent"
         }, "By Design"));
       case 'finding':
@@ -3344,7 +3354,7 @@ function Roadmap({
       className: 'status-badge ' + STATUS_COLORS[t.status]
     }, /*#__PURE__*/React.createElement("span", {
       className: "dot"
-    }), t.status)), /*#__PURE__*/React.createElement("div", {
+    }), statusLabel(t.status))), /*#__PURE__*/React.createElement("div", {
       className: "task-id"
     }, t.checkId, " \xB7 ", t.domain), /*#__PURE__*/React.createElement("div", {
       className: "task-tags"
@@ -3689,7 +3699,7 @@ function StrykerBlock() {
     className: 'status-badge ' + STATUS_COLORS[f.status]
   }, /*#__PURE__*/React.createElement("span", {
     className: "dot"
-  }), f.status)), /*#__PURE__*/React.createElement("div", {
+  }), statusLabel(f.status))), /*#__PURE__*/React.createElement("div", {
     className: "finding-title"
   }, /*#__PURE__*/React.createElement("div", {
     className: "t"

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -131,6 +131,16 @@ const STATUS_COLORS = {
   NotApplicable: 'notapplicable',
   NotLicensed:   'notlicensed',
 };
+
+// Short display label for the inline status-badge in narrow table columns.
+// The data value (status key) is unchanged; only the rendered text differs.
+// Filter chips use longer friendly labels via the statusChips array's third
+// element (see FilterBar).
+const STATUS_LABEL = {
+  NotApplicable: 'N/A',
+  NotLicensed:   'No License',
+};
+const statusLabel = s => STATUS_LABEL[s] || s;
 const SEV_LABEL = { critical:'Critical', high:'High', medium:'Medium', low:'Low', none:'—', info:'Info' };
 
 // --------------------- Helpers ---------------------
@@ -1526,11 +1536,13 @@ function FilterBar({ filters, setFilters, counts, total, search, setSearch }) {
       <div className="fb-row fb-row-chips">
       <div className="filter-group">
         <span className="filter-group-label">Status</span>
-        {statusChips.map(([v,cls,label])=>(
-          <button key={v} className={'chip '+cls+(filters.status.includes(v)?' selected':'')} onClick={()=>update('status',v)}>
-            <span className="dot"/>{label || v}<span className="ct">{counts.status[v]||0}</span>
-          </button>
-        ))}
+        {statusChips
+          .filter(([v]) => (counts.status[v] || 0) > 0 || filters.status.includes(v))
+          .map(([v,cls,label])=>(
+            <button key={v} className={'chip '+cls+(filters.status.includes(v)?' selected':'')} onClick={()=>update('status',v)}>
+              <span className="dot"/>{label || v}<span className="ct">{counts.status[v]||0}</span>
+            </button>
+          ))}
       </div>
       <div className="filter-divider"/>
       <div className="filter-group">
@@ -1785,7 +1797,7 @@ function FindingsTable({ filters, search, focusFinding, onFocusClear, onMatchesC
       case 'status': return (
         <div key="status" style={{display:'flex',flexDirection:'column',gap:3}}>
           <span className={'status-badge ' + STATUS_COLORS[f.status]}>
-            <span className="dot"/>{f.status}
+            <span className="dot"/>{statusLabel(f.status)}
           </span>
           {f.intentDesign && <span className="badge-intent">By Design</span>}
         </div>
@@ -2120,7 +2132,7 @@ function Roadmap({ onViewFinding, editMode, hiddenFindings, roadmapOverrides, on
         <button className="task-head-btn" onClick={()=>setOpen(isOpen?null:key)} aria-expanded={isOpen}>
           <div className="task-head">
             <span>{t.setting}{isCustom && <span className="task-custom-badge">custom</span>}</span>
-            <span className={'status-badge ' + STATUS_COLORS[t.status]}><span className="dot"/>{t.status}</span>
+            <span className={'status-badge ' + STATUS_COLORS[t.status]}><span className="dot"/>{statusLabel(t.status)}</span>
           </div>
           <div className="task-id">{t.checkId} · {t.domain}</div>
           <div className="task-tags">
@@ -2292,7 +2304,7 @@ function StrykerBlock() {
         </div>
         {stryker.map((f,i) => (
           <div key={i} className="finding-row" style={{cursor:'default'}}>
-            <div><span className={'status-badge '+STATUS_COLORS[f.status]}><span className="dot"/>{f.status}</span></div>
+            <div><span className={'status-badge '+STATUS_COLORS[f.status]}><span className="dot"/>{statusLabel(f.status)}</span></div>
             <div className="finding-title"><div className="t">{f.setting}</div><div className="sub">{f.section}</div></div>
             <div className="check-id">{f.checkId}</div>
             <div><span className={'sev-badge '+f.severity}><span className="bar"><i/><i/><i/><i/></span><span>{SEV_LABEL[f.severity]}</span></span></div>


### PR DESCRIPTION
## Summary

Two small UI hygiene fixes for the new v2.9.0 statuses, both reported visually after #803/#806 shipped.

## Fix 1 — badge overflow

**Problem:** The inline status badge in the findings table is uppercased + `0.06em` letter-spaced. `NOTLICENSED` (11 chars) overflowed the STATUS column into the Finding column. `NOTAPPLICABLE` (13 chars) would too.

**Fix:** New `STATUS_LABEL` map provides short display labels for the badge:
- `NotApplicable` → `N/A`
- `NotLicensed` → `No License`

Data values (status keys) are unchanged; filter logic still keys off the full identifier. Filter chips keep their friendly long labels (`Not Applicable`, `Not Licensed`) because they have horizontal room.

Three inline `status-badge` sites updated to call `statusLabel(s)`.

## Fix 2 — filter chip clutter

**Problem:** All 9 status chips rendered in the FilterBar even when several have zero findings. From the screenshot: `Skipped 0`, `Unknown 0`, `Not Applicable 0` were taking up bar real estate with no functional purpose.

**Fix:** `FilterBar.statusChips` render now hides chips with zero count, **except** when the chip is currently selected. The defensive carve-out means if you've narrowed your filters to a state where the result set is empty for a status you've selected, the active chip stays visible so you can deselect it.

## Test plan

- [x] `npm run build` — succeeds, JS regenerated
- [x] `node --check` on compiled JS — clean
- [x] `Invoke-Pester ./tests/Smoke` — 329/329 pass
- [ ] Visual: badge no longer overflows STATUS column for `NotLicensed` / `NotApplicable`
- [ ] Visual: zero-count chips no longer appear in FilterBar
- [ ] Visual: selecting a chip then filtering down to 0 keeps the chip visible (so you can deselect)

## Notes

- The choice of "No License" over "Unlicensed" is semantic: "Unlicensed" implies illegitimate use; "No License" accurately describes a tenant that lacks the *required* license tier.
- This is a fix-only PR — no test additions because the existing smoke + build-data tests cover the behavior, and the UI behavior is best verified visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)