### PR TITLE
feat(baseline): normalize storage to tenant GUID with read fallback (closes #780)

### DIFF
--- a/src/M365-Assess/Common/Build-SectionHtml.ps1
+++ b/src/M365-Assess/Common/Build-SectionHtml.ps1
@@ -63,9 +63,12 @@ $sectionData = @{
                             elseif ($reportDomainPrefix)                                                        { $reportDomainPrefix }
                             elseif ($tenantData -and @($tenantData).Count -gt 0 -and $tenantData[0].TenantId)   { $tenantData[0].TenantId }
                             else                                                                                  { '' }
+        # C1 #780: also pass the tenant GUID so v2.9.0+ baselines (which use
+        # _<GUID> folder suffix) are picked up alongside legacy _<domain> ones.
+        $tenantGuidForTrend = if ($tenantData -and @($tenantData).Count -gt 0 -and $tenantData[0].TenantId) { $tenantData[0].TenantId } else { '' }
         if (-not $tenantIdForTrend -or -not (Test-Path -Path $baselinesRoot)) { return @() }
         . (Join-Path -Path $PSScriptRoot -ChildPath 'Get-BaselineTrend.ps1')
-        @(Get-BaselineTrend -BaselinesRoot $baselinesRoot -TenantId $tenantIdForTrend)
+        @(Get-BaselineTrend -BaselinesRoot $baselinesRoot -TenantId $tenantIdForTrend -TenantGuid $tenantGuidForTrend)
     }
     'sharepoint-config'= & $loadCsv '20b-SharePoint-Security-Config.csv'
     'ad-hybrid'        = & $loadCsv '23-Hybrid-Sync.csv'

--- a/src/M365-Assess/Common/Get-BaselineTrend.ps1
+++ b/src/M365-Assess/Common/Get-BaselineTrend.ps1
@@ -3,14 +3,24 @@ function Get-BaselineTrend {
     .SYNOPSIS
         Enumerates saved baselines for a tenant and aggregates per-status counts per snapshot.
     .DESCRIPTION
-        Scans the Baselines directory for folders matching *_<SafeTenant>/, reads each
-        manifest.json for timestamp + version metadata, and counts the Status field
-        across every security-config JSON file in the baseline. Returns a chronologically
-        sorted array suitable for trend visualisation in the report.
+        Scans the Baselines directory for folders matching the tenant's identity
+        suffixes, reads each manifest.json for timestamp + version metadata, and
+        counts the Status field across every security-config JSON file in the
+        baseline. Returns a chronologically sorted array suitable for trend
+        visualisation in the report.
+
+        C1 #780: searches BOTH the legacy '_<TenantId>' folder shape AND the new
+        '_<TenantGuid>' shape so a tenant carrying baselines from both pre- and
+        post-v2.9.0 runs sees its full history on the trend chart. Folder names
+        are unique (timestamp-based), so the union doesn't double-count.
     .PARAMETER BaselinesRoot
         Path to the Baselines directory (typically <OutputFolder>/Baselines).
     .PARAMETER TenantId
-        Tenant identifier used to filter baseline folders by suffix.
+        Tenant identifier (typically DefaultDomain). Matches legacy baselines
+        saved as '<Label>_<TenantId>'.
+    .PARAMETER TenantGuid
+        Optional canonical tenant GUID. When supplied, also matches v2.9.0+
+        baselines saved as '<Label>_<TenantGuid>'.
     .PARAMETER MaxSnapshots
         Maximum number of most-recent snapshots to return. Defaults to 10 — enough
         context for a visible trend without cluttering the chart. Older snapshots
@@ -19,7 +29,9 @@ function Get-BaselineTrend {
         [PSCustomObject[]] One entry per baseline, sorted chronologically:
           Label, SavedAt, Version, Pass, Warn, Fail, Review, Info, Skipped, Total
     .EXAMPLE
-        $trend = Get-BaselineTrend -BaselinesRoot '.\M365-Assessment\Baselines' -TenantId 'contoso.com'
+        $trend = Get-BaselineTrend -BaselinesRoot '.\M365-Assessment\Baselines' `
+                                    -TenantId 'contoso.com' `
+                                    -TenantGuid '11111111-2222-3333-4444-555555555555'
     #>
     [CmdletBinding()]
     [OutputType([PSCustomObject[]])]
@@ -33,6 +45,9 @@ function Get-BaselineTrend {
         [string]$TenantId,
 
         [Parameter()]
+        [string]$TenantGuid = '',
+
+        [Parameter()]
         [ValidateRange(1, 100)]
         [int]$MaxSnapshots = 10
     )
@@ -42,8 +57,21 @@ function Get-BaselineTrend {
         return @()
     }
 
+    # C1 #780: union of legacy domain suffix + new GUID suffix. Filter against
+    # both so post-v2.9.0 baselines (GUID-keyed) and pre-v2.9.0 baselines
+    # (TenantId-keyed) both feed the trend chart.
     $safeTenant = $TenantId -replace '[^\w\.\-]', '_'
-    $baselineDirs = Get-ChildItem -Path $BaselinesRoot -Directory -Filter "*_${safeTenant}" -ErrorAction SilentlyContinue
+    $matchedDirs = New-Object -TypeName System.Collections.Generic.Dictionary[string, System.IO.DirectoryInfo]
+    foreach ($d in (Get-ChildItem -Path $BaselinesRoot -Directory -Filter "*_${safeTenant}" -ErrorAction SilentlyContinue)) {
+        if (-not $matchedDirs.ContainsKey($d.FullName)) { $matchedDirs[$d.FullName] = $d }
+    }
+    if ($TenantGuid) {
+        $safeGuid = $TenantGuid -replace '[^\w\-]', ''
+        foreach ($d in (Get-ChildItem -Path $BaselinesRoot -Directory -Filter "*_${safeGuid}" -ErrorAction SilentlyContinue)) {
+            if (-not $matchedDirs.ContainsKey($d.FullName)) { $matchedDirs[$d.FullName] = $d }
+        }
+    }
+    $baselineDirs = @($matchedDirs.Values)
 
     $snapshots = [System.Collections.Generic.List[PSCustomObject]]::new()
 

--- a/src/M365-Assess/Common/Resolve-TenantIdentity.ps1
+++ b/src/M365-Assess/Common/Resolve-TenantIdentity.ps1
@@ -1,0 +1,162 @@
+<#
+.SYNOPSIS
+    Resolves the canonical tenant identity for baseline / drift bookkeeping.
+.DESCRIPTION
+    Returns a PSCustomObject describing the connected tenant in stable terms:
+
+      Guid          : the tenant GUID (from Get-MgContext.TenantId after Graph
+                      connect) -- the canonical identifier used as the folder
+                      key for baselines (C1 #780). Falls back to a stable hash
+                      of the user-supplied TenantId if Graph isn't connected.
+      DisplayName   : tenant display name (from Get-MgOrganization)
+      PrimaryDomain : primary verified domain (Get-MgOrganization VerifiedDomains
+                      with isDefault=true)
+      Environment   : commercial / gcc / gcchigh / dod (passed in by caller)
+      Source        : 'Graph' when fully resolved, 'Fallback' when Graph data
+                      was unavailable -- callers can warn
+
+    The function is read-only: no Graph calls beyond Get-MgContext +
+    Get-MgOrganization, both of which are already in the assessment's required
+    permissions for the Tenant section.
+
+    Resolves once per assessment run (caller caches the result). Used by the
+    baseline export/compare path and intended for any future feature that
+    needs a stable tenant identifier (#812 permissions deficit CSV, #802
+    score-disclosure, etc.).
+.PARAMETER TenantIdInput
+    The user-supplied -TenantId from Invoke-M365Assessment. Used as the
+    fallback folder key when Graph context isn't usable (e.g. AD-only runs).
+.PARAMETER Environment
+    The cloud environment (commercial/gcc/gcchigh/dod). Stored as metadata.
+.EXAMPLE
+    $identity = Resolve-TenantIdentity -TenantIdInput $TenantId -Environment $M365Environment
+    $folderKey = $identity.Guid
+#>
+function Resolve-TenantIdentity {
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$TenantIdInput,
+
+        [Parameter()]
+        [string]$Environment = 'commercial'
+    )
+
+    $guid          = $null
+    $displayName   = ''
+    $primaryDomain = ''
+    $source        = 'Fallback'
+
+    try {
+        $context = Get-MgContext -ErrorAction SilentlyContinue
+        if ($context -and $context.TenantId) {
+            $guid = [string]$context.TenantId
+            $source = 'Graph'
+        }
+    }
+    catch { Write-Verbose "Resolve-TenantIdentity: Get-MgContext threw: $($_.Exception.Message)" }
+
+    # Try to enrich with display name + primary domain via Get-MgOrganization.
+    # This call requires Organization.Read.All which the Tenant section already
+    # asks for, so it's expected to succeed for any normal assessment run.
+    if ($guid) {
+        try {
+            $org = Get-MgOrganization -ErrorAction Stop | Select-Object -First 1
+            if ($org) {
+                $displayName = [string]$org.DisplayName
+                $primary = $org.VerifiedDomains | Where-Object { $_.IsDefault } | Select-Object -First 1
+                if ($primary) { $primaryDomain = [string]$primary.Name }
+            }
+        }
+        catch { Write-Verbose "Resolve-TenantIdentity: Get-MgOrganization unavailable: $($_.Exception.Message)" }
+    }
+
+    # Fallback: synthesize a stable key from the user-supplied TenantId. The
+    # resulting "guid" isn't a real GUID -- it's a deterministic 32-hex hash
+    # so identical TenantIdInput values produce identical folder keys.
+    if (-not $guid) {
+        $sha = [System.Security.Cryptography.SHA256]::Create()
+        try {
+            $bytes = $sha.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($TenantIdInput.ToLowerInvariant()))
+            $hex = ([System.BitConverter]::ToString($bytes) -replace '-', '').Substring(0, 32).ToLowerInvariant()
+            # Format as a GUID-shaped string so callers can treat it uniformly.
+            $guid = "{0}-{1}-{2}-{3}-{4}" -f $hex.Substring(0, 8), $hex.Substring(8, 4), $hex.Substring(12, 4), $hex.Substring(16, 4), $hex.Substring(20, 12)
+        }
+        finally {
+            $sha.Dispose()
+        }
+    }
+
+    return [pscustomobject]@{
+        Guid          = $guid
+        DisplayName   = $displayName
+        PrimaryDomain = $primaryDomain
+        Environment   = $Environment
+        Source        = $source
+        TenantInput   = $TenantIdInput
+    }
+}
+
+function Resolve-BaselineFolder {
+    <#
+    .SYNOPSIS
+        Resolves a baseline folder path, preferring GUID-keyed naming
+        and falling back to legacy TenantId-keyed naming for read.
+    .DESCRIPTION
+        C1 #780: baselines saved on v2.9.0+ use '<Label>_<TenantGuid>' as
+        the folder name. Pre-v2.9.0 baselines used '<Label>_<TenantId>'
+        where TenantId was whatever string the user supplied. This helper
+        searches the GUID path first, then the legacy path. Returns the
+        first existing folder, or the canonical GUID path if neither
+        exists (so error messages point at the new location).
+    .PARAMETER OutputFolder
+        Root output folder (parent of Baselines/).
+    .PARAMETER Label
+        Baseline label.
+    .PARAMETER TenantGuid
+        Canonical tenant GUID. If supplied, the GUID-keyed folder is the
+        first candidate.
+    .PARAMETER TenantId
+        Legacy tenant identifier (vanity domain or onmicrosoft.com short).
+        Searched as a fallback for pre-v2.9.0 baselines.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$OutputFolder,
+
+        [Parameter(Mandatory)]
+        [string]$Label,
+
+        [Parameter()]
+        [string]$TenantGuid = '',
+
+        [Parameter()]
+        [string]$TenantId = ''
+    )
+
+    $safeLabel = $Label -replace '[^\w\-]', '_'
+    $candidates = @()
+    if ($TenantGuid) {
+        $g = $TenantGuid -replace '[^\w\-]', ''
+        $candidates += (Join-Path -Path $OutputFolder -ChildPath ("Baselines\${safeLabel}_${g}"))
+    }
+    if ($TenantId) {
+        $t = $TenantId -replace '[^\w\.\-]', '_'
+        $candidates += (Join-Path -Path $OutputFolder -ChildPath ("Baselines\${safeLabel}_${t}"))
+    }
+
+    foreach ($candidate in $candidates) {
+        if (Test-Path -LiteralPath $candidate -PathType Container) {
+            return $candidate
+        }
+    }
+
+    # Neither folder exists -- return the canonical (GUID) candidate if we
+    # have one, else the legacy candidate. This lets callers compose useful
+    # "not found" messages pointing at the path they expected.
+    if ($candidates.Count -gt 0) { return $candidates[0] }
+    return Join-Path -Path $OutputFolder -ChildPath ("Baselines\${safeLabel}")
+}

--- a/src/M365-Assess/Invoke-M365Assessment.ps1
+++ b/src/M365-Assess/Invoke-M365Assessment.ps1
@@ -1216,6 +1216,10 @@ $driftReport         = @()
 $driftBaselineLabel  = ''
 $driftBaselineTimestamp = ''
 
+# C1 #780: resolve canonical tenant identity once for all baseline operations.
+# GUID becomes the folder key; the rest enriches the manifest.
+$tenantIdentity = Resolve-TenantIdentity -TenantIdInput $TenantId -Environment $M365Environment
+
 if ($SaveBaseline) {
     Write-AssessmentLog -Level INFO -Message "Saving baseline '$SaveBaseline'..."
     $savedBaselineDir = Export-AssessmentBaseline `
@@ -1223,6 +1227,10 @@ if ($SaveBaseline) {
         -OutputFolder $OutputFolder `
         -Label $SaveBaseline `
         -TenantId $TenantId `
+        -TenantGuid $tenantIdentity.Guid `
+        -DisplayName $tenantIdentity.DisplayName `
+        -PrimaryDomain $tenantIdentity.PrimaryDomain `
+        -Environment $tenantIdentity.Environment `
         -Sections @($sections | ForEach-Object { $_ }) `
         -Version $script:AssessmentVersion `
         -RegistryVersion (Get-RegistryVersion -ProjectRoot $projectRoot)
@@ -1230,9 +1238,11 @@ if ($SaveBaseline) {
 }
 
 if ($CompareBaseline) {
-    $safeLabel  = $CompareBaseline -replace '[^\w\-]', '_'
-    $safeTenant = $TenantId -replace '[^\w\.\-]', '_'
-    $baselineFolder = Join-Path -Path $OutputFolder -ChildPath "Baselines\${safeLabel}_${safeTenant}"
+    $baselineFolder = Resolve-BaselineFolder `
+        -OutputFolder $OutputFolder `
+        -Label $CompareBaseline `
+        -TenantGuid $tenantIdentity.Guid `
+        -TenantId $TenantId
     if (Test-Path -Path $baselineFolder -PathType Container) {
         Write-AssessmentLog -Level INFO -Message "Comparing against baseline '$CompareBaseline'..."
         $driftReport = Compare-AssessmentBaseline `
@@ -1259,22 +1269,31 @@ if ($CompareBaseline) {
 # AutoBaseline — save dated snapshot and compare to previous auto-*
 # ------------------------------------------------------------------
 if ($AutoBaseline) {
-    $autoLabel   = "auto_$(Get-Date -Format 'yyyy-MM-ddTHH-mm-ss')"
-    $safeTenant  = $TenantId -replace '[^\w\.\-]', '_'
-    $sections    = @($Section | ForEach-Object { $_ })
+    $autoLabel = "auto_$(Get-Date -Format 'yyyy-MM-ddTHH-mm-ss')"
+    # C1 #780: prefer GUID-keyed folder names; fall back to legacy
+    # TenantId-based regex for finding pre-v2.9.0 auto baselines.
+    $folderSuffix = if ($tenantIdentity.Guid) { $tenantIdentity.Guid -replace '[^\w\-]', '' } else { $TenantId -replace '[^\w\.\-]', '_' }
+    $legacySuffix = $TenantId -replace '[^\w\.\-]', '_'
+    $sections = @($Section | ForEach-Object { $_ })
     Export-AssessmentBaseline `
         -AssessmentFolder $assessmentFolder `
         -OutputFolder $OutputFolder `
         -TenantId $TenantId `
+        -TenantGuid $tenantIdentity.Guid `
+        -DisplayName $tenantIdentity.DisplayName `
+        -PrimaryDomain $tenantIdentity.PrimaryDomain `
+        -Environment $tenantIdentity.Environment `
         -Label $autoLabel `
         -Sections $sections `
         -Version $script:AssessmentVersion `
         -RegistryVersion (Get-RegistryVersion -ProjectRoot $projectRoot)
     Write-AssessmentLog -Level INFO -Message "AutoBaseline saved: $autoLabel"
 
-    # Compare to most recent previous auto-snapshot for this tenant
+    # Compare to most recent previous auto-snapshot for this tenant. Search
+    # the canonical GUID-keyed names first, then legacy TenantId names.
+    $autoPattern = "^auto_.*_(?:${folderSuffix}|${legacySuffix})$"
     $prevAuto = Get-ChildItem -Path (Join-Path $OutputFolder 'Baselines') -Directory -ErrorAction SilentlyContinue |
-        Where-Object { $_.Name -match "^auto_.*_${safeTenant}$" } |
+        Where-Object { $_.Name -match $autoPattern } |
         Sort-Object LastWriteTime -Descending |
         Select-Object -Skip 1 -First 1
     if ($prevAuto) {
@@ -1283,7 +1302,8 @@ if ($AutoBaseline) {
             -AssessmentFolder $assessmentFolder `
             -BaselineFolder $prevAuto.FullName `
             -RegistryVersion (Get-RegistryVersion -ProjectRoot $projectRoot)
-        $driftBaselineLabel = $prevAuto.Name -replace "_${safeTenant}$", ''
+        # Strip either suffix off the label for display
+        $driftBaselineLabel = $prevAuto.Name -replace "_(?:${folderSuffix}|${legacySuffix})$", ''
         try {
             $meta = Get-Content -Path (Join-Path $prevAuto.FullName 'manifest.json') -Raw | ConvertFrom-Json
             $driftBaselineTimestamp = $meta.SavedAt

--- a/src/M365-Assess/M365-Assess.psd1
+++ b/src/M365-Assess/M365-Assess.psd1
@@ -78,6 +78,7 @@
         'Common\SecurityConfigHelper.ps1'
         'Common\Connect-Service.ps1'
         'Common\Resolve-DnsRecord.ps1'
+        'Common\Resolve-TenantIdentity.ps1'
         'Common\Resolve-TenantLicenses.ps1'
         'Common\Export-AssessmentReport.ps1'
         'Common\Export-AssessmentBridgeJson.ps1'

--- a/src/M365-Assess/M365-Assess.psm1
+++ b/src/M365-Assess/M365-Assess.psm1
@@ -6,6 +6,7 @@ Get-ChildItem -Path "$PSScriptRoot\Orchestrator\*.ps1" | ForEach-Object { . $_.F
 # Dot-source shared helpers needed by public cmdlets
 . "$PSScriptRoot\Common\SecurityConfigHelper.ps1"
 . "$PSScriptRoot\Common\Resolve-DnsRecord.ps1"
+. "$PSScriptRoot\Common\Resolve-TenantIdentity.ps1"
 . "$PSScriptRoot\Orchestrator\Compare-M365Baseline.ps1"
 # Dot-source the main orchestrator to import Invoke-M365Assessment function
 . $PSScriptRoot\Invoke-M365Assessment.ps1

--- a/src/M365-Assess/Orchestrator/Export-AssessmentBaseline.ps1
+++ b/src/M365-Assess/Orchestrator/Export-AssessmentBaseline.ps1
@@ -17,7 +17,22 @@ function Export-AssessmentBaseline {
         Human-readable baseline label (e.g. 'Q1-2026'). Used as the folder name
         prefix and referenced with -CompareBaseline on future runs.
     .PARAMETER TenantId
-        Tenant identifier for the baseline folder name suffix.
+        Tenant identifier passed in (GUID, vanity domain, or .onmicrosoft.com).
+        Recorded in the manifest as the user-facing label. Falls back to the
+        folder-key suffix when TenantGuid is not supplied (legacy callers).
+    .PARAMETER TenantGuid
+        Canonical tenant GUID (from Get-MgContext.TenantId via
+        Resolve-TenantIdentity). When supplied, the baseline folder is named
+        '<Label>_<TenantGuid>' so the same tenant referenced multiple ways
+        produces a single folder (C1 #780). Friendly TenantId is preserved
+        in the manifest for display.
+    .PARAMETER DisplayName
+        Tenant display name (Get-MgOrganization.DisplayName). Manifest only.
+    .PARAMETER PrimaryDomain
+        Primary verified domain (Get-MgOrganization.VerifiedDomains.IsDefault).
+        Manifest only.
+    .PARAMETER Environment
+        Cloud environment string (commercial / gcc / gcchigh / dod). Manifest only.
     .PARAMETER Sections
         Array of section names that were assessed (recorded in metadata).
     .PARAMETER Version
@@ -27,7 +42,8 @@ function Export-AssessmentBaseline {
         recorded in metadata to enable version-aware drift comparison.
     .EXAMPLE
         Export-AssessmentBaseline -AssessmentFolder $assessmentFolder `
-            -OutputFolder '.\M365-Assessment' -Label 'Q1-2026' -TenantId 'contoso.com'
+            -OutputFolder '.\M365-Assessment' -Label 'Q1-2026' -TenantId 'contoso.com' `
+            -TenantGuid '00000000-0000-0000-0000-000000000000'
     #>
     [CmdletBinding()]
     [OutputType([string])]
@@ -49,6 +65,18 @@ function Export-AssessmentBaseline {
         [string]$TenantId,
 
         [Parameter()]
+        [string]$TenantGuid = '',
+
+        [Parameter()]
+        [string]$DisplayName = '',
+
+        [Parameter()]
+        [string]$PrimaryDomain = '',
+
+        [Parameter()]
+        [string]$Environment = '',
+
+        [Parameter()]
         [string[]]$Sections = @(),
 
         [Parameter()]
@@ -59,9 +87,17 @@ function Export-AssessmentBaseline {
     )
 
     # Sanitise label for use as a folder name
-    $safeLabel  = $Label  -replace '[^\w\-]', '_'
-    $safeTenant = $TenantId -replace '[^\w\.\-]', '_'
-    $baselineDir = Join-Path -Path $OutputFolder -ChildPath "Baselines\${safeLabel}_${safeTenant}"
+    $safeLabel = $Label -replace '[^\w\-]', '_'
+
+    # C1 #780: prefer the canonical GUID as the folder-key suffix. When the
+    # caller hasn't resolved one (legacy callers, AD-only runs without Graph),
+    # fall back to the user-supplied TenantId so behavior matches pre-v2.9.0.
+    $folderSuffix = if ($TenantGuid) {
+        $TenantGuid -replace '[^\w\-]', ''
+    } else {
+        $TenantId -replace '[^\w\.\-]', '_'
+    }
+    $baselineDir = Join-Path -Path $OutputFolder -ChildPath "Baselines\${safeLabel}_${folderSuffix}"
 
     if (-not (Test-Path -Path $baselineDir -PathType Container)) {
         $null = New-Item -Path $baselineDir -ItemType Directory -Force
@@ -93,11 +129,18 @@ function Export-AssessmentBaseline {
         }
     }
 
-    # Write manifest after CSV scan (includes accurate CheckCount)
+    # Write manifest after CSV scan (includes accurate CheckCount).
+    # C1 #780: enriched identity fields (TenantGuid + DisplayName + PrimaryDomain
+    # + Environment) live alongside the legacy TenantId. Older readers ignore
+    # the new fields; new readers use TenantGuid as the canonical key.
     $manifest = [PSCustomObject]@{
         Label             = $Label
         SavedAt           = (Get-Date -Format 'o')
         TenantId          = $TenantId
+        TenantGuid        = $TenantGuid
+        DisplayName       = $DisplayName
+        PrimaryDomain     = $PrimaryDomain
+        Environment       = $Environment
         AssessmentVersion = $Version
         RegistryVersion   = $RegistryVersion
         CheckCount        = $checkCount

--- a/tests/Common/Resolve-TenantIdentity.Tests.ps1
+++ b/tests/Common/Resolve-TenantIdentity.Tests.ps1
@@ -1,0 +1,114 @@
+BeforeAll {
+    . "$PSScriptRoot/../../src/M365-Assess/Common/Resolve-TenantIdentity.ps1"
+}
+
+Describe 'Resolve-TenantIdentity (C1 #780)' {
+    Context 'when Get-MgContext returns a TenantId' {
+        BeforeAll {
+            Mock Get-MgContext { return [pscustomobject]@{ TenantId = '11111111-2222-3333-4444-555555555555' } }
+            Mock Get-MgOrganization {
+                return [pscustomobject]@{
+                    DisplayName     = 'Contoso Ltd'
+                    VerifiedDomains = @(
+                        [pscustomobject]@{ Name = 'contoso.onmicrosoft.com'; IsDefault = $false }
+                        [pscustomobject]@{ Name = 'contoso.com';             IsDefault = $true }
+                    )
+                }
+            }
+        }
+
+        It 'should return Source = Graph' {
+            $r = Resolve-TenantIdentity -TenantIdInput 'contoso.com' -Environment 'commercial'
+            $r.Source | Should -Be 'Graph'
+        }
+
+        It 'should return the GUID from Get-MgContext' {
+            $r = Resolve-TenantIdentity -TenantIdInput 'contoso.com'
+            $r.Guid | Should -Be '11111111-2222-3333-4444-555555555555'
+        }
+
+        It 'should populate DisplayName from Get-MgOrganization' {
+            $r = Resolve-TenantIdentity -TenantIdInput 'contoso.com'
+            $r.DisplayName | Should -Be 'Contoso Ltd'
+        }
+
+        It 'should populate PrimaryDomain from the IsDefault verified domain' {
+            $r = Resolve-TenantIdentity -TenantIdInput 'contoso.com'
+            $r.PrimaryDomain | Should -Be 'contoso.com'
+        }
+
+        It 'should preserve the user-supplied TenantInput verbatim' {
+            $r = Resolve-TenantIdentity -TenantIdInput 'contoso.com'
+            $r.TenantInput | Should -Be 'contoso.com'
+        }
+    }
+
+    Context 'when Get-MgContext returns null (Graph not connected)' {
+        BeforeAll {
+            Mock Get-MgContext { return $null }
+        }
+
+        It 'should return Source = Fallback' {
+            $r = Resolve-TenantIdentity -TenantIdInput 'fallback.tenant.com'
+            $r.Source | Should -Be 'Fallback'
+        }
+
+        It 'should derive a deterministic GUID-shaped key from the TenantIdInput' {
+            $r1 = Resolve-TenantIdentity -TenantIdInput 'fallback.tenant.com'
+            $r2 = Resolve-TenantIdentity -TenantIdInput 'fallback.tenant.com'
+            $r1.Guid | Should -Be $r2.Guid
+            $r1.Guid | Should -Match '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+        }
+
+        It 'should produce different keys for different TenantIdInput values' {
+            $a = Resolve-TenantIdentity -TenantIdInput 'tenantA.onmicrosoft.com'
+            $b = Resolve-TenantIdentity -TenantIdInput 'tenantB.onmicrosoft.com'
+            $a.Guid | Should -Not -Be $b.Guid
+        }
+
+        It 'should be case-insensitive on the TenantIdInput hash' {
+            $upper = Resolve-TenantIdentity -TenantIdInput 'CONTOSO.COM'
+            $lower = Resolve-TenantIdentity -TenantIdInput 'contoso.com'
+            $upper.Guid | Should -Be $lower.Guid
+        }
+    }
+
+    Context 'Environment metadata passthrough' {
+        BeforeAll {
+            Mock Get-MgContext { return $null }
+        }
+
+        It 'should record the supplied Environment value' {
+            $r = Resolve-TenantIdentity -TenantIdInput 'gov.onmicrosoft.us' -Environment 'gcchigh'
+            $r.Environment | Should -Be 'gcchigh'
+        }
+    }
+}
+
+Describe 'Resolve-BaselineFolder (C1 #780)' {
+    Context 'when both GUID and TenantId are supplied' {
+        It 'should prefer the GUID path when it exists' {
+            $output = $TestDrive
+            $guidFolder   = Join-Path $output 'Baselines\Q1_11111111-2222-3333-4444-555555555555'
+            $legacyFolder = Join-Path $output 'Baselines\Q1_contoso.com'
+            $null = New-Item $guidFolder   -ItemType Directory -Force
+            $null = New-Item $legacyFolder -ItemType Directory -Force
+            $resolved = Resolve-BaselineFolder -OutputFolder $output -Label 'Q1' -TenantGuid '11111111-2222-3333-4444-555555555555' -TenantId 'contoso.com'
+            $resolved | Should -Be $guidFolder
+        }
+
+        It 'should fall back to the legacy TenantId path when only legacy exists' {
+            $output = Join-Path $TestDrive 'fb1'
+            $legacyFolder = Join-Path $output 'Baselines\Q1_legacytenant.com'
+            $null = New-Item $legacyFolder -ItemType Directory -Force
+            $resolved = Resolve-BaselineFolder -OutputFolder $output -Label 'Q1' -TenantGuid '11111111-2222-3333-4444-555555555555' -TenantId 'legacytenant.com'
+            $resolved | Should -Be $legacyFolder
+        }
+
+        It 'should return the canonical (GUID) path when neither exists' {
+            $output = Join-Path $TestDrive 'fb2'
+            $resolved = Resolve-BaselineFolder -OutputFolder $output -Label 'Q1' -TenantGuid '11111111-2222-3333-4444-555555555555' -TenantId 'contoso.com'
+            $resolved | Should -Match '_11111111-2222-3333-4444-555555555555$'
+        }
+    }
+}

--- a/tests/Orchestrator/Export-AssessmentBaseline.Tests.ps1
+++ b/tests/Orchestrator/Export-AssessmentBaseline.Tests.ps1
@@ -91,4 +91,55 @@ Describe 'Export-AssessmentBaseline' {
             $dir | Should -Match 'Baseline_2026_Q1_contoso\.com'
         }
     }
+
+    Context 'GUID-keyed folders + enriched manifest (C1 #780)' {
+        It 'should name the folder with TenantGuid when supplied' {
+            $dir = Export-AssessmentBaseline `
+                -AssessmentFolder $script:tempAssessment `
+                -OutputFolder $script:tempOutput `
+                -Label 'Q2-2026' `
+                -TenantId 'whatever.user.typed.com' `
+                -TenantGuid '11111111-2222-3333-4444-555555555555'
+            $dir | Should -Match 'Q2-2026_11111111-2222-3333-4444-555555555555$'
+        }
+
+        It 'should fall back to TenantId in the folder name when TenantGuid is empty (legacy callers)' {
+            $dir = Export-AssessmentBaseline `
+                -AssessmentFolder $script:tempAssessment `
+                -OutputFolder $script:tempOutput `
+                -Label 'Q3-2026' `
+                -TenantId 'legacy.contoso.com'
+            $dir | Should -Match 'Q3-2026_legacy\.contoso\.com$'
+        }
+
+        It 'should write the new identity fields into the manifest' {
+            $dir = Export-AssessmentBaseline `
+                -AssessmentFolder $script:tempAssessment `
+                -OutputFolder $script:tempOutput `
+                -Label 'Q4-2026' `
+                -TenantId 'contoso.com' `
+                -TenantGuid '99999999-0000-1111-2222-333333333333' `
+                -DisplayName 'Contoso Ltd' `
+                -PrimaryDomain 'contoso.com' `
+                -Environment 'commercial'
+            $meta = Get-Content (Join-Path $dir 'manifest.json') -Raw | ConvertFrom-Json
+            $meta.TenantGuid    | Should -Be '99999999-0000-1111-2222-333333333333'
+            $meta.DisplayName   | Should -Be 'Contoso Ltd'
+            $meta.PrimaryDomain | Should -Be 'contoso.com'
+            $meta.Environment   | Should -Be 'commercial'
+            # Legacy field still preserved for back-compat readers
+            $meta.TenantId      | Should -Be 'contoso.com'
+        }
+
+        It 'should sanitise braces / curly characters out of the GUID folder suffix' {
+            $dir = Export-AssessmentBaseline `
+                -AssessmentFolder $script:tempAssessment `
+                -OutputFolder $script:tempOutput `
+                -Label 'Q5' `
+                -TenantId 'contoso.com' `
+                -TenantGuid '{aaaa1111-2222-3333-4444-555555555555}'
+            $dir | Should -Match '_aaaa1111-2222-3333-4444-555555555555$'
+            $dir | Should -Not -Match '[{}]'
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Sprint 4 PR 4b. Baselines previously keyed off whatever string the user passed as `-TenantId`, so the same tenant referenced as a GUID, vanity domain, or `.onmicrosoft.com` short produced three different baseline folders — and three different "drift" stories. C1 #780: key folders by tenant **GUID**; preserve friendly identity in the manifest as metadata.

Closes C1 **#780**.

## What ships

### `src/M365-Assess/Common/Resolve-TenantIdentity.ps1` (NEW)

Two new helpers used by all baseline call sites and any future feature that needs a stable tenant identifier:

| Helper | Purpose |
|---|---|
| `Resolve-TenantIdentity` | Returns `{Guid, DisplayName, PrimaryDomain, Environment, Source, TenantInput}`. GUID from `Get-MgContext.TenantId` (Source='Graph'); enriched via `Get-MgOrganization`. **Falls back** to a deterministic SHA-256-derived GUID-shaped key when Graph isn't connected (Source='Fallback'). Same TenantIdInput → same fallback key. |
| `Resolve-BaselineFolder` | Returns a baseline folder path. Searches GUID-keyed names first (canonical), then legacy TenantId-keyed names, then returns the canonical GUID path so "not found" errors point at the new location. |

### `Export-AssessmentBaseline.ps1`

- New optional params: `-TenantGuid`, `-DisplayName`, `-PrimaryDomain`, `-Environment`
- When `TenantGuid` supplied: folder name is `<Label>_<TenantGuid>` (canonical)
- When `TenantGuid` empty: falls back to `<Label>_<TenantId>` (legacy callers unchanged so existing tests still pass)
- Manifest enriched with `TenantGuid + DisplayName + PrimaryDomain + Environment`. Legacy `TenantId` field preserved for back-compat readers.

### `Invoke-M365Assessment.ps1`

- Resolves identity once via `Resolve-TenantIdentity` before any baseline op
- `-SaveBaseline` + `-AutoBaseline` call sites pass the GUID + enriched fields
- `-CompareBaseline` uses `Resolve-BaselineFolder` which searches canonical → legacy
- `-AutoBaseline`'s "previous auto-snapshot" search regex matches **both** GUID and legacy TenantId folder suffixes, so tenants carrying pre-v2.9.0 auto baselines still get drift comparisons

## Migration semantics — never lose user data

| Scenario | Behavior |
|---|---|
| Existing baseline at `<Label>_<TenantId>` (pre-v2.9.0) | Still **loads** via `Resolve-BaselineFolder`'s fallback search |
| New `-SaveBaseline` run | Writes to `<Label>_<TenantGuid>` (canonical) |
| Legacy folders | **Not renamed or deleted.** User cleans up manually. |
| `-AutoBaseline` with mixed legacy + new folders | Regex matches both shapes; previous-run comparison still works |

Same defensive pattern as B1 (#814): preserve user data, prefer new path on write, fall back on read.

## Tests

- **`tests/Common/Resolve-TenantIdentity.Tests.ps1`** (NEW): 13 tests
  - Graph happy path (Source/Guid/DisplayName/PrimaryDomain/TenantInput)
  - Fallback path (deterministic, case-insensitive, GUID-shaped, distinct keys for distinct inputs)
  - Environment passthrough
  - `Resolve-BaselineFolder` (3 cases: GUID-exists / legacy-only / neither-exists)
- **`tests/Orchestrator/Export-AssessmentBaseline.Tests.ps1`** (extended): +4 tests
  - GUID-keyed folder naming
  - Legacy fallback when `TenantGuid` is empty
  - Enriched manifest fields
  - Sanitisation of brace-wrapped GUIDs (`{aaaa1111...}` → `aaaa1111...`)

**Result:** 25/25 dedicated pass; smoke 336/336 pass; PSScriptAnalyzer clean.

## Reviewer notes

- The fallback hash is intentionally a 32-hex-char GUID-shaped string (not a real GUID) so all callers can treat the field uniformly. The shape lets folder names look consistent whether Graph is connected or not.
- `Get-MgOrganization` is wrapped in try/catch — if the tenant section's permissions aren't granted, the helper returns an empty DisplayName/PrimaryDomain rather than throwing. The folder still gets the GUID; the manifest just has thinner metadata.
- Legacy auto-baseline folders use the format `auto_<timestamp>_<TenantId>`. The new regex matches `auto_.*_(<guid>|<legacy>)$` so a tenant with one legacy auto folder + one new GUID auto folder gets the most-recent of either as the comparison target. If you only have legacy folders, the comparison still works.

## Sprint 4 status after this lands

- 4a #814 (B1 profile path) — merged
- 4b (this PR) — C1 #780
- Sprint 4 complete; v2.9.0 milestone gets 2 more closures

🤖 Generated with [Claude Code](https://claude.com/claude-code)