### PR TITLE
feat(supply-chain): React provenance docs + npm audit advisory + license attribution (closes #783)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,23 @@ jobs:
           fi
           echo "JS build check passed — report-app.js matches Babel output"
 
+      - name: npm audit (advisory)
+        shell: bash
+        # C4 #783: surface HIGH-or-above advisories without blocking the PR.
+        # Babel devDependencies don't ship to end users; runtime React/ReactDOM
+        # are pinned + committed and not subject to transitive npm advisories.
+        # Rationale + cadence: docs/REPORT-FRONTEND.md.
+        run: |
+          set +e
+          npm audit --audit-level=high
+          AUDIT_EXIT=$?
+          set -e
+          if [ "$AUDIT_EXIT" -ne 0 ]; then
+            echo "::warning::npm audit found HIGH-or-above advisories (advisory; not blocking). See docs/REPORT-FRONTEND.md for the response cadence."
+          else
+            echo "npm audit: no HIGH-or-above advisories"
+          fi
+
       - name: Smoke tests
         shell: pwsh
         run: |

--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -1,0 +1,81 @@
+# Third-party licenses
+
+This document lists every third-party package shipped in the M365-Assess HTML report or used in the developer build chain. All current dependencies are MIT-licensed. Regenerate this file whenever the dep tree changes (see [`docs/REPORT-FRONTEND.md`](docs/REPORT-FRONTEND.md) and [`docs/RELEASE-PROCESS.md`](docs/RELEASE-PROCESS.md)).
+
+Last updated: 2026-04-26 for M365-Assess v2.9.0.
+
+---
+
+## Runtime — shipped in every HTML report
+
+These are inlined into the self-contained HTML report and execute in the end user's browser when the report is opened.
+
+### React
+
+- **Version:** 18.3.1
+- **Source:** https://unpkg.com/react@18.3.1/umd/react.production.min.js
+- **License:** MIT
+- **Copyright:** © Meta Platforms, Inc. and affiliates.
+- **License text:** [https://github.com/facebook/react/blob/main/LICENSE](https://github.com/facebook/react/blob/main/LICENSE)
+
+### ReactDOM
+
+- **Version:** 18.3.1
+- **Source:** https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js
+- **License:** MIT
+- **Copyright:** © Meta Platforms, Inc. and affiliates.
+- **License text:** [https://github.com/facebook/react/blob/main/LICENSE](https://github.com/facebook/react/blob/main/LICENSE)
+
+---
+
+## Developer tooling — not shipped to end users
+
+These run only at developer / CI time to transpile `report-app.jsx` → `report-app.js`. They never reach an end user's machine via the HTML report.
+
+### @babel/cli
+
+- **License:** MIT
+- **Repository:** https://github.com/babel/babel
+- **Used for:** running the transpile step (`npm run build`)
+
+### @babel/core
+
+- **License:** MIT
+- **Repository:** https://github.com/babel/babel
+- **Used for:** the Babel transpiler itself
+
+### @babel/preset-react
+
+- **License:** MIT
+- **Repository:** https://github.com/babel/babel
+- **Used for:** transforming JSX → `React.createElement(...)` calls
+
+Transitive dependencies of the Babel packages are also MIT or compatible (BSD-2-Clause / Apache-2.0). The full transitive tree is captured in `package-lock.json`; run `license-checker --production --json` against `node_modules/` for an exhaustive list.
+
+---
+
+## Microsoft licensing-service-plan reference data
+
+The bundled SKU friendly-names CSV (`src/M365-Assess/assets/sku-friendly-names.csv`) is a snapshot of Microsoft's published [Product names and service plan identifiers for licensing](https://learn.microsoft.com/en-us/entra/identity/users/licensing-service-plan-reference) reference. Microsoft publishes this under permissive use for licensing tooling. The runtime tries the live download first; the bundled copy is a fallback for offline / restricted environments.
+
+To refresh the bundled snapshot:
+
+```powershell
+pwsh -NoProfile -File ./src/M365-Assess/assets/Update-SkuCsv.ps1
+```
+
+---
+
+## License compliance summary
+
+| Component | License | Distributed to end users? |
+|---|---|---|
+| M365-Assess (this project) | MIT | ✅ |
+| React 18 | MIT | ✅ (inlined in HTML report) |
+| ReactDOM 18 | MIT | ✅ (inlined in HTML report) |
+| @babel/cli | MIT | ❌ (developer-only) |
+| @babel/core | MIT | ❌ (developer-only) |
+| @babel/preset-react | MIT | ❌ (developer-only) |
+| Microsoft SKU reference CSV | Permissive (Microsoft Learn) | ✅ (bundled snapshot, used as fallback) |
+
+All distributed components are MIT-licensed. M365-Assess itself ships under MIT — no copyleft obligations propagate.

--- a/docs/REPORT-FRONTEND.md
+++ b/docs/REPORT-FRONTEND.md
@@ -1,0 +1,123 @@
+# Report frontend
+
+How the M365-Assess HTML report's React app is sourced, built, and shipped.
+
+---
+
+## What ships in every report
+
+The HTML report is **self-contained** — a single `.html` file that runs in any modern browser with no network dependencies. Every dependency is inlined at report-generation time.
+
+| Asset | Source | License | Rendered at runtime? |
+|---|---|---|---|
+| React 18 (production build) | [react.production.min.js](https://unpkg.com/react@18.3.1/umd/react.production.min.js) | MIT | ✅ inlined |
+| ReactDOM 18 (production build) | [react-dom.production.min.js](https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js) | MIT | ✅ inlined |
+| `report-app.js` (compiled) | Babel-transpiled from `report-app.jsx` | MIT (own code) | ✅ inlined |
+| `report-shell.css` + `report-themes.css` | Hand-authored | MIT (own code) | ✅ inlined |
+
+Pinned versions live at `src/M365-Assess/assets/react.production.min.js` and `react-dom.production.min.js`. They're committed to the repo so the build is reproducible without npm at report-generation time.
+
+---
+
+## Build pipeline
+
+```
+report-app.jsx  ── babel ──>  report-app.js  ── inlined ──>  _Assessment-Report_<tenant>.html
+                  (transpile)                 (Get-ReportTemplate.ps1)
+```
+
+Babel runs only at developer time:
+
+```powershell
+npm install        # installs @babel/cli + @babel/core + @babel/preset-react
+npm run build      # transpiles JSX -> ES5-compatible JS
+```
+
+`report-app.js` is **committed** to the repo. CI's quality-gates job runs `npm run build` and `git diff` to verify the committed `.js` matches a fresh transpile of the `.jsx`. Any drift fails the PR with an explicit error pointing at the regen command.
+
+### Why React via plain `<script>` and not bundled
+
+`report-app.js` is concatenated into the HTML inside a plain `<script>` tag — no Webpack, no Rollup, no module bundler. Two reasons:
+
+1. **No JSX at runtime.** Babel transpiles JSX → `React.createElement(...)` calls. The browser parser doesn't need a JSX runtime.
+2. **Reproducible build minimum.** Adding a bundler would mean reproducible builds depend on bundler config, not just Babel + React versions. Keeping the runtime to "react production min + transpiled JSX" is the smallest defensible footprint.
+
+The cost: every component must use `React.createElement` semantics. JSX edited into `report-app.jsx` survives Babel transpile; raw JSX accidentally pasted into `report-app.js` causes a SyntaxError that blanks the entire report. CI's `node --check` step catches this. See `.claude/rules/` for the project-internal contributor rule.
+
+---
+
+## Pinning + reproducibility
+
+Production React/ReactDOM are committed at known SHA-pinned versions:
+
+```bash
+$ shasum -a 256 src/M365-Assess/assets/react.production.min.js
+$ shasum -a 256 src/M365-Assess/assets/react-dom.production.min.js
+```
+
+Update procedure when bumping React:
+
+1. Download the new pinned version from `unpkg.com/react@<version>/umd/react.production.min.js`
+2. Verify the SHA against the [npm package's published shasum](https://www.npmjs.com/package/react)
+3. Replace the file in `src/M365-Assess/assets/`
+4. Update this doc's table with the new version
+5. Test the report renders against `docs/sample-report/` per `.claude/rules/`'s "live test before merging" rule
+6. Update `THIRD-PARTY-LICENSES.md`'s React entry if anything material changed
+
+Babel deps (`devDependencies` in `package.json`) are pinned via `package-lock.json`. Update via `npm install <package>@<version> --save-dev` and commit the lock file change.
+
+---
+
+## Supply chain monitoring
+
+CI runs `npm audit --audit-level=high` as an **advisory** step (non-blocking) on every PR that modifies `package.json` or `package-lock.json`. Findings surface in the workflow log; a HIGH-or-above advisory is a signal to investigate but does not auto-fail the build.
+
+Why advisory rather than blocking: Babel devDependencies don't ship to end users. A vulnerability in `@babel/cli` is a developer-machine concern, not a runtime concern for the assessment report. Blocking PRs on advisories that don't affect runtime safety adds friction without commensurate security value.
+
+For genuine runtime concerns (e.g., a CVE in React itself), the bump procedure above applies and the PR description should call out the security driver in CHANGELOG.
+
+### Quarterly cadence
+
+Per the lockfile-hygiene rule (folded in from #678):
+
+- Quarterly: `npm install && npm audit`; review findings; commit any lockfile drift
+- Annually: revisit whether Dependabot + manual audit suffices, or whether a dedicated `npm-audit` workflow that opens issues on advisories would add value
+
+---
+
+## License attribution
+
+[`THIRD-PARTY-LICENSES.md`](../THIRD-PARTY-LICENSES.md) at the repo root lists every third-party license shipping in the HTML report or developer build chain. Maintained by hand today (the dep list is small); regenerate from `node_modules/` via `license-checker` if/when the surface grows:
+
+```powershell
+npm install -g license-checker
+license-checker --production --json | ConvertFrom-Json | Format-Table
+```
+
+The licenses doc updates in lockstep with the React/ReactDOM/Babel pinning above. Per `RELEASE-PROCESS.md`, regenerate on every minor or major version bump that changes the dep tree.
+
+---
+
+## Files
+
+| Path | Purpose |
+|---|---|
+| `src/M365-Assess/assets/react.production.min.js` | Pinned React 18 production build (committed) |
+| `src/M365-Assess/assets/react-dom.production.min.js` | Pinned ReactDOM 18 production build (committed) |
+| `src/M365-Assess/assets/report-app.jsx` | **Editable source** for the report's React app |
+| `src/M365-Assess/assets/report-app.js` | Babel-transpiled output of `.jsx`; committed; CI verifies sync |
+| `src/M365-Assess/assets/report-shell.css` | Base CSS (chip styles, layout, status badges) |
+| `src/M365-Assess/assets/report-themes.css` | Theme overrides (Neon, Vibe, Console, HighContrast) |
+| `src/M365-Assess/Common/Get-ReportTemplate.ps1` | PowerShell function that inlines all assets into the final HTML |
+| `package.json` | Babel devDependencies + `npm run build` script |
+| `package-lock.json` | Dependency lockfile; committed for reproducible builds |
+| `THIRD-PARTY-LICENSES.md` | License attribution (MIT for React/ReactDOM/Babel) |
+
+---
+
+## Related
+
+- [`REPORT-SCHEMA.md`](REPORT-SCHEMA.md) — the data shape the React app consumes
+- [`TESTING.md`](TESTING.md) — local report swap-in test pattern
+- [`RELEASE-PROCESS.md`](RELEASE-PROCESS.md) — when to regenerate THIRD-PARTY-LICENSES.md
+- `.claude/rules/` (internal) — JSX→JS sync rule, live-test-before-merge rule


### PR DESCRIPTION
Sprint 5e — last piece of the Sprint 5 docs cluster. Closes **C4 #783**.

## What ships

- `docs/REPORT-FRONTEND.md` — pinning + build pipeline + why-no-bundler + supply-chain cadence
- `THIRD-PARTY-LICENSES.md` (root) — React/ReactDOM 18.3.1 MIT, Babel devDeps MIT, all components MIT
- `.github/workflows/ci.yml` — new `npm audit (advisory)` step in quality-gates: runs after JS build check, emits `::warning::` on HIGH-or-above advisories, does NOT block the PR

Rationale for advisory-not-blocking: Babel devDependencies don't ship to end users (no runtime exposure); runtime React/ReactDOM are pinned + committed. Quarterly cadence documented in REPORT-FRONTEND.md (folds in the lockfile-hygiene work absorbed from #678).

## Test plan
- [x] All three files render correctly
- [x] CI yaml parses; npm audit step is structurally correct
- [ ] CI green (this PR touches `.github/workflows/ci.yml` so quality-gates + Pester run, but the only behavior change is the new advisory step)

Closes #783.