### PR TITLE
feat(setup): isolate Grant-M365AssessConsent with high-impact ShouldProcess (closes #791)

### DIFF
--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -4,6 +4,28 @@ M365 Assess supports multiple authentication methods for connecting to Microsoft
 
 > **Recommended for unattended assessments:** certificate-based authentication. Client secret authentication is supported only where the underlying Microsoft module supports it (Microsoft Graph, Power BI). Exchange Online and Purview reject client-secret auth by design — use `-CertificateThumbprint` for non-interactive runs against those services.
 
+## Cmdlet categories — read before connecting
+
+M365 Assess exports two distinct kinds of cmdlets. **They behave fundamentally differently against your tenant** — read this section before choosing what to run.
+
+### Assessment cmdlets — read-only
+
+These cmdlets only call `Get-*` Graph endpoints and read-only EXO/Purview operations. They never mutate tenant configuration, never create or modify objects, never grant permissions. CI gates this guarantee per `scripts/Test-CollectorReadOnly.ps1`.
+
+- `Invoke-M365Assessment` — main entry point; runs collectors, generates reports
+- `Compare-M365Baseline` — drift comparison against a saved baseline
+- `Get-M365CASecurityConfig`, `Get-M365EntraSecurityConfig`, `Get-M365ExoSecurityConfig`, …  — individual collector wrappers
+- `Get-M365ConnectionProfile` — read a saved connection profile
+
+### Setup cmdlets — tenant-mutating
+
+These cmdlets modify your tenant or local configuration. They use `[CmdletBinding(SupportsShouldProcess, ConfirmImpact='High')]` and prompt for confirmation by default. Pass `-Force` to bypass the prompt in scripted scenarios where confirmation is consented out of band.
+
+- `Grant-M365AssessConsent` — creates app registration, assigns API permissions, grants admin consent, adds directory-role and Exchange-RBAC group memberships. **Run once per tenant by a Global / Application Administrator.** All subsequent assessment runs use the resulting service principal in read-only mode.
+- `New-M365ConnectionProfile`, `Set-M365ConnectionProfile`, `Remove-M365ConnectionProfile` — manage local connection profiles (writes / mutates `.m365assess.json` in user app-data, no tenant changes)
+
+The two categories are visibly separated in the manifest's `FunctionsToExport` and discoverable via `Get-Command -Module M365-Assess`. If you're ever unsure: assessment cmdlets start with `Invoke-`, `Compare-`, or `Get-`; setup cmdlets start with `Grant-`, `New-`, `Set-`, or `Remove-`.
+
 ## Interactive (Default)
 
 A browser window opens for each service (Graph, Exchange Online, etc.). Best for one-time or ad-hoc assessments.

--- a/src/M365-Assess/Setup/Grant-M365AssessConsent.ps1
+++ b/src/M365-Assess/Setup/Grant-M365AssessConsent.ps1
@@ -4,9 +4,18 @@
 function Grant-M365AssessConsent {
     <#
     .SYNOPSIS
-        Creates and configures an Entra ID app registration with all permissions
-        required by M365-Assess.
+        SETUP CMDLET (tenant-mutating). Creates and configures an Entra ID app
+        registration with all permissions required by M365-Assess.
     .DESCRIPTION
+        WARNING -- This is a SETUP cmdlet, not an assessment cmdlet. Unlike
+        Invoke-M365Assessment (and the Get-M365* read-only collectors), this
+        function MUTATES tenant configuration: it creates app registrations,
+        assigns API permissions, grants admin consent, and adds directory-role
+        / Exchange-RBAC group memberships. ConfirmImpact is High; the cmdlet
+        prompts for confirmation by default. Use -Force to bypass the prompt
+        in scripted scenarios where confirmation is provably consented out of
+        band.
+
         Provisions a read-only service principal for Invoke-M365Assessment with:
         - 24 Microsoft Graph API application permissions (all .Read.All)
         - 3 Office 365 Exchange Online API permissions (ManageAsApp, Organization.Read.All, MailboxSettings.Read)
@@ -74,6 +83,11 @@ function Grant-M365AssessConsent {
         Skip the Exchange Online role group assignment step.
     .PARAMETER SkipComplianceRoles
         Skip the Purview/Compliance Entra directory role assignment step.
+    .PARAMETER Force
+        Bypass the high-impact ShouldProcess confirmation prompt. Without -Force,
+        the cmdlet prompts before any tenant-mutating action (ConfirmImpact='High').
+        Use only in scripted scenarios where confirmation is consented out of band
+        (CI/CD, deployment scripts that gate on operator approval upstream).
     .EXAMPLE
         Grant-M365AssessConsent -TenantId 'contoso.onmicrosoft.com' -AdminUpn 'admin@contoso.onmicrosoft.com' -CreateNew
 
@@ -95,7 +109,7 @@ function Grant-M365AssessConsent {
             Install-Module Microsoft.Graph.Identity.Governance -Scope CurrentUser
             Install-Module ExchangeOnlineManagement          -Scope CurrentUser
     #>
-    [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'CreateNew')]
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High', DefaultParameterSetName = 'CreateNew')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'CreateNew',
         Justification = 'Used implicitly via ParameterSetName')]
     [OutputType([PSCustomObject])]
@@ -132,11 +146,31 @@ function Grant-M365AssessConsent {
         [switch]$SkipComplianceRoles,
 
         [Parameter()]
+        [switch]$Force,
+
+        [Parameter()]
         [string]$ProfileName
     )
 
     $ErrorActionPreference = 'Stop'
     Set-StrictMode -Version Latest
+
+    # E2 #791: high-impact ShouldProcess gate. The cmdlet mutates tenant config
+    # (app registration, API permissions, admin consent, role memberships).
+    # ConfirmImpact='High' triggers a confirmation prompt at default
+    # $ConfirmPreference; -Force bypasses for scripted use.
+    if (-not $Force) {
+        $shouldProcessTarget = "tenant '$TenantId'"
+        $shouldProcessAction = if ($PSCmdlet.ParameterSetName -eq 'CreateNew') {
+            "Create app registration '$AppDisplayName' and grant M365-Assess permissions"
+        } else {
+            "Configure existing app registration (ClientId '$ClientId') with M365-Assess permissions"
+        }
+        if (-not $PSCmdlet.ShouldProcess($shouldProcessTarget, $shouldProcessAction)) {
+            Write-Host "  Cancelled by user. No tenant changes were made." -ForegroundColor Yellow
+            return
+        }
+    }
 
     # ==================================================================
     # INTERNAL HELPERS (private to function scope)

--- a/tests/Setup/Grant-M365AssessConsent.Tests.ps1
+++ b/tests/Setup/Grant-M365AssessConsent.Tests.ps1
@@ -78,6 +78,45 @@ Describe 'Grant-M365AssessConsent' {
         $param = $cmd.Parameters['ProfileName']
         $param | Should -Not -BeNullOrEmpty
     }
+
+    Context 'high-impact ShouldProcess gate (E2 #791)' {
+        It 'should declare SupportsShouldProcess on CmdletBinding' {
+            $cmd = Get-Command -Name 'Grant-M365AssessConsent'
+            $cmd.CmdletBinding | Should -BeTrue
+            # SupportsShouldProcess surfaces a -WhatIf and -Confirm parameter
+            $cmd.Parameters.ContainsKey('WhatIf')  | Should -BeTrue
+            $cmd.Parameters.ContainsKey('Confirm') | Should -BeTrue
+        }
+
+        It 'should declare ConfirmImpact = High on CmdletBinding' {
+            $cmd = Get-Command -Name 'Grant-M365AssessConsent'
+            $attr = $cmd.ScriptBlock.Ast.Body.ParamBlock.Attributes |
+                Where-Object { $_.TypeName.Name -eq 'CmdletBinding' }
+            $attr | Should -Not -BeNullOrEmpty
+            $confirmImpact = $attr.NamedArguments | Where-Object { $_.ArgumentName -eq 'ConfirmImpact' }
+            $confirmImpact | Should -Not -BeNullOrEmpty
+            $confirmImpact.Argument.Value | Should -Be 'High'
+        }
+
+        It 'should expose a -Force switch to bypass the confirmation prompt' {
+            $cmd = Get-Command -Name 'Grant-M365AssessConsent'
+            $param = $cmd.Parameters['Force']
+            $param | Should -Not -BeNullOrEmpty
+            $param.SwitchParameter | Should -BeTrue
+        }
+
+        It 'should not run any Graph mutation when -WhatIf is supplied' {
+            # Track whether mutations were attempted; mocks would normally hit these
+            $script:mutationAttempts = 0
+            Mock New-MgApplication { $script:mutationAttempts++; [PSCustomObject]@{ AppId = 'x'; Id = 'y' } }
+            Mock New-MgServicePrincipal { $script:mutationAttempts++; [PSCustomObject]@{ Id = 'sp' } }
+
+            { Grant-M365AssessConsent -TenantId 'contoso.onmicrosoft.com' -CreateNew -AdminUpn 'admin@contoso.onmicrosoft.com' -WhatIf -ErrorAction Stop } |
+                Should -Not -Throw
+
+            $script:mutationAttempts | Should -Be 0
+        }
+    }
 }
 
 Describe 'PermissionDefinitions.ps1 - Data Tables' {


### PR DESCRIPTION
## Summary

Sprint 3 PR 3a — separates the one tenant-mutating cmdlet in the public surface from the read-only assessment cmdlets, both **visually** (AUTHENTICATION docs) and **behaviorally** (high-impact confirmation prompt by default).

Closes E2 **#791**.

## Cmdlet changes

`src/M365-Assess/Setup/Grant-M365AssessConsent.ps1`

- **`CmdletBinding`** now declares `ConfirmImpact='High'` alongside the existing `SupportsShouldProcess`. With PowerShell's default `$ConfirmPreference='High'`, the cmdlet prompts for confirmation by default.
- **New `[switch]$Force`** parameter bypasses the confirmation gate for scripted scenarios (CI/CD, deployment scripts where consent is upstream).
- **Early ShouldProcess gate** at the top of the function body. When `-WhatIf` is supplied, no Graph/EXO mutations are attempted — the cmdlet prints `What if:` and exits cleanly.
- **Help block** opens with an explicit `WARNING -- This is a SETUP cmdlet` block so the tenant-mutating nature is obvious from `Get-Help`.

## Documentation

`AUTHENTICATION.md`

- **New "Cmdlet categories" section** near the top splits the public surface into:
  - **Assessment cmdlets (read-only)** — `Invoke-`, `Compare-`, `Get-*`
  - **Setup cmdlets (tenant-mutating)** — `Grant-`, `New-`, `Set-`, `Remove-*`
- The split gives users a one-glance answer to "is this safe to run?" before they even open the cmdlet's help.

AUTHENTICATION.md is already cross-linked from README:191 + README:403 so no README change needed.

## Tests

`tests/Setup/Grant-M365AssessConsent.Tests.ps1`

New `Context 'high-impact ShouldProcess gate (E2 #791)'` with 4 tests:
- declares `SupportsShouldProcess` (`-WhatIf` and `-Confirm` parameters exist)
- declares `ConfirmImpact='High'` on the binding (verified via AST inspection)
- exposes a `-Force` switch (parameter type `SwitchParameter`)
- `-WhatIf` triggers no Graph mutation attempts (asserted via `Mock` counters)

**Result:** 13/13 tests pass. PSScriptAnalyzer clean.

## Test plan

- [x] `Invoke-Pester ./tests/Setup/Grant-M365AssessConsent.Tests.ps1` — 13/13 pass
- [x] PSScriptAnalyzer on changed file — clean
- [ ] CI matrix (PS 7.4 + 7.6) green
- [ ] (Manual, if you want) `Grant-M365AssessConsent -TenantId ... -CreateNew -AdminUpn ...` confirms a prompt appears; passing `-Confirm:$false` or `-Force` skips it

## Sprint 3 plan

| PR | Issue | Status |
|---|---|---|
| 3a (this PR) | E2 #791 | Open |
| 3b | B7 #778 — generated permissions matrix | Next |
| 3c | B2 #773 — app-only Graph permission validation | After 3b |

🤖 Generated with [Claude Code](https://claude.com/claude-code)