### PR TITLE
ci(smoke): Linux/macOS cross-platform smoke lane (closes #777)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,6 +334,42 @@ jobs:
           }
           Write-Host "Coverage gate passed" -ForegroundColor Green
 
+  cross-platform-smoke:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    name: Cross-Platform Smoke (${{ matrix.os }})
+    # B6 #777: catches platform-shaped bugs (path separators, case-sensitivity in
+    # dot-source paths, line endings) without paying the heavy install cost of
+    # Microsoft.Graph + EXO modules. Pester-on-Windows in `test` remains the
+    # source of truth; this lane just verifies that the parts of the module
+    # that DON'T require the Graph SDK still load on Linux + macOS.
+    #
+    # Advisory initially -- not part of the `ci-status` aggregator that drives
+    # branch protection. Promote to required by adding to `ci-status.needs`
+    # after one stable green run.
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Pester
+        shell: pwsh
+        run: |
+          Set-PSRepository PSGallery -InstallationPolicy Trusted
+          Install-Module Pester -Force -Scope CurrentUser -MinimumVersion 5.0.0
+
+      - name: Run cross-platform smoke
+        shell: pwsh
+        run: |
+          $config = New-PesterConfiguration
+          $config.Run.Path = './tests/Smoke/Cross-Platform.Tests.ps1'
+          $config.Run.Exit = $true
+          $config.Output.Verbosity = 'Detailed'
+          Invoke-Pester -Configuration $config
+
   ci-status:
     name: CI
     needs: [quality-gates, test, docs-gates]

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -172,21 +172,23 @@ CI surfaces a `behavior-tests` count separately from line-coverage so each is me
 
 ## Cross-platform smoke (post-B6)
 
-`B6 #777` adds a `cross-platform-smoke` CI job running on `ubuntu-latest` and `macos-latest`. Steps:
+`B6 #777` adds a `cross-platform-smoke` CI job running on `ubuntu-latest` and `macos-latest`. The job runs `tests/Smoke/Cross-Platform.Tests.ps1`, which exercises the parts of the module that don't require the Microsoft.Graph SDK:
 
-```powershell
-Import-Module ./src/M365-Assess
-Test-ModuleManifest -Path ./src/M365-Assess/M365-Assess.psd1
-# Generate a report from a checked-in fixture (no tenant calls)
-```
+- Manifest parses via `Import-PowerShellDataFile` on the current platform
+- `FileList` entries resolve case-correctly on Linux (case-sensitive filesystem)
+- `Import-ControlRegistry` + `Import-FrameworkDefinitions` succeed
+- `SecurityConfigHelper` contract works (Initialize / Add-SecuritySetting)
+- `Build-ReportDataJson` produces a well-formed `window.REPORT_DATA = {...};` from synthetic findings
 
 Local equivalent:
 
 ```bash
-pwsh -NoProfile -Command 'Import-Module ./src/M365-Assess; Test-ModuleManifest ./src/M365-Assess/M365-Assess.psd1'
+pwsh -NoProfile -Command "Invoke-Pester -Path './tests/Smoke/Cross-Platform.Tests.ps1' -Output Detailed"
 ```
 
-The smoke lane catches platform-shaped bugs (path separators, case-sensitivity, missing modules) without running the full Windows-only Pester matrix.
+The smoke lane is **advisory initially** — it runs on every PR and shows a check, but is not part of the `ci-status` aggregator that drives branch protection. Promote it to required by adding to `ci-status.needs` after one stable green run.
+
+It deliberately skips `Import-Module ./src/M365-Assess` and `Test-ModuleManifest` because those would require installing the entire Microsoft.Graph SDK + EXO + Purview module set on each platform (5–10 minutes per OS). Pester-on-Windows remains the source of truth for full integration; this lane just catches platform-shaped bugs (path separators, case-sensitivity in dot-source paths, line endings).
 
 ---
 

--- a/tests/Smoke/Cross-Platform.Tests.ps1
+++ b/tests/Smoke/Cross-Platform.Tests.ps1
@@ -1,0 +1,97 @@
+# tests/Smoke/Cross-Platform.Tests.ps1 — B6 #777
+#
+# Catches platform-shaped bugs (path separators, case-sensitivity in dot-source
+# paths, line-ending differences) without paying the heavy install cost of
+# Microsoft.Graph / ExchangeOnlineManagement / Microsoft.PowerApps modules.
+# Pester-on-Windows remains the source of truth; this lane just verifies that
+# the parts of the module that DON'T require the Graph SDK still load and
+# behave on Linux + macOS.
+
+BeforeAll {
+    $script:repoRoot   = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
+    $script:moduleRoot = Join-Path $script:repoRoot 'src/M365-Assess'
+    $script:manifestPath = Join-Path $script:moduleRoot 'M365-Assess.psd1'
+}
+
+Describe 'Cross-platform smoke (B6 #777)' {
+
+    Context 'Manifest parses without platform-specific assumptions' {
+        It 'should parse via Import-PowerShellDataFile on the current platform' {
+            $manifest = Import-PowerShellDataFile -Path $script:manifestPath
+            $manifest.ModuleVersion | Should -Match '^\d+\.\d+\.\d+$'
+            $manifest.RootModule    | Should -BeLike '*.psm1'
+        }
+
+        It 'FileList entries resolve case-correctly (Linux is case-sensitive)' {
+            $manifest = Import-PowerShellDataFile -Path $script:manifestPath
+            $missing = @()
+            foreach ($rel in $manifest.FileList) {
+                # The case of the file as listed in the manifest must match the
+                # case on disk. Linux runners reject mismatches that Windows + macOS
+                # silently accept, so a stale FileList entry surfaces here first.
+                $candidate = Join-Path $script:moduleRoot $rel
+                if (-not (Test-Path $candidate)) {
+                    $missing += $rel
+                }
+            }
+            if ($missing.Count -gt 0) {
+                throw "FileList contains $($missing.Count) entry(ies) that don't resolve on this platform:`n$(($missing | Select-Object -First 10) -join "`n")"
+            }
+        }
+    }
+
+    Context 'Control registry imports cleanly' {
+        It 'should load registry.json + framework JSONs without parse errors' {
+            . (Join-Path $script:moduleRoot 'Common/Import-ControlRegistry.ps1')
+            . (Join-Path $script:moduleRoot 'Common/Import-FrameworkDefinitions.ps1')
+
+            $registry = Import-ControlRegistry -ControlsPath (Join-Path $script:moduleRoot 'controls')
+            $registry | Should -Not -BeNullOrEmpty
+            $registry.Count | Should -BeGreaterThan 100
+
+            $frameworks = Import-FrameworkDefinitions -FrameworksPath (Join-Path $script:moduleRoot 'controls/frameworks')
+            $frameworks | Should -Not -BeNullOrEmpty
+            ($frameworks | Measure-Object).Count | Should -BeGreaterThan 5
+        }
+    }
+
+    Context 'SecurityConfigHelper contract works on this platform' {
+        It 'should accept findings via Add-SecuritySetting and export them' {
+            . (Join-Path $script:moduleRoot 'Common/SecurityConfigHelper.ps1')
+
+            $ctx = Initialize-SecurityConfig
+            Add-SecuritySetting -Settings $ctx.Settings -CheckIdCounter $ctx.CheckIdCounter `
+                -Category 'Smoke' -Setting 'cross-platform check' -CurrentValue 'ok' `
+                -RecommendedValue 'ok' -Status 'Pass' -CheckId 'SMOKE-001'
+
+            $ctx.Settings.Count | Should -Be 1
+            $ctx.Settings[0].Status | Should -Be 'Pass'
+            $ctx.Settings[0].CheckId | Should -Be 'SMOKE-001.1'
+        }
+    }
+
+    Context 'Build-ReportDataJson produces valid output from synthetic findings' {
+        It 'should emit a well-formed window.REPORT_DATA assignment without tenant calls' {
+            . (Join-Path $script:moduleRoot 'Common/Build-ReportData.ps1')
+
+            $synthetic = @(
+                [PSCustomObject]@{
+                    CheckId          = 'SMOKE-001.1'
+                    Category         = 'Smoke'
+                    Setting          = 'platform parity'
+                    CurrentValue     = 'ok'
+                    RecommendedValue = 'ok'
+                    Status           = 'Pass'
+                    Remediation      = ''
+                    Section          = 'Smoke'
+                }
+            )
+
+            $json = Build-ReportDataJson -AllFindings $synthetic
+            $json | Should -Not -BeNullOrEmpty
+            $json | Should -Match '^window\.REPORT_DATA\s*='
+            # The closing semicolon is required for the inline <script> contract.
+            $json.TrimEnd() | Should -Match ';\s*$'
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- New advisory CI job `cross-platform-smoke` runs on `ubuntu-latest` + `macos-latest` against `tests/Smoke/Cross-Platform.Tests.ps1` (5 tests)
- Exercises only the parts of the module that don't require the Microsoft.Graph SDK — catches path-separator bugs, Linux case-sensitivity, and line-ending divergence without paying the 5–10 minute install tax for Microsoft.Graph + EXO + Purview on each platform
- Intentionally **not** part of the `ci-status` aggregator — shows on every PR, doesn't block merge. Promote to required by adding to `ci-status.needs` after one stable green run

## What it asserts
- Manifest parses via `Import-PowerShellDataFile`
- `FileList` entries resolve case-correctly on Linux
- `Import-ControlRegistry` + `Import-FrameworkDefinitions` succeed
- `SecurityConfigHelper` (Initialize + Add-SecuritySetting) works
- `Build-ReportDataJson` emits well-formed `window.REPORT_DATA = {...};` from synthetic findings

## Test plan
- [x] `Invoke-Pester -Path './tests/Smoke/Cross-Platform.Tests.ps1'` — 5/5 green on Windows
- [ ] CI green on `ubuntu-latest`
- [ ] CI green on `macos-latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)