### PR TITLE
docs: contributor guides for testing + release process (closes #795, #796)

### DIFF
--- a/docs/RELEASE-PROCESS.md
+++ b/docs/RELEASE-PROCESS.md
@@ -1,0 +1,204 @@
+# Release process
+
+How M365 Assess versions are bumped, gated, tagged, and shipped.
+
+---
+
+## Semver rules
+
+| Bump | When | Examples |
+|---|---|---|
+| **MAJOR** | Breaking changes to public API, output schema, or required parameters | Removed cmdlet, renamed parameter, restructured `window.REPORT_DATA` |
+| **MINOR** | New collectors, new checks, new framework support, new public cmdlets | Added Defender vulnerability scanning, new `-EvidencePackage` switch |
+| **PATCH** | Bug fixes, documentation, cosmetic report changes, dependency updates | Fixed denominator math, updated bundled SKU list, README typo |
+
+When in doubt, bump conservatively (lean toward MINOR over PATCH).
+
+---
+
+## The 4 version locations
+
+Bump every one in a single PR. CI's version-consistency gate fails if they drift.
+
+| # | File | Field | Pattern |
+|---|------|-------|---------|
+| 1 | `src/M365-Assess/M365-Assess.psd1` (~line 6) | `ModuleVersion` | `ModuleVersion = '2.9.0'` |
+| 2 | `src/M365-Assess/M365-Assess.psd1` (~line 184) | `ReleaseNotes` | `ReleaseNotes = 'v2.9.0 - ...'` |
+| 3 | `README.md` (~line 19) | Version badge | `version-2.9.0-blue` |
+| 4 | `CHANGELOG.md` | New version header | `## [2.9.0] - YYYY-MM-DD` |
+
+The `.psd1` `ModuleVersion` is the **single source of truth at runtime**. The HTML report banner, footer, and console output all read it dynamically via `Import-PowerShellDataFile`.
+
+The other three locations are documentation/discovery surfaces that need to match. CI verifies the README badge matches the manifest version on every PR (`Quality Gates -> Version consistency` and on doc-only PRs `Docs Gates -> Version consistency`).
+
+---
+
+## CHANGELOG format
+
+Follow [Keep a Changelog](https://keepachangelog.com/) conventions:
+
+```markdown
+## [2.9.0] - 2026-MM-DD
+
+### Added
+- Read-only CI guardrail (#771)
+- Generated permissions matrix (#778)
+- ...
+
+### Changed
+- Pass% denominator now strict-rule per CHECK-STATUS-MODEL.md (#802)
+- ...
+
+### Fixed
+- ...
+
+### Removed
+- 13 deprecated `Get-M365*SecurityConfig` wrappers (warn in v2.9.x, full removal v3.0.0)
+```
+
+Reference each PR by number; group changes under the four headers (Added / Changed / Fixed / Removed). Skip empty headers.
+
+---
+
+## Step-by-step release
+
+After all milestone PRs have merged to `main`:
+
+### 1. Pre-flight check
+
+```powershell
+# Confirm main is green and matches origin
+git checkout main && git pull --ff-only
+
+# All milestone issues closed
+gh api repos/Galvnyz/M365-Assess/milestones/<num> --jq '{open_issues, closed_issues}'
+
+# CHANGELOG has a [Unreleased] section to promote (or you'll write one)
+grep -n '^## \[Unreleased\]' CHANGELOG.md
+```
+
+### 2. Bump version (single PR)
+
+```powershell
+git checkout -b chore/release-vX.Y.Z
+
+# Edit the 4 locations listed above:
+#   src/M365-Assess/M365-Assess.psd1: ModuleVersion + ReleaseNotes
+#   README.md: version badge
+#   CHANGELOG.md: rename [Unreleased] -> [X.Y.Z] - YYYY-MM-DD, add new [Unreleased] block above
+
+git add -A
+git commit -m "chore(release): bump to vX.Y.Z"
+git push -u origin chore/release-vX.Y.Z
+gh pr create --title "chore(release): bump to vX.Y.Z" --label chore
+```
+
+CI must pass — version-consistency gate confirms all 4 locations match.
+
+### 3. Merge to main
+
+Squash-merge. The PR title becomes the commit message; the version-bump commit on main is the canonical "this is vX.Y.Z" reference.
+
+### 4. Tag + GitHub release (after merge)
+
+```powershell
+# Create the annotated tag from the merge commit
+git checkout main && git pull --ff-only
+git tag -a vX.Y.Z -m "vX.Y.Z"
+git push origin vX.Y.Z
+
+# Create the GitHub release pulling notes from CHANGELOG
+gh release create vX.Y.Z --title "vX.Y.Z" --notes-file - <<EOF
+$(awk '/^## \[X.Y.Z\]/,/^## \[/' CHANGELOG.md | sed '$d')
+EOF
+```
+
+Or manually paste the CHANGELOG section into `gh release create`'s editor.
+
+### 5. Close the milestone
+
+```powershell
+gh api -X PATCH repos/Galvnyz/M365-Assess/milestones/<num> -f state=closed
+```
+
+### 6. Regenerate doc-as-code artifacts (when source changed)
+
+If the release added or removed Graph permissions / collectors / scope mappings:
+
+```powershell
+pwsh -NoProfile -File ./scripts/Build-PermissionsMatrix.ps1
+git add docs/PERMISSIONS.md
+git commit -m "docs: regenerate PERMISSIONS.md for vX.Y.Z"
+```
+
+If npm dependencies changed (rare):
+
+```powershell
+npm install
+# Regenerate THIRD-PARTY-LICENSES.md per docs/REPORT-FRONTEND.md (post-C4)
+```
+
+These are separate small PRs that follow the version-bump merge.
+
+### 7. PSGallery publish (separate workflow)
+
+Publishing to PSGallery is currently manual; the maintainer pushes via `Publish-Module` after tag creation. Future improvement: GH Actions workflow on tag push.
+
+---
+
+## Branch protection
+
+`main` requires:
+
+- The `CI` job to pass (aggregates Quality Gates + Pester matrix + CodeQL)
+- At least one PR (no direct pushes)
+
+Doc-only PRs route to a lighter `Docs Gates` job (~30 seconds) instead of the full Pester matrix (~4 minutes), so quick text fixes don't block the maintainer queue.
+
+---
+
+## Hotfix procedure
+
+For urgent post-release fixes (e.g., a regression discovered after vX.Y.Z is tagged):
+
+1. Branch from the tag: `git checkout -b hotfix/X.Y.Z+1 vX.Y.Z`
+2. Make the minimal fix; commit; push
+3. Open a PR targeting `main`. Same CI gates apply.
+4. Once merged, bump to `X.Y.Z+1` (PATCH) and follow steps 4-6 above.
+
+Hotfixes never skip the version-consistency gate — every release tag has a matching CHANGELOG entry and badge update.
+
+---
+
+## Pre-release / RC channel (planned, #722)
+
+`#722` tracks adding a release-candidate workflow:
+
+- New `release-candidate` branch with branch protection
+- Automatic GH pre-release tag (`vX.Y.Z-rc.1`) on push
+- Soak window before promoting to a full tag
+
+Out of scope for v2.9.0 closure but tracked for v2.10.0 or v3.0.0.
+
+---
+
+## When to regenerate generated docs
+
+Generated docs are part of the source code surface. Bump the regenerator output anytime the source map changes. CI catches drift on every PR.
+
+| Generated doc | Regen command | Source-of-truth |
+|---|---|---|
+| `docs/PERMISSIONS.md` | `pwsh -File ./scripts/Build-PermissionsMatrix.ps1` | `Orchestrator/AssessmentMaps.ps1` + `Setup/PermissionDefinitions.ps1` |
+| `docs/SOVEREIGN-CLOUDS.md` (post-C2) | (TBD) | `controls/sovereign-cloud-support.json` |
+| `THIRD-PARTY-LICENSES.md` (post-C4) | `npm run licenses` (or equivalent) | `node_modules/` license-checker output |
+
+CI's `-Check` mode for each generator fails the PR if the doc is out of sync. Action is always: run the generator locally, commit the updated doc, push.
+
+---
+
+## Related
+
+- [`TESTING.md`](TESTING.md) — local + CI testing guide
+- [`PERMISSIONS.md`](PERMISSIONS.md) — generated; covered above
+- `.claude/rules/releases.md` — internal release rules for AI-assisted contributors
+- `.claude/rules/versions.md` — version-bump checklist (mirrors §"The 4 version locations" above)

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,278 @@
+# Testing
+
+Practical guide for running M365 Assess tests locally and understanding the CI gates.
+
+---
+
+## Quick start
+
+```powershell
+# All tests
+pwsh -NoProfile -Command "Invoke-Pester -Path './tests' -Output Detailed"
+
+# A specific domain
+pwsh -NoProfile -Command "Invoke-Pester -Path './tests/Entra' -Output Detailed"
+
+# A specific test file
+pwsh -NoProfile -Command "Invoke-Pester -Path './tests/Common/Build-ReportData.Tests.ps1' -Output Detailed"
+```
+
+Tests assume **PowerShell 7.4+** and **Pester 5.x**. Pester is auto-installed in CI; for local runs:
+
+```powershell
+Install-Module -Name Pester -MinimumVersion 5.0.0 -Scope CurrentUser
+```
+
+---
+
+## Test layout
+
+```
+tests/
+├── Common/                    Tests for Common/ helpers (Build-ReportData, Connect-Service, etc.)
+├── Consistency/               Manifest + FileList drift gates
+├── controls/                  Control registry + framework JSON validation
+├── Entra/                     Entra collector tests
+├── Exchange-Online/           EXO collector tests
+├── Intune/                    Intune collector tests
+├── Orchestrator/              Orchestrator helpers (Test-GraphPermissions, baselines)
+├── Purview/                   Purview collector tests
+├── Security/                  Defender + DLP + Stryker tests
+├── SOC2/                      SOC 2 evidence collector tests
+├── Setup/                     Grant-M365AssessConsent + connection profile tests
+└── Smoke/                     Fast-running gates (collector read-only, manifest, PSGallery)
+```
+
+Mirror the `src/M365-Assess/<Domain>/` structure under `tests/<Domain>/`.
+
+---
+
+## Conventions
+
+### Naming
+
+- Test files: `<ScriptName>.Tests.ps1` (e.g., `Get-LicenseReport.Tests.ps1`)
+- `Describe` block = script or function name
+- `Context` block = scenario, prefixed with "when": `Context 'when given a valid tenant'`
+- `It` block = expected behavior, prefixed with "should": `It 'should return the SKU summary'`
+
+### Loading the script under test
+
+```powershell
+BeforeAll {
+    . (Join-Path $PSScriptRoot '../../src/M365-Assess/Entra/Get-LicenseReport.ps1')
+}
+```
+
+For collectors that depend on `Common/` helpers, dot-source those first:
+
+```powershell
+BeforeAll {
+    . (Join-Path $PSScriptRoot '../../src/M365-Assess/Common/SecurityConfigHelper.ps1')
+    . (Join-Path $PSScriptRoot '../../src/M365-Assess/Common/Connect-Service.ps1')
+    . (Join-Path $PSScriptRoot '../../src/M365-Assess/Entra/Get-EntraSecurityConfig.ps1')
+}
+```
+
+### Mocking external services
+
+Mock Graph, EXO, Purview, and Power BI cmdlets. **Never make real API calls in tests.**
+
+```powershell
+Mock Get-MgUser { return @{ DisplayName = 'Test User'; UserPrincipalName = 'test@contoso.com' } }
+Mock Connect-MgGraph { } -ParameterFilter { $true }
+```
+
+Verify with `Should -Invoke` (Pester 5.x) — not the legacy v4 `Assert-MockCalled`.
+
+For Pester's `Mock` to register, the target command must exist in scope. CI runners only install PSScriptAnalyzer + Pester explicitly — Microsoft.Graph + EXO + PowerBI may be missing. Stub-define them when needed:
+
+```powershell
+BeforeAll {
+    if (-not (Get-Command Connect-MgGraph -ErrorAction SilentlyContinue)) {
+        function global:Connect-MgGraph { param() }
+    }
+    Mock Connect-MgGraph { }
+}
+
+AfterAll {
+    Remove-Item -Path 'function:global:Connect-MgGraph' -ErrorAction SilentlyContinue
+}
+```
+
+### Filtering by Setting, not CheckId
+
+Stored CheckId is sub-numbered (`ENTRA-MFA-001.1`, `.2`, `.3`). When asserting on a specific check, filter by the human-readable `Setting` field:
+
+```powershell
+$check = $settings | Where-Object { $_.Setting -eq 'MFA Required for All Users' }
+$check.Status | Should -Be 'Pass'
+```
+
+---
+
+## Fixtures (post-D5)
+
+Mocked Graph/EXO fixture tests live under `tests/Fixtures/` once D5 #789 ships. Pattern: per-collector tests feed checked-in JSON snapshots into mocked Graph/EXO calls and assert Status + Setting + Evidence outcomes.
+
+```
+tests/Fixtures/
+├── Graph/
+│   ├── empty-tenant.json
+│   ├── normal-tenant.json
+│   ├── missing-permission.json
+│   └── throttled.json
+├── Exchange/
+├── Intune/
+└── Reports/                 Full-tenant snapshots for end-to-end report tests
+```
+
+`tests/Fixtures/` is line-ending-stable per the repo's `.gitattributes` so cross-platform CI doesn't see false drift.
+
+---
+
+## Coverage gate
+
+The CI line-coverage threshold is **65%** (`COVERAGE_THRESHOLD: 65` in `.github/workflows/ci.yml`). Run locally:
+
+```powershell
+$config = New-PesterConfiguration
+$config.Run.Path                = './tests'
+$config.CodeCoverage.Enabled    = $true
+$config.CodeCoverage.Path       = @('./src/M365-Assess/Common/', './src/M365-Assess/Entra/', '...')
+$config.CodeCoverage.OutputPath = './coverage.xml'
+$config.CodeCoverage.OutputFormat = 'JaCoCo'
+Invoke-Pester -Configuration $config
+```
+
+CI gates fail the PR when line coverage drops below 65%. The gate doesn't auto-bump — raising it is a deliberate decision documented in CHANGELOG.
+
+### Why 65%
+
+Line coverage is a noisy metric on PowerShell modules dominated by external service calls. The 65% gate catches catastrophic regressions without forcing brittle "test the wrapper" coverage that adds little real safety. The complementary `tests/Behavior/` (post-C5 #784) tracks targeted behavioral coverage in a separate counter so the line-coverage number stays meaningful.
+
+---
+
+## Behavioral tests (post-C5)
+
+Once C5 #784 ships, `tests/Behavior/` will hold high-leverage assertions that don't always show up in line coverage:
+
+- `Permission-Map-Consistency.Tests.ps1` — every section in `AssessmentMaps.SectionScopeMap` has a populated scope list
+- `Status-Normalization.Tests.ps1` — every collector emits valid Status values from `Add-Setting`'s ValidateSet
+- `Check-Id-Uniqueness.Tests.ps1` — no duplicate base CheckIds in `controls/registry.json`
+- `Report-Math.Tests.ps1` — `Pass% = Pass / (Pass + Fail + Warning)` everywhere (#802 doc rule)
+- `Baseline-Drift.Tests.ps1` — drift comparison handles renamed/removed/added checks
+- `QuickScan-Filter.Tests.ps1` — `-QuickScan` returns the documented subset
+- `Cloud-Env-Mapping.Tests.ps1` — sovereign cloud env strings resolve to correct endpoints
+- `Module-Compat-Downgrade.Tests.ps1` — required-vs-optional module behavior on missing/wrong version
+
+CI surfaces a `behavior-tests` count separately from line-coverage so each is meaningful on its own.
+
+---
+
+## Cross-platform smoke (post-B6)
+
+`B6 #777` adds a `cross-platform-smoke` CI job running on `ubuntu-latest` and `macos-latest`. Steps:
+
+```powershell
+Import-Module ./src/M365-Assess
+Test-ModuleManifest -Path ./src/M365-Assess/M365-Assess.psd1
+# Generate a report from a checked-in fixture (no tenant calls)
+```
+
+Local equivalent:
+
+```bash
+pwsh -NoProfile -Command 'Import-Module ./src/M365-Assess; Test-ModuleManifest ./src/M365-Assess/M365-Assess.psd1'
+```
+
+The smoke lane catches platform-shaped bugs (path separators, case-sensitivity, missing modules) without running the full Windows-only Pester matrix.
+
+---
+
+## Testing the HTML report locally
+
+To verify report rendering without a live tenant:
+
+```bash
+# Build a swap-in test HTML using the existing sample report's REPORT_DATA + your latest JSX
+(head -n 21202 docs/sample-report/_Example-Report.html; \
+ cat src/M365-Assess/assets/report-app.js; \
+ tail -n +24526 docs/sample-report/_Example-Report.html) > _test.html
+```
+
+Then open `_test.html` in a browser. DevTools console should be clean. The "live test report before merging" rule in this project's `.claude/rules/` requires this for any PR touching `report-app.js`/`.jsx`/CSS.
+
+After:
+
+```powershell
+Remove-Item ./_test.html
+```
+
+---
+
+## Linting
+
+```powershell
+pwsh -NoProfile -Command "Invoke-ScriptAnalyzer -Path '.' -Recurse -Severity Warning -ExcludePath '.claude'"
+```
+
+CI runs PSScriptAnalyzer with `-Settings ./PSScriptAnalyzerSettings.psd1`. Severity Warning + Error fail the build; Information rules are advisory.
+
+Per-file:
+
+```powershell
+Invoke-ScriptAnalyzer -Path ./src/M365-Assess/Common/SecurityConfigHelper.ps1 -Settings ./PSScriptAnalyzerSettings.psd1
+```
+
+---
+
+## CI gate summary
+
+| Job | Triggers | What it checks |
+|---|---|---|
+| **Detect Changes** | Always | Routes between `code` (src/tests/workflow) and `docs` (md/json) filters |
+| **Quality Gates** | `code` | PSScriptAnalyzer, JS build (`npm run build`), Smoke tests, Permissions matrix in sync, Version consistency |
+| **Pester Tests (PS 7.4 + 7.6)** | `code` | Full Pester run with code coverage gate |
+| **Docs Gates** | `docs` only (when `code` doesn't match) | Lightweight version-consistency on doc-only PRs |
+| **CodeQL** | `code` | Semantic security analysis (JS + Actions) |
+| **CI status** | All | Aggregator; main branch protection requires `CI` to pass |
+
+The full Pester suite typically runs in ~3-4 minutes on CI; the docs lane finishes in ~30 seconds.
+
+---
+
+## Common test patterns
+
+### Parameterized tests (Pester 5.x)
+
+```powershell
+It 'should accept <Status> as a valid status' -ForEach @(
+    @{ Status = 'Pass' }
+    @{ Status = 'Fail' }
+    @{ Status = 'NotApplicable' }
+) {
+    { Add-SecuritySetting -Status $Status ... } | Should -Not -Throw
+}
+```
+
+### Asserting Pass% denominators
+
+```powershell
+$pass = ($settings | Where-Object Status -eq 'Pass').Count
+$fail = ($settings | Where-Object Status -eq 'Fail').Count
+$warn = ($settings | Where-Object Status -eq 'Warning').Count
+$pct  = if (($pass + $fail + $warn) -gt 0) { [math]::Round(100 * $pass / ($pass + $fail + $warn), 1) } else { 0 }
+$pct | Should -Be 46.2
+```
+
+(Per `docs/CHECK-STATUS-MODEL.md`'s denominator rule.)
+
+---
+
+## Related
+
+- `.claude/rules/pester.md` — internal Pester conventions for AI-assisted contributors
+- [`CHECK-STATUS-MODEL.md`](CHECK-STATUS-MODEL.md) — status semantics tested by `Status-Normalization.Tests.ps1`
+- [`PERMISSIONS.md`](PERMISSIONS.md) — section-to-scope map tested by `Permission-Map-Consistency.Tests.ps1`
+- [`RELEASE-PROCESS.md`](RELEASE-PROCESS.md) — version-consistency gate referenced above


### PR DESCRIPTION
## Summary

Sprint 5c — F6 + F7 paired. Two new contributor docs, no code.

## What ships

### `docs/TESTING.md` (~210 lines)
Practical contributor guide for running tests locally and understanding CI gates. Covers:
- Quick start commands (Pester 5.x, PS 7.4+)
- Test layout mirroring `src/M365-Assess/<Domain>/`
- Conventions: naming, dot-source patterns, mocking external cmdlets (with stub-when-missing pattern from #810), the Setting-not-CheckId filter rule
- Forward references to D5 #789 (fixtures), C5 #784 (behavioral tests), B6 #777 (cross-platform smoke)
- Coverage gate rationale (65%, why not higher)
- HTML report swap-in test pattern (from #803/#807 live-test rule)
- CI gate summary table
- Common test patterns (parameterized, denominator math from #802)

### `docs/RELEASE-PROCESS.md` (~190 lines)
Surfaces the internal release rules from `.claude/rules/` for outside contributors. Covers:
- Semver rules with concrete examples
- The 4 version locations (psd1 ModuleVersion + ReleaseNotes, README badge, CHANGELOG); psd1 is the runtime source of truth, CI verifies the others match
- CHANGELOG format (Keep a Changelog)
- 7-step release ritual: pre-flight → bump PR → merge → tag → GH release → close milestone → regenerate doc-as-code
- Branch protection (CI required, docs route to lightweight gate)
- Hotfix procedure
- #722 RC channel planned scope (out of v2.9.0)
- When-to-regenerate table for generated docs (`PERMISSIONS.md` today, `SOVEREIGN-CLOUDS.md` post-C2, `THIRD-PARTY-LICENSES.md` post-C4)

Closes #795 + #796.