### PR TITLE
feat(auth): app-only Graph permission validation (#773 partial; #812 followup)

### DIFF
--- a/src/M365-Assess/Orchestrator/Test-GraphPermissions.ps1
+++ b/src/M365-Assess/Orchestrator/Test-GraphPermissions.ps1
@@ -1,11 +1,161 @@
 <#
 .SYNOPSIS
-    Validates Graph API scopes after connection against required scopes.
+    Validates Graph API permissions after connection against required permissions.
 .DESCRIPTION
-    Compares granted scopes from Get-MgContext against the scopes
-    required by selected assessment sections. Warns about missing
-    scopes before collectors run.
+    For delegated auth, compares granted scopes from Get-MgContext against the
+    scopes required by selected assessment sections (sectionScopeMap).
+
+    For app-only auth (B2 #773), queries the running app's service principal
+    appRoleAssignments and compares against the per-section app permissions
+    declared in Setup/PermissionDefinitions.ps1. Both paths emit per-section
+    deficit warnings before collectors run, so users know which sections may
+    produce incomplete results.
 #>
+
+# B2 #773: dot-source PermissionDefinitions for the per-section app-role map.
+# Same source of truth as Grant-M365AssessConsent and the generated
+# docs/PERMISSIONS.md (B7 #778). Idempotent re-source on each load.
+. (Join-Path -Path $PSScriptRoot -ChildPath '..\Setup\PermissionDefinitions.ps1')
+
+function Test-GraphAppRolePermissions {
+    <#
+    .SYNOPSIS
+        Validates app-only Graph permissions by querying the running SP's
+        app-role assignments and comparing against per-section requirements.
+    .DESCRIPTION
+        Used by Test-GraphPermissions when app-only auth is detected. Reads
+        $script:RequiredGraphPermissions from PermissionDefinitions.ps1
+        (which has Sections annotations on every permission) and inverts to
+        a per-section view; queries the SP's appRoleAssignments via Graph;
+        resolves role IDs to permission names through the Microsoft Graph
+        SP's appRoles collection; reports missing roles per active section.
+
+        Failures to query (e.g., the app lacks Application.Read.All to
+        introspect itself) produce an explicit "could not verify" warning,
+        not silence. AC for B2 #773.
+    .PARAMETER Context
+        The Get-MgContext output for the current Graph connection.
+    .PARAMETER ActiveSections
+        Section names the user selected for this run.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [object]$Context,
+
+        [Parameter(Mandatory)]
+        [string[]]$ActiveSections
+    )
+
+    $clientId = $Context.ClientId
+    if (-not $clientId) {
+        Write-Host '    i App-only auth detected but no ClientId in context -- cannot validate app roles.' -ForegroundColor Yellow
+        Write-AssessmentLog -Level WARN -Message 'App-role validation skipped: ClientId missing from Graph context' -Section 'Setup'
+        return
+    }
+
+    # Build per-section app-role requirements from the shared definitions.
+    $perSection = @{}
+    foreach ($entry in $script:RequiredGraphPermissions) {
+        $sections = $entry.Sections -split ',' | ForEach-Object { $_.Trim() }
+        foreach ($s in $sections) {
+            if (-not $perSection.ContainsKey($s)) {
+                $perSection[$s] = [System.Collections.Generic.List[string]]::new()
+            }
+            $perSection[$s].Add($entry.Name)
+        }
+    }
+
+    # Required permissions for the selected sections (deduplicated, case-insensitive).
+    $requiredRoles = New-Object -TypeName System.Collections.Generic.HashSet[string] -ArgumentList @([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($s in $ActiveSections) {
+        if ($perSection.ContainsKey($s)) {
+            foreach ($p in $perSection[$s]) { [void]$requiredRoles.Add($p) }
+        }
+    }
+
+    if ($requiredRoles.Count -eq 0) {
+        Write-Host '    i App-only auth: no Graph app roles required for the selected sections.' -ForegroundColor DarkGray
+        return
+    }
+
+    # Query the running SP's app-role assignments and resolve role IDs through
+    # the Microsoft Graph SP's appRoles collection. Wrapped in try/catch so
+    # the structured "could not verify" warning fires on any failure.
+    try {
+        $sp = Get-MgServicePrincipal -Filter "appId eq '$clientId'" -Top 1 -ErrorAction Stop
+        if (-not $sp) {
+            Write-Host "    ! App-only auth: could not locate service principal for ClientId '$clientId'." -ForegroundColor Yellow
+            Write-AssessmentLog -Level WARN -Message 'App-role validation skipped: SP lookup returned no results' -Section 'Setup'
+            return
+        }
+
+        $assignments = @(Get-MgServicePrincipalAppRoleAssignment -ServicePrincipalId $sp.Id -All -ErrorAction Stop)
+
+        $graphSp = Get-MgServicePrincipal -Filter "appId eq '00000003-0000-0000-c000-000000000000'" -Top 1 -ErrorAction Stop
+        if (-not $graphSp) {
+            Write-Host '    ! App-only auth: Microsoft Graph SP not resolvable -- cannot map role IDs to names.' -ForegroundColor Yellow
+            Write-AssessmentLog -Level WARN -Message 'App-role validation skipped: Microsoft Graph SP not found' -Section 'Setup'
+            return
+        }
+
+        $roleById = @{}
+        foreach ($r in $graphSp.AppRoles) {
+            $roleById[[string]$r.Id] = $r.Value
+        }
+
+        $grantedRoles = New-Object -TypeName System.Collections.Generic.HashSet[string] -ArgumentList @([System.StringComparer]::OrdinalIgnoreCase)
+        foreach ($a in $assignments) {
+            if ($a.ResourceId -eq $graphSp.Id) {
+                $name = $roleById[[string]$a.AppRoleId]
+                if ($name) { [void]$grantedRoles.Add($name) }
+            }
+        }
+
+        $missing = @($requiredRoles | Where-Object { -not $grantedRoles.Contains($_) })
+
+        if ($missing.Count -eq 0) {
+            Write-Host "    $([char]0x2714) All $($requiredRoles.Count) required Graph app role(s) granted" -ForegroundColor Green
+            Write-AssessmentLog -Level INFO -Message "Graph app-role validation passed ($($requiredRoles.Count) roles)" -Section 'Setup'
+            return
+        }
+
+        # Map missing roles back to affected sections.
+        $affectedSections = @{}
+        foreach ($role in $missing) {
+            foreach ($s in $ActiveSections) {
+                if (-not $perSection.ContainsKey($s)) { continue }
+                if ($perSection[$s] | Where-Object { $_ -ieq $role }) {
+                    if (-not $affectedSections.ContainsKey($s)) {
+                        $affectedSections[$s] = [System.Collections.Generic.List[string]]::new()
+                    }
+                    $affectedSections[$s].Add($role)
+                }
+            }
+        }
+
+        Write-Host ''
+        Write-Host "    $([char]0x26A0) $($missing.Count) Graph app role(s) not granted -- some checks may fail:" -ForegroundColor Yellow
+        foreach ($s in $affectedSections.Keys | Sort-Object) {
+            $list = ($affectedSections[$s] | Sort-Object) -join ', '
+            Write-Host "      ${s}: $list" -ForegroundColor Yellow
+        }
+        Write-Host '    To fix: Entra ID > App registrations > [your app] > API permissions >' -ForegroundColor DarkGray
+        Write-Host '      Add a permission > Microsoft Graph > Application permissions' -ForegroundColor DarkGray
+        Write-Host "    Then click 'Grant admin consent for [tenant]' and re-run." -ForegroundColor DarkGray
+        Write-Host ''
+
+        Write-AssessmentLog -Level WARN -Message "Missing Graph app roles: $($missing -join ', ')" -Section 'Setup'
+    }
+    catch {
+        # Structured "could not verify" warning per the AC -- never silent.
+        Write-Host "    ! App-only auth: could not validate app roles -- $($_.Exception.Message)" -ForegroundColor Yellow
+        Write-Host '    This usually means the app lacks Application.Read.All or Directory.Read.All' -ForegroundColor DarkGray
+        Write-Host '    (needed to read its own service principal). Add either permission and re-run.' -ForegroundColor DarkGray
+        Write-AssessmentLog -Level WARN -Message "App-role validation could not be performed: $($_.Exception.Message)" -Section 'Setup'
+    }
+}
+
 function Test-GraphPermissions {
     <#
     .SYNOPSIS
@@ -47,10 +197,11 @@ function Test-GraphPermissions {
 
     $grantedScopes = @($context.Scopes)
 
-    # App-only auth: scopes may be empty or contain only '.default'
+    # App-only auth: delegated scopes are empty / '.default' (B2 #773).
+    # Hand off to the app-role validator instead of skipping silently.
     if ($grantedScopes.Count -eq 0 -or ($grantedScopes.Count -eq 1 -and $grantedScopes[0] -eq '.default')) {
-        Write-Host '    i App-only auth detected -- scope validation not available (permissions set in app registration)' -ForegroundColor DarkGray
-        Write-AssessmentLog -Level INFO -Message 'App-only auth: scope validation skipped (permissions defined in Entra app registration)' -Section 'Setup'
+        Write-Host '    i App-only auth detected -- validating Graph app role assignments instead of delegated scopes...' -ForegroundColor DarkGray
+        Test-GraphAppRolePermissions -Context $context -ActiveSections $ActiveSections
         return
     }
 

--- a/tests/Orchestrator/Test-GraphPermissions.Tests.ps1
+++ b/tests/Orchestrator/Test-GraphPermissions.Tests.ps1
@@ -113,16 +113,20 @@ Describe 'Test-GraphPermissions' {
         }
     }
 
-    Context 'when app-only auth context returns .default scope' {
+    Context 'when app-only auth context returns .default scope (B2 #773)' {
         BeforeEach {
             Mock Get-MgContext {
                 return [PSCustomObject]@{
-                    Scopes = @('.default')
+                    Scopes   = @('.default')
+                    ClientId = 'fake-client-id'
                 }
             }
         }
 
-        It 'should skip validation and not throw' {
+        It 'should hand off to app-role validation and not throw' {
+            # With no Get-MgServicePrincipal mock, the validator catches the
+            # command-not-found and emits the structured "could not verify"
+            # warning per the AC.
             {
                 Test-GraphPermissions `
                     -RequiredScopes @('User.Read.All') `
@@ -131,13 +135,85 @@ Describe 'Test-GraphPermissions' {
             } | Should -Not -Throw
         }
 
-        It 'should log INFO about app-only auth' {
+        It 'should emit a structured WARN when the validator cannot verify (no app-role data)' {
+            # AC: "If full validation can't be done, emit a structured warning, not silence"
             Test-GraphPermissions `
                 -RequiredScopes @('User.Read.All') `
                 -SectionScopeMap @{ Identity = @('User.Read.All') } `
                 -ActiveSections @('Identity')
-            $infoLog = $global:AssessmentLogCalls | Where-Object { $_.Level -eq 'INFO' -and $_.Message -match 'app-only' }
+            $warnLog = $global:AssessmentLogCalls | Where-Object { $_.Level -eq 'WARN' -and $_.Message -match 'could not be performed|not found|not in context' }
+            $warnLog | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Test-GraphAppRolePermissions -- happy path' {
+        BeforeAll {
+            $graphAppRoles = @(
+                [pscustomobject]@{ Id = [guid]'11111111-1111-1111-1111-111111111111'; Value = 'User.Read.All' }
+                [pscustomobject]@{ Id = [guid]'22222222-2222-2222-2222-222222222222'; Value = 'AuditLog.Read.All' }
+                [pscustomobject]@{ Id = [guid]'33333333-3333-3333-3333-333333333333'; Value = 'Organization.Read.All' }
+            )
+            $script:appRoles = $graphAppRoles
+        }
+
+        BeforeEach {
+            Mock Get-MgServicePrincipal {
+                # First call: lookup of the running app's SP
+                # Second call: lookup of Microsoft Graph SP
+                if ($Filter -match "appId eq '00000003-0000-0000-c000-000000000000'") {
+                    return [pscustomobject]@{ Id = 'graph-sp-id'; AppRoles = $script:appRoles }
+                }
+                return [pscustomobject]@{ Id = 'running-sp-id' }
+            }
+            Mock Get-MgServicePrincipalAppRoleAssignment {
+                return @(
+                    [pscustomobject]@{ ResourceId = 'graph-sp-id'; AppRoleId = $script:appRoles[0].Id }
+                    [pscustomobject]@{ ResourceId = 'graph-sp-id'; AppRoleId = $script:appRoles[1].Id }
+                    [pscustomobject]@{ ResourceId = 'graph-sp-id'; AppRoleId = $script:appRoles[2].Id }
+                )
+            }
+        }
+
+        It 'should log INFO when all required roles are granted' {
+            # 'Licensing' section only requires Organization.Read.All + User.Read.All,
+            # both of which our mock grants. (Tenant requires more roles than our
+            # minimal fixture covers, so we use Licensing here.)
+            $context = [pscustomobject]@{ ClientId = 'fake-client'; Scopes = @('.default') }
+            Test-GraphAppRolePermissions -Context $context -ActiveSections @('Licensing')
+            $infoLog = $global:AssessmentLogCalls | Where-Object { $_.Level -eq 'INFO' -and $_.Message -match 'app-role validation passed' }
             $infoLog | Should -Not -BeNullOrEmpty
+        }
+
+        It 'should log WARN when a required role is missing' {
+            # Mock the assignment list to omit one of the granted roles
+            Mock Get-MgServicePrincipalAppRoleAssignment {
+                return @(
+                    [pscustomobject]@{ ResourceId = 'graph-sp-id'; AppRoleId = $script:appRoles[0].Id }
+                    # AuditLog.Read.All NOT granted
+                )
+            }
+            $context = [pscustomobject]@{ ClientId = 'fake-client'; Scopes = @('.default') }
+            Test-GraphAppRolePermissions -Context $context -ActiveSections @('Identity')
+            $warnLog = $global:AssessmentLogCalls | Where-Object { $_.Level -eq 'WARN' -and $_.Message -match 'Missing Graph app roles' }
+            $warnLog | Should -Not -BeNullOrEmpty
+            $warnLog.Message | Should -Match 'AuditLog.Read.All'
+        }
+    }
+
+    Context 'Test-GraphAppRolePermissions -- failure paths' {
+        It 'should emit a WARN when ClientId is missing from context' {
+            $context = [pscustomobject]@{ Scopes = @('.default') }  # no ClientId
+            Test-GraphAppRolePermissions -Context $context -ActiveSections @('Identity')
+            $warnLog = $global:AssessmentLogCalls | Where-Object { $_.Level -eq 'WARN' -and $_.Message -match 'ClientId missing' }
+            $warnLog | Should -Not -BeNullOrEmpty
+        }
+
+        It 'should emit a structured WARN when SP lookup throws' {
+            Mock Get-MgServicePrincipal { throw 'Insufficient permissions to read service principal' }
+            $context = [pscustomobject]@{ ClientId = 'fake-client'; Scopes = @('.default') }
+            Test-GraphAppRolePermissions -Context $context -ActiveSections @('Identity')
+            $warnLog = $global:AssessmentLogCalls | Where-Object { $_.Level -eq 'WARN' -and $_.Message -match 'could not be performed' }
+            $warnLog | Should -Not -BeNullOrEmpty
         }
     }
 


### PR DESCRIPTION
## Summary

Sprint 3 PR 3c. Closes the long-standing skip-on-app-only gap in `Test-GraphPermissions`: when app-only auth is detected, instead of writing "scope validation skipped" and moving on, the orchestrator now queries the running app's service principal, resolves its `appRoleAssignments` through the Microsoft Graph SP's `appRoles`, and reports per-section deficits before any collector runs.

Closes B2 #773 (the AC's console + log surface). The remaining ACs (summary CSV + HTML Permissions panel) are filed as **#812** for a follow-up PR — see "Out of scope" below.

## What ships

### `src/M365-Assess/Orchestrator/Test-GraphPermissions.ps1`

- New function **`Test-GraphAppRolePermissions`**:
  - Reads `$script:RequiredGraphPermissions` from `PermissionDefinitions.ps1` — **same source of truth** as `Grant-M365AssessConsent` and the generated `docs/PERMISSIONS.md` from B7 #778
  - Inverts the `Sections` annotations into per-section app-role requirements
  - Queries the SP's `appRoleAssignments` via `Get-MgServicePrincipalAppRoleAssignment`
  - Resolves role IDs through the Microsoft Graph SP's `appRoles` array (fixed appId `00000003-0000-0000-c000-000000000000`)
  - Emits per-section deficits in console + `Write-AssessmentLog WARN`
  - Structured "could not verify" warning (never silent) when the query fails — e.g., when the app lacks `Application.Read.All` to introspect itself
- `Test-GraphPermissions` itself: replaced the early-return for app-only auth with a hand-off to `Test-GraphAppRolePermissions`

### `tests/Orchestrator/Test-GraphPermissions.Tests.ps1`

- Updated existing app-only-default test to expect the new hand-off behavior (`Should -Not -Throw` + structured `WARN` when no SP mock present)
- New `Context 'Test-GraphAppRolePermissions -- happy path'`:
  - all-required-roles-granted → INFO log
  - one-required-role-missing → WARN with the missing role name
- New `Context 'Test-GraphAppRolePermissions -- failure paths'`:
  - missing `ClientId` in context → "ClientId missing" WARN
  - SP lookup throws → "could not be performed" WARN

**Result:** 15/15 tests pass (was 11). Smoke + Orchestrator suites: 477/477.

## Out of scope (#812)

- **Summary CSV / JSON** of the deficit map — write to `<OutputFolder>/_PermissionDeficits.csv` or extend `_Assessment-<Tenant>.json`
- **HTML report Permissions panel** — render the deficit map in the report so it lands in the deliverable for clients/auditors

The console + log surface is the high-value path: an unattended consultant run sees the deficit at connect time, before any data collection. The report-side renderer is meaningful but more involved (touches `Build-ReportData`, React app, CSS) and deserves its own PR. Tracked as #812.

## Test plan

- [x] `Invoke-Pester ./tests/Orchestrator/Test-GraphPermissions.Tests.ps1` — 15/15 pass
- [x] `Invoke-Pester ./tests/Smoke ./tests/Orchestrator` — 477/477 pass
- [x] PSScriptAnalyzer on changed file — clean
- [x] CI matrix (PS 7.4 + 7.6) green
- [ ] (Manual, when convenient) Live test against a tenant with a deliberately under-scoped app — expect to see the per-section deficit at connect time

## Reviewer notes

- The catch block fires the **structured "could not verify" warning** rather than silently moving on — that's the AC's explicit ask. If the app can't read its own SP (lacks `Application.Read.All`), the user sees a yellow `!` line in the console and a `WARN` log entry.
- The `BeforeEach` for the happy-path tests defines a Graph SP mock with 3 deterministic role IDs (`User.Read.All`, `AuditLog.Read.All`, `Organization.Read.All`); the failure-path tests just throw from the SP lookup mock.
- The "all required roles granted" test deliberately uses `ActiveSections = @('Licensing')` because Licensing only requires `Organization.Read.All` + `User.Read.All` — the minimal mock fixture covers it. Larger sections (e.g., Tenant, Identity) require more roles than the fixture grants on purpose, to exercise the WARN paths.

## Sprint 3 final standings

| PR | Issue | Status |
|---|---|---|
| 3a #810 | E2 #791 — consent isolation | ✅ Merged |
| 3b #811 | B7 #778 — permissions matrix | ✅ Merged |
| 3c (this PR) | B2 #773 — app-only validation (console) | Open |
| Followup #812 | B2 — CSV + HTML render | Filed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)