### PR TITLE
feat(evidence): standardized evidence schema (closes #785)

### DIFF
--- a/docs/EVIDENCE-MODEL.md
+++ b/docs/EVIDENCE-MODEL.md
@@ -1,0 +1,154 @@
+# Evidence Model (D1 #785)
+
+## What this is
+
+Every M365-Assess finding answers two questions: **what was checked** (the `Setting` and `CheckId`) and **what was found** (`Status`, `CurrentValue`). The evidence model adds a structured layer for the auditor's question: **how do you know?**
+
+Eight optional fields capture the provenance and confidence of each finding so a consultant can defend a result without re-running the assessment.
+
+---
+
+## The schema
+
+| Field | Type | Purpose |
+|---|---|---|
+| `ObservedValue` | `string` | Machine-readable representation of what the tenant returned. `CurrentValue` is the human-readable summary (e.g. `"Disabled"`); `ObservedValue` is the raw value (`"false"`, a GUID, a count). |
+| `ExpectedValue` | `string` | Machine-readable representation of what the benchmark expects. Companion to `ObservedValue`. |
+| `EvidenceSource` | `string` | The Graph endpoint, EXO cmdlet, or DNS query that produced the data (e.g. `Get-AdminAuditLogConfig`, `/identity/conditionalAccess/policies`, `_dmarc.contoso.com TXT`). |
+| `EvidenceTimestamp` | `string` | UTC ISO-8601 timestamp of when the upstream data was collected. **Leave empty** if the collector does not have a precise collection time -- do not synthesize one. |
+| `CollectionMethod` | `Direct` \| `Derived` \| `Inferred` \| `''` | How the value was determined. `Direct` = read straight from the API. `Derived` = computed from API output. `Inferred` = best-effort based on partial data. |
+| `PermissionRequired` | `string` | The Graph scope or RBAC role used to produce this finding (e.g. `Policy.Read.All`, `Exchange Online: View-Only Configuration`). Lets auditors verify the access path. |
+| `Confidence` | `double` (`0.0`-`1.0`, nullable) | Confidence in the finding. `null` = unspecified. Distinguishes "this is definitely Pass" (`1.0`) from "best-effort given missing scopes" (e.g. `0.6`). |
+| `Limitations` | `string` | Free-text note explaining caveats (e.g. *"Required Reports.Read.All which was not granted; counted user signins from /auditLogs/signIns instead"*). |
+
+All eight fields are **optional**. Existing collectors keep working without changes. New code can populate one, several, or all.
+
+---
+
+## How it flows
+
+```
+Collector
+  └─ calls Add-Setting / Add-SecuritySetting with evidence params
+        └─ helper builds PSCustomObject { Status, CheckId, ..., 8 evidence fields }
+              └─ Export-SecurityConfigReport writes per-collector CSV (one column per field)
+                    ├─ Build-ReportData reads the row, emits structured `evidence` object
+                    │     on window.REPORT_DATA.findings[].evidence (only non-empty fields)
+                    │       └─ React Appendix EvidenceBlock renders a per-field table
+                    └─ Export-ComplianceMatrix reads the row, populates Sheet 7 "Evidence Details"
+```
+
+Empty fields are dropped at every stage:
+
+- The CSV column is empty
+- `window.REPORT_DATA.findings[].evidence` omits the field from its object (or sets `evidence` itself to `null` if no field is populated)
+- The "Evidence Details" XLSX sheet only includes rows where at least one evidence field is populated
+
+This keeps the output lean for collectors that haven't migrated yet.
+
+---
+
+## When to populate which fields
+
+**Always populate when you have it:**
+
+- `EvidenceSource` -- if you called a specific Graph endpoint or EXO cmdlet, name it. Auditors trace claims back to APIs.
+- `PermissionRequired` -- the scope you needed. If you don't know offhand, leave empty rather than guess.
+
+**Populate when meaningful:**
+
+- `ObservedValue` / `ExpectedValue` -- when the comparison is the finding (most rule-based checks). Skip for narrative findings (`Info` rows that summarize multiple values).
+- `CollectionMethod` -- when the answer isn't obvious from `EvidenceSource`. A direct GET is usually `Direct`; if you're computing percentages or classifications, use `Derived`.
+
+**Populate only when relevant:**
+
+- `Confidence` -- when the assessment is best-effort. A direct API read with a Pass/Fail rule is typically `1.0`; if you're inferring from partial data because of throttling or missing permissions, use a lower value.
+- `Limitations` -- when the auditor needs to know about caveats. Examples: a permission you didn't have, a query you couldn't run, a tenant-specific quirk.
+- `EvidenceTimestamp` -- only if you have a true collection time from the upstream API. Don't synthesize `Get-Date` at the helper -- the timestamp would drift seconds-to-minutes for late-stage `Add-SecuritySetting` calls in long collectors.
+
+---
+
+## Migration cookbook
+
+To add structured evidence to an existing collector:
+
+### 1. Extend the local `Add-Setting` wrapper
+
+Most collectors thin-wrap `Add-SecuritySetting` with a local function. Add the eight new optional params and forward them:
+
+```powershell
+function Add-Setting {
+    param(
+        [string]$Category, [string]$Setting, [string]$CurrentValue,
+        [string]$RecommendedValue, [string]$Status,
+        [string]$CheckId = '', [string]$Remediation = '',
+        [PSCustomObject]$Evidence = $null,
+        # D1 #785
+        [string]$ObservedValue = '',
+        [string]$ExpectedValue = '',
+        [string]$EvidenceSource = '',
+        [string]$EvidenceTimestamp = '',
+        [ValidateSet('', 'Direct', 'Derived', 'Inferred')]
+        [string]$CollectionMethod = '',
+        [string]$PermissionRequired = '',
+        [Nullable[double]]$Confidence = $null,
+        [string]$Limitations = ''
+    )
+    Add-SecuritySetting -Settings $settings -CheckIdCounter $checkIdCounter `
+        -Category $Category -Setting $Setting -CurrentValue $CurrentValue `
+        -RecommendedValue $RecommendedValue -Status $Status `
+        -CheckId $CheckId -Remediation $Remediation -Evidence $Evidence `
+        -ObservedValue $ObservedValue -ExpectedValue $ExpectedValue `
+        -EvidenceSource $EvidenceSource -EvidenceTimestamp $EvidenceTimestamp `
+        -CollectionMethod $CollectionMethod -PermissionRequired $PermissionRequired `
+        -Confidence $Confidence -Limitations $Limitations
+}
+```
+
+### 2. Populate at the call sites where it matters
+
+You don't need to migrate every call. Pick the high-signal checks (e.g. ones an auditor is likely to ask about):
+
+```powershell
+$settingParams = @{
+    Category           = 'Authentication'
+    Setting            = 'Modern Authentication Enabled'
+    CurrentValue       = "$modernAuth"
+    RecommendedValue   = 'True'
+    Status             = if ($modernAuth) { 'Pass' } else { 'Fail' }
+    CheckId            = 'EXO-AUTH-001'
+    # D1 evidence
+    ObservedValue      = [string][bool]$modernAuth
+    ExpectedValue      = 'True'
+    EvidenceSource     = 'Get-OrganizationConfig'
+    CollectionMethod   = 'Direct'
+    PermissionRequired = 'Exchange Online: View-Only Configuration'
+    Confidence         = 1.0
+}
+Add-Setting @settingParams
+```
+
+### 3. Don't fabricate
+
+If you don't know the `EvidenceSource`, leave it empty. Empty fields disappear from the report; fabricated fields mislead auditors. The schema rewards honesty about gaps via `Limitations`, not coverage theatre.
+
+---
+
+## Reference: collectors that already populate evidence
+
+As of v2.9.0:
+
+- `src/M365-Assess/Security/DefenderAntiPhishingChecks.ps1` -- phishing threshold check
+- `src/M365-Assess/Exchange-Online/Get-ExoSecurityConfig.ps1` -- modern auth + audit config
+- `src/M365-Assess/Entra/EntraConditionalAccessChecks.ps1` -- enabled CA policy count (covers MFA-via-CA scope)
+- `src/M365-Assess/Intune/Get-IntuneSecurityConfig.ps1` -- non-compliant default threshold
+
+Future minor releases will adopt the schema in remaining collectors at their own pace -- no coordinated cutover required.
+
+---
+
+## See also
+
+- `docs/CHECK-STATUS-MODEL.md` -- the Pass/Fail/Warning/Review/Info/Skipped/Unknown/NotApplicable/NotLicensed taxonomy these findings live within
+- `docs/REPORT-SCHEMA.md` -- the full `window.REPORT_DATA` shape, including how `evidence` slots into `findings[]`
+- `docs/EVIDENCE-PACKAGE.md` -- the `-EvidencePackage` ZIP format that bundles structured evidence for auditor handoff (D4 #788)

--- a/docs/REPORT-SCHEMA.md
+++ b/docs/REPORT-SCHEMA.md
@@ -128,11 +128,32 @@ Every entry in `findings[]` follows this shape:
     "cmmc":   { "controlId": "IA.L2-3.5.3", "profiles": ["L2"] },
     "nist-800-53-r5": { "controlId": "IA-2", "profiles": [] }
   },
-  "references":      [ /* learn-more links from registry */ ]
+  "references":      [ /* learn-more links from registry */ ],
+  "evidence":        { /* optional; D1 #785 -- see Evidence object below */ }
 }
 ```
 
 **Sub-numbering**: a single registry CheckId (`ENTRA-MFA-001`) emits multiple finding rows when the collector inspects the same control in multiple ways. The React app strips trailing `.\d+` to find registry metadata: `baseCheckId = checkId.replace(/\.\d+$/, '')`.
+
+## Evidence object (optional, D1 #785)
+
+When a collector populates any of the structured evidence fields on `Add-SecuritySetting`, `findings[].evidence` is a structured object. When no evidence field is populated, it is `null` (or omitted entirely from the JSON). Consumers should branch on the property's truthiness, not its type.
+
+```jsonc
+{
+  "observedValue":      "false",                                    // machine-readable
+  "expectedValue":      "true",
+  "evidenceSource":     "Get-OrganizationConfig",                   // API/cmdlet/endpoint
+  "evidenceTimestamp":  "2026-04-26T10:00:00Z",                     // UTC ISO-8601 (optional)
+  "collectionMethod":   "Direct",                                   // Direct | Derived | Inferred
+  "permissionRequired": "Exchange Online: View-Only Configuration", // scope or RBAC role
+  "confidence":         1.0,                                        // 0.0-1.0
+  "limitations":        "Org-level audit ≠ active UAL flow",        // free-text caveat
+  "raw":                "{...}"                                     // legacy free-form blob (JSON string)
+}
+```
+
+Empty fields are omitted (so a finding that only sets `EvidenceSource` and `PermissionRequired` produces an object with just those two keys). The `raw` subfield carries the legacy `Add-SecuritySetting -Evidence` blob from collectors that haven't migrated to the structured schema; new collectors should prefer the typed fields. See [`EVIDENCE-MODEL.md`](EVIDENCE-MODEL.md) for the field reference and migration cookbook.
 
 ## Status semantics
 

--- a/src/M365-Assess/Common/Build-ReportData.ps1
+++ b/src/M365-Assess/Common/Build-ReportData.ps1
@@ -157,9 +157,30 @@ function Build-ReportDataJson {
                      } else { @() }
         $impact     = if ($regEntry) { $regEntry.impact }    else { $null }
         $rationale  = if ($regEntry) { $regEntry.rationale } else { $null }
-        $evidence  = if ($f.PSObject.Properties['Evidence'] -and $null -ne $f.Evidence) {
-                         $f.Evidence | ConvertTo-Json -Depth 5 -Compress
-                     } else { $null }
+        # D1 #785 -- structured evidence schema. Emit a typed object so the React
+        # appendix can render a per-field table; preserve legacy free-form Evidence
+        # blob under .raw for backwards compat with collectors that haven't migrated.
+        $evidence = $null
+        $hasStructured = $false
+        $structured = [ordered]@{}
+        foreach ($field in @('ObservedValue','ExpectedValue','EvidenceSource','EvidenceTimestamp','CollectionMethod','PermissionRequired','Confidence','Limitations')) {
+            if ($f.PSObject.Properties[$field]) {
+                $val = $f.$field
+                $isEmpty = ($null -eq $val) -or ($val -is [string] -and [string]::IsNullOrWhiteSpace($val))
+                if (-not $isEmpty) {
+                    $structured[([char]::ToLower($field[0])) + $field.Substring(1)] = $val
+                    $hasStructured = $true
+                }
+            }
+        }
+        $rawEvidence = if ($f.PSObject.Properties['Evidence'] -and $null -ne $f.Evidence) {
+                           $f.Evidence | ConvertTo-Json -Depth 5 -Compress
+                       } else { $null }
+        if ($hasStructured -or $rawEvidence) {
+            $evidence = [ordered]@{}
+            foreach ($k in $structured.Keys) { $evidence[$k] = $structured[$k] }
+            if ($rawEvidence) { $evidence['raw'] = $rawEvidence }
+        }
 
         $effort = if ($regEntry) { $e = if ($regEntry -is [hashtable]) { $regEntry['effort'] } else { $regEntry.effort }; if ($e) { $e } else { 'medium' } } else { 'medium' }
 

--- a/src/M365-Assess/Common/Export-ComplianceMatrix.ps1
+++ b/src/M365-Assess/Common/Export-ComplianceMatrix.ps1
@@ -3,11 +3,14 @@
     Exports compliance overview data as a formatted XLSX workbook.
 .DESCRIPTION
     Reads security config CSVs from an assessment folder, looks up each CheckId
-    in the control registry, and generates an XLSX file with up to four sheets:
+    in the control registry, and generates an XLSX file with up to seven sheets:
       Sheet 1 - Compliance Matrix (one row per check; framework columns + SCF impact/domain)
       Sheet 2 - Summary (pass/fail counts and coverage per framework)
       Sheet 3 - Grouped by Profile (CIS M365 profile-level breakdown)
       Sheet 4 - Verification (one row per SCF assessment objective -- audit guidance)
+      Sheet 5 - Remediation Roadmap (Now/Next/Later view; only when findings need fixing)
+      Sheet 6 - Drift (only when -CompareBaseline was passed)
+      Sheet 7 - Evidence Details (D1 #785; one row per finding with structured evidence)
     Framework columns are auto-discovered from JSON definitions in controls/frameworks/.
     SCF impact and verification data require CheckID v2.0.0 registry entries.
     Requires the ImportExcel module. If not available, logs a warning and returns.
@@ -109,6 +112,10 @@ $summary = Import-Csv -Path $summaryFile.FullName
 # Scan CSVs and build findings with dynamic framework columns
 # ------------------------------------------------------------------
 $findings = [System.Collections.Generic.List[PSCustomObject]]::new()
+# D1 #785 -- parallel collection of structured evidence per finding. Populated only
+# for rows where at least one evidence field is non-empty; surfaced on Sheet 5.
+$evidenceRows = [System.Collections.Generic.List[PSCustomObject]]::new()
+$evidenceFieldNames = @('ObservedValue','ExpectedValue','EvidenceSource','EvidenceTimestamp','CollectionMethod','PermissionRequired','Confidence','Limitations')
 
 foreach ($c in $summary) {
     if ($c.Status -ne 'Complete' -or [int]$c.Items -eq 0) { continue }
@@ -123,6 +130,31 @@ foreach ($c in $summary) {
 
     foreach ($row in $data) {
         if (-not $row.CheckId -or $row.CheckId -eq '') { continue }
+
+        # D1 #785 -- collect rows with structured evidence for the dedicated sheet
+        $hasEvidence = $false
+        foreach ($f in $evidenceFieldNames) {
+            if ($columns -contains $f -and -not [string]::IsNullOrWhiteSpace($row.$f)) {
+                $hasEvidence = $true
+                break
+            }
+        }
+        if ($hasEvidence) {
+            $evidenceRows.Add([PSCustomObject][ordered]@{
+                CheckId            = $row.CheckId
+                Setting            = $row.Setting
+                Status             = $row.Status
+                ObservedValue      = if ($columns -contains 'ObservedValue')      { $row.ObservedValue }      else { '' }
+                ExpectedValue      = if ($columns -contains 'ExpectedValue')      { $row.ExpectedValue }      else { '' }
+                EvidenceSource     = if ($columns -contains 'EvidenceSource')     { $row.EvidenceSource }     else { '' }
+                EvidenceTimestamp  = if ($columns -contains 'EvidenceTimestamp')  { $row.EvidenceTimestamp }  else { '' }
+                CollectionMethod   = if ($columns -contains 'CollectionMethod')   { $row.CollectionMethod }   else { '' }
+                PermissionRequired = if ($columns -contains 'PermissionRequired') { $row.PermissionRequired } else { '' }
+                Confidence         = if ($columns -contains 'Confidence')         { $row.Confidence }         else { '' }
+                Limitations        = if ($columns -contains 'Limitations')        { $row.Limitations }        else { '' }
+            })
+        }
+
         $baseCheckId = $row.CheckId -replace '\.\d+$', ''
         $entry = if ($controlRegistry.ContainsKey($baseCheckId)) { $controlRegistry[$baseCheckId] } else { $null }
         $fw = if ($entry) { $entry.frameworks } else { @{} }
@@ -583,6 +615,25 @@ if ($DriftReport -and $DriftReport.Count -gt 0) {
         TableStyle    = 'Medium2'
     }
     $driftRows | Export-Excel @driftParams
+}
+
+# ------------------------------------------------------------------
+# Sheet - Evidence Details (D1 #785)
+# One row per finding with at least one structured evidence field populated.
+# Kept on a dedicated sheet so the main Compliance Matrix stays scannable for
+# compliance leaders who only need CheckId/Status/framework mappings.
+# ------------------------------------------------------------------
+if ($evidenceRows -and @($evidenceRows).Count -gt 0) {
+    $evidenceParams = @{
+        Path          = $outputFile
+        WorksheetName = 'Evidence Details'
+        AutoSize      = $true
+        AutoFilter    = $true
+        FreezeTopRow  = $true
+        BoldTopRow    = $true
+        TableStyle    = 'Medium3'
+    }
+    $evidenceRows | Export-Excel @evidenceParams
 }
 
 # ------------------------------------------------------------------

--- a/src/M365-Assess/Common/SecurityConfigHelper.ps1
+++ b/src/M365-Assess/Common/SecurityConfigHelper.ps1
@@ -64,6 +64,30 @@ function Add-SecuritySetting {
         Guidance for fixing a non-passing result.
     .PARAMETER Evidence
         Optional structured evidence object attached to the finding (serialized to JSON in the report).
+        Free-form -- prefer the typed evidence fields below for new code.
+    .PARAMETER ObservedValue
+        Machine-readable representation of what the tenant returned. CurrentValue is the
+        human-readable summary; ObservedValue is the raw value (e.g. boolean, GUID, count).
+    .PARAMETER ExpectedValue
+        Machine-readable representation of what the benchmark expects. Companion to ObservedValue.
+    .PARAMETER EvidenceSource
+        The Graph endpoint, EXO cmdlet, or DNS query that produced the data
+        (e.g. 'Get-AdminAuditLogConfig', '/identity/conditionalAccess/policies').
+    .PARAMETER EvidenceTimestamp
+        UTC ISO-8601 timestamp of when the upstream data was collected. Leave empty
+        if the collector does not have a precise collection time -- do not synthesize one.
+    .PARAMETER CollectionMethod
+        How the value was determined: 'Direct' (read from API), 'Derived' (computed
+        from API output), or 'Inferred' (best-effort based on partial data).
+    .PARAMETER PermissionRequired
+        The Graph scope or RBAC role used to produce this finding (e.g. 'Policy.Read.All',
+        'Exchange Online: View-Only Configuration'). Lets auditors verify the access path.
+    .PARAMETER Confidence
+        Number from 0.0 to 1.0 indicating confidence in the finding. Null = unspecified.
+        Distinguishes 'this is definitely Pass' (1.0) from 'best-effort given missing scopes' (e.g. 0.6).
+    .PARAMETER Limitations
+        Free-text note explaining caveats (e.g. 'Required Reports.Read.All which was not
+        granted; counted user signins from /auditLogs/signIns instead').
     #>
     [CmdletBinding()]
     param(
@@ -103,8 +127,41 @@ function Add-SecuritySetting {
         [switch]$IntentDesign,
 
         [Parameter()]
-        [PSCustomObject]$Evidence = $null
+        [PSCustomObject]$Evidence = $null,
+
+        # D1 #785 -- standardized evidence schema (all optional; empty by default)
+        [Parameter()]
+        [string]$ObservedValue = '',
+
+        [Parameter()]
+        [string]$ExpectedValue = '',
+
+        [Parameter()]
+        [string]$EvidenceSource = '',
+
+        [Parameter()]
+        [string]$EvidenceTimestamp = '',
+
+        [Parameter()]
+        [ValidateSet('', 'Direct', 'Derived', 'Inferred')]
+        [string]$CollectionMethod = '',
+
+        [Parameter()]
+        [string]$PermissionRequired = '',
+
+        [Parameter()]
+        [Nullable[double]]$Confidence = $null,
+
+        [Parameter()]
+        [string]$Limitations = ''
     )
+
+    # D1 #785 -- validate Confidence range manually so the [Nullable[double]] default
+    # of $null does not trip ValidateRange (which rejects null on PS 7.x).
+    if ($null -ne $Confidence -and ($Confidence -lt 0.0 -or $Confidence -gt 1.0)) {
+        throw [System.Management.Automation.ValidationMetadataException]::new(
+            "Confidence must be between 0.0 and 1.0 (or omitted). Received: $Confidence")
+    }
 
     # Auto-generate sub-numbered CheckId for individual setting traceability
     $subCheckId = $CheckId
@@ -124,15 +181,23 @@ function Add-SecuritySetting {
     }
 
     $Settings.Add([PSCustomObject]@{
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $subCheckId
-        Remediation      = $Remediation
-        IntentDesign     = [bool]$IntentDesign
-        Evidence         = $Evidence
+        Category           = $Category
+        Setting            = $Setting
+        CurrentValue       = $CurrentValue
+        RecommendedValue   = $RecommendedValue
+        Status             = $Status
+        CheckId            = $subCheckId
+        Remediation        = $Remediation
+        IntentDesign       = [bool]$IntentDesign
+        Evidence           = $Evidence
+        ObservedValue      = $ObservedValue
+        ExpectedValue      = $ExpectedValue
+        EvidenceSource     = $EvidenceSource
+        EvidenceTimestamp  = $EvidenceTimestamp
+        CollectionMethod   = $CollectionMethod
+        PermissionRequired = $PermissionRequired
+        Confidence         = $Confidence
+        Limitations        = $Limitations
     })
 
     # Accumulate adoption signal for Value Opportunity analysis

--- a/src/M365-Assess/Entra/EntraConditionalAccessChecks.ps1
+++ b/src/M365-Assess/Entra/EntraConditionalAccessChecks.ps1
@@ -33,13 +33,20 @@ try {
     Add-Setting @settingParams
 
     $settingParams = @{
-        Category         = 'Conditional Access'
-        Setting          = 'Enabled CA Policies'
-        CurrentValue     = "$enabledCount"
-        RecommendedValue = '1+'
-        Status           = $(if ($enabledCount -gt 0) { 'Pass' } else { 'Warning' })
-        CheckId          = 'ENTRA-CA-003'
-        Remediation      = 'Run: Get-MgIdentityConditionalAccessPolicy | Where-Object {$_.State -eq ''enabled''}. Ensure policies are set to On, not Report-only.'
+        Category           = 'Conditional Access'
+        Setting            = 'Enabled CA Policies'
+        CurrentValue       = "$enabledCount"
+        RecommendedValue   = '1+'
+        Status             = $(if ($enabledCount -gt 0) { 'Pass' } else { 'Warning' })
+        CheckId            = 'ENTRA-CA-003'
+        Remediation        = 'Run: Get-MgIdentityConditionalAccessPolicy | Where-Object {$_.State -eq ''enabled''}. Ensure policies are set to On, not Report-only.'
+        # D1 #785 -- structured evidence
+        ObservedValue      = [string]$enabledCount
+        ExpectedValue      = '>=1'
+        EvidenceSource     = '/identity/conditionalAccess/policies'
+        CollectionMethod   = 'Direct'
+        PermissionRequired = 'Policy.Read.All'
+        Confidence         = 1.0
     }
     Add-Setting @settingParams
 

--- a/src/M365-Assess/Entra/Get-CASecurityConfig.ps1
+++ b/src/M365-Assess/Entra/Get-CASecurityConfig.ps1
@@ -46,19 +46,37 @@ function Add-Setting {
         [string]$Category, [string]$Setting, [string]$CurrentValue,
         [string]$RecommendedValue, [string]$Status,
         [string]$CheckId = '', [string]$Remediation = '',
-        [PSCustomObject]$Evidence = $null
+        [PSCustomObject]$Evidence = $null,
+        # D1 #785 -- structured evidence schema
+        [string]$ObservedValue = '',
+        [string]$ExpectedValue = '',
+        [string]$EvidenceSource = '',
+        [string]$EvidenceTimestamp = '',
+        [ValidateSet('', 'Direct', 'Derived', 'Inferred')]
+        [string]$CollectionMethod = '',
+        [string]$PermissionRequired = '',
+        [Nullable[double]]$Confidence = $null,
+        [string]$Limitations = ''
     )
     $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-        Evidence         = $Evidence
+        Settings           = $settings
+        CheckIdCounter     = $checkIdCounter
+        Category           = $Category
+        Setting            = $Setting
+        CurrentValue       = $CurrentValue
+        RecommendedValue   = $RecommendedValue
+        Status             = $Status
+        CheckId            = $CheckId
+        Remediation        = $Remediation
+        Evidence           = $Evidence
+        ObservedValue      = $ObservedValue
+        ExpectedValue      = $ExpectedValue
+        EvidenceSource     = $EvidenceSource
+        EvidenceTimestamp  = $EvidenceTimestamp
+        CollectionMethod   = $CollectionMethod
+        PermissionRequired = $PermissionRequired
+        Confidence         = $Confidence
+        Limitations        = $Limitations
     }
     Add-SecuritySetting @p
 }

--- a/src/M365-Assess/Exchange-Online/Get-ExoSecurityConfig.ps1
+++ b/src/M365-Assess/Exchange-Online/Get-ExoSecurityConfig.ps1
@@ -45,19 +45,37 @@ function Add-Setting {
         [ValidateSet('Pass', 'Fail', 'Warning', 'Review', 'Info', 'Skipped', 'Unknown')]
         [string]$Status,
         [string]$CheckId = '', [string]$Remediation = '',
-        [PSCustomObject]$Evidence = $null
+        [PSCustomObject]$Evidence = $null,
+        # D1 #785 -- structured evidence schema
+        [string]$ObservedValue = '',
+        [string]$ExpectedValue = '',
+        [string]$EvidenceSource = '',
+        [string]$EvidenceTimestamp = '',
+        [ValidateSet('', 'Direct', 'Derived', 'Inferred')]
+        [string]$CollectionMethod = '',
+        [string]$PermissionRequired = '',
+        [Nullable[double]]$Confidence = $null,
+        [string]$Limitations = ''
     )
     $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-        Evidence         = $Evidence
+        Settings           = $settings
+        CheckIdCounter     = $checkIdCounter
+        Category           = $Category
+        Setting            = $Setting
+        CurrentValue       = $CurrentValue
+        RecommendedValue   = $RecommendedValue
+        Status             = $Status
+        CheckId            = $CheckId
+        Remediation        = $Remediation
+        Evidence           = $Evidence
+        ObservedValue      = $ObservedValue
+        ExpectedValue      = $ExpectedValue
+        EvidenceSource     = $EvidenceSource
+        EvidenceTimestamp  = $EvidenceTimestamp
+        CollectionMethod   = $CollectionMethod
+        PermissionRequired = $PermissionRequired
+        Confidence         = $Confidence
+        Limitations        = $Limitations
     }
     Add-SecuritySetting @p
 }
@@ -72,29 +90,43 @@ try {
     # Modern Authentication
     $modernAuth = $orgConfig.OAuth2ClientProfileEnabled
     $settingParams = @{
-        Category         = 'Authentication'
-        Setting          = 'Modern Authentication Enabled'
-        CurrentValue     = "$modernAuth"
-        RecommendedValue = 'True'
-        Status           = if ($modernAuth) { 'Pass' } else { 'Fail' }
-        CheckId          = 'EXO-AUTH-001'
-        Remediation      = 'Exchange admin center > Settings > Modern authentication > Enable. Run: Set-OrganizationConfig -OAuth2ClientProfileEnabled $true'
-        Evidence         = [PSCustomObject]@{
+        Category           = 'Authentication'
+        Setting            = 'Modern Authentication Enabled'
+        CurrentValue       = "$modernAuth"
+        RecommendedValue   = 'True'
+        Status             = if ($modernAuth) { 'Pass' } else { 'Fail' }
+        CheckId            = 'EXO-AUTH-001'
+        Remediation        = 'Exchange admin center > Settings > Modern authentication > Enable. Run: Set-OrganizationConfig -OAuth2ClientProfileEnabled $true'
+        Evidence           = [PSCustomObject]@{
             OAuth2ClientProfileEnabled = [bool]$modernAuth
         }
+        # D1 #785 -- structured evidence
+        ObservedValue      = [string][bool]$modernAuth
+        ExpectedValue      = 'True'
+        EvidenceSource     = 'Get-OrganizationConfig'
+        CollectionMethod   = 'Direct'
+        PermissionRequired = 'Exchange Online: View-Only Configuration'
+        Confidence         = 1.0
     }
     Add-Setting @settingParams
 
     # Audit Enabled
     $auditEnabled = $orgConfig.AuditDisabled
     $settingParams = @{
-        Category         = 'Auditing'
-        Setting          = 'Exchange Org Audit Config'
-        CurrentValue     = "$(if ($auditEnabled) { 'Disabled' } else { 'Enabled' })"
-        RecommendedValue = 'Enabled'
-        Status           = if (-not $auditEnabled) { 'Pass' } else { 'Fail' }
-        CheckId          = 'EXO-AUDIT-001'
-        Remediation      = 'Run: Set-OrganizationConfig -AuditDisabled $false. Note: this is the Exchange org-level audit flag and is a pre-condition for UAL, but does not guarantee UAL ingestion is active. Verify UAL separately (COMPLIANCE-AUDIT-001).'
+        Category           = 'Auditing'
+        Setting            = 'Exchange Org Audit Config'
+        CurrentValue       = "$(if ($auditEnabled) { 'Disabled' } else { 'Enabled' })"
+        RecommendedValue   = 'Enabled'
+        Status             = if (-not $auditEnabled) { 'Pass' } else { 'Fail' }
+        CheckId            = 'EXO-AUDIT-001'
+        Remediation        = 'Run: Set-OrganizationConfig -AuditDisabled $false. Note: this is the Exchange org-level audit flag and is a pre-condition for UAL, but does not guarantee UAL ingestion is active. Verify UAL separately (COMPLIANCE-AUDIT-001).'
+        ObservedValue      = if ($auditEnabled) { 'Disabled' } else { 'Enabled' }
+        ExpectedValue      = 'Enabled'
+        EvidenceSource     = 'Get-OrganizationConfig'
+        CollectionMethod   = 'Direct'
+        PermissionRequired = 'Exchange Online: View-Only Configuration'
+        Confidence         = 1.0
+        Limitations        = 'Org-level audit is a pre-condition for UAL ingestion but does not guarantee active UAL flow; verify via COMPLIANCE-AUDIT-001.'
     }
     Add-Setting @settingParams
 

--- a/src/M365-Assess/Intune/Get-IntuneSecurityConfig.ps1
+++ b/src/M365-Assess/Intune/Get-IntuneSecurityConfig.ps1
@@ -45,18 +45,36 @@ function Add-Setting {
     param(
         [string]$Category, [string]$Setting, [string]$CurrentValue,
         [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = ''
+        [string]$CheckId = '', [string]$Remediation = '',
+        # D1 #785 -- structured evidence schema
+        [string]$ObservedValue = '',
+        [string]$ExpectedValue = '',
+        [string]$EvidenceSource = '',
+        [string]$EvidenceTimestamp = '',
+        [ValidateSet('', 'Direct', 'Derived', 'Inferred')]
+        [string]$CollectionMethod = '',
+        [string]$PermissionRequired = '',
+        [Nullable[double]]$Confidence = $null,
+        [string]$Limitations = ''
     )
     $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
+        Settings           = $settings
+        CheckIdCounter     = $checkIdCounter
+        Category           = $Category
+        Setting            = $Setting
+        CurrentValue       = $CurrentValue
+        RecommendedValue   = $RecommendedValue
+        Status             = $Status
+        CheckId            = $CheckId
+        Remediation        = $Remediation
+        ObservedValue      = $ObservedValue
+        ExpectedValue      = $ExpectedValue
+        EvidenceSource     = $EvidenceSource
+        EvidenceTimestamp  = $EvidenceTimestamp
+        CollectionMethod   = $CollectionMethod
+        PermissionRequired = $PermissionRequired
+        Confidence         = $Confidence
+        Limitations        = $Limitations
     }
     Add-SecuritySetting @p
 }
@@ -77,13 +95,20 @@ try {
     # A low threshold (or specific config) means devices are flagged quickly
     if ($null -ne $markNonCompliant) {
         $settingParams = @{
-            Category         = 'Device Compliance'
-            Setting          = 'Non-Compliant Default Threshold'
-            CurrentValue     = "$markNonCompliant days"
-            RecommendedValue = 'Devices without policy marked non-compliant'
-            Status           = if ([int]$markNonCompliant -le 30) { 'Pass' } else { 'Warning' }
-            CheckId          = 'INTUNE-COMPLIANCE-001'
-            Remediation      = 'Intune admin center > Devices > Compliance > Compliance policy settings > Mark devices with no compliance policy assigned as > Not compliant.'
+            Category           = 'Device Compliance'
+            Setting            = 'Non-Compliant Default Threshold'
+            CurrentValue       = "$markNonCompliant days"
+            RecommendedValue   = 'Devices without policy marked non-compliant'
+            Status             = if ([int]$markNonCompliant -le 30) { 'Pass' } else { 'Warning' }
+            CheckId            = 'INTUNE-COMPLIANCE-001'
+            Remediation        = 'Intune admin center > Devices > Compliance > Compliance policy settings > Mark devices with no compliance policy assigned as > Not compliant.'
+            # D1 #785 -- structured evidence
+            ObservedValue      = [string][int]$markNonCompliant
+            ExpectedValue      = '<=30'
+            EvidenceSource     = '/deviceManagement/settings'
+            CollectionMethod   = 'Direct'
+            PermissionRequired = 'DeviceManagementConfiguration.Read.All'
+            Confidence         = 1.0
         }
         Add-Setting @settingParams
     }

--- a/src/M365-Assess/Security/DefenderAntiPhishingChecks.ps1
+++ b/src/M365-Assess/Security/DefenderAntiPhishingChecks.ps1
@@ -37,18 +37,25 @@ try {
         $threshold = $policy.PhishThresholdLevel
         $mailboxIntelligence = [bool]$policy.EnableMailboxIntelligence
         $settingParams = @{
-            Category         = 'Anti-Phishing'
-            Setting          = "Phishing Threshold ($policyLabel)"
-            CurrentValue     = "$threshold"
-            RecommendedValue = '2+ (Aggressive)'
-            Status           = if ([int]$threshold -ge 2) { 'Pass' } else { 'Fail' }
-            CheckId          = 'DEFENDER-ANTIPHISH-001'
-            Remediation      = 'Run: Set-AntiPhishPolicy -Identity <PolicyName> -PhishThresholdLevel 2. Security admin center > Anti-phishing > Edit policy > Set threshold to 2 (Aggressive) or higher.'
-            Evidence         = [PSCustomObject]@{
+            Category           = 'Anti-Phishing'
+            Setting            = "Phishing Threshold ($policyLabel)"
+            CurrentValue       = "$threshold"
+            RecommendedValue   = '2+ (Aggressive)'
+            Status             = if ([int]$threshold -ge 2) { 'Pass' } else { 'Fail' }
+            CheckId            = 'DEFENDER-ANTIPHISH-001'
+            Remediation        = 'Run: Set-AntiPhishPolicy -Identity <PolicyName> -PhishThresholdLevel 2. Security admin center > Anti-phishing > Edit policy > Set threshold to 2 (Aggressive) or higher.'
+            Evidence           = [PSCustomObject]@{
                 PolicyName                = $policy.Name
                 PhishThresholdLevel       = [int]$threshold
                 EnableMailboxIntelligence = $mailboxIntelligence
             }
+            # D1 #785 -- structured evidence
+            ObservedValue      = [string][int]$threshold
+            ExpectedValue      = '2'
+            EvidenceSource     = 'Get-AntiPhishPolicy'
+            CollectionMethod   = 'Direct'
+            PermissionRequired = 'Exchange Online: View-Only Configuration'
+            Confidence         = 1.0
         }
         Add-Setting @settingParams
 

--- a/src/M365-Assess/Security/Get-DefenderSecurityConfig.ps1
+++ b/src/M365-Assess/Security/Get-DefenderSecurityConfig.ps1
@@ -56,19 +56,37 @@ function Add-Setting {
         [string]$Status,
         [string]$CheckId = '',
         [string]$Remediation = '',
-        [PSCustomObject]$Evidence = $null
+        [PSCustomObject]$Evidence = $null,
+        # D1 #785 -- structured evidence schema
+        [string]$ObservedValue = '',
+        [string]$ExpectedValue = '',
+        [string]$EvidenceSource = '',
+        [string]$EvidenceTimestamp = '',
+        [ValidateSet('', 'Direct', 'Derived', 'Inferred')]
+        [string]$CollectionMethod = '',
+        [string]$PermissionRequired = '',
+        [Nullable[double]]$Confidence = $null,
+        [string]$Limitations = ''
     )
     $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-        Evidence         = $Evidence
+        Settings           = $settings
+        CheckIdCounter     = $checkIdCounter
+        Category           = $Category
+        Setting            = $Setting
+        CurrentValue       = $CurrentValue
+        RecommendedValue   = $RecommendedValue
+        Status             = $Status
+        CheckId            = $CheckId
+        Remediation        = $Remediation
+        Evidence           = $Evidence
+        ObservedValue      = $ObservedValue
+        ExpectedValue      = $ExpectedValue
+        EvidenceSource     = $EvidenceSource
+        EvidenceTimestamp  = $EvidenceTimestamp
+        CollectionMethod   = $CollectionMethod
+        PermissionRequired = $PermissionRequired
+        Confidence         = $Confidence
+        Limitations        = $Limitations
     }
     Add-SecuritySetting @p
 }

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -3139,10 +3139,51 @@ function FindingsTable({
       href: r.url,
       target: "_blank",
       rel: "noreferrer noopener"
-    }, "\uD83D\uDCD6 ", r.title, " \u2197"))), f.evidence && /*#__PURE__*/React.createElement("details", {
-      className: "finding-evidence"
-    }, /*#__PURE__*/React.createElement("summary", null, "Evidence"), /*#__PURE__*/React.createElement("pre", null, JSON.stringify(JSON.parse(f.evidence), null, 2)))));
+    }, "\uD83D\uDCD6 ", r.title, " \u2197"))), f.evidence && /*#__PURE__*/React.createElement(EvidenceBlock, {
+      evidence: f.evidence
+    })));
   })));
+}
+
+// D1 #785 -- structured evidence schema renderer.
+// Accepts either the new object shape ({ observedValue, expectedValue, ..., raw }) or
+// the legacy JSON-string shape (pre-v2.9 reports). Renders a structured table for
+// typed fields and a collapsible <pre> for the legacy raw blob when present.
+function EvidenceBlock({
+  evidence
+}) {
+  if (!evidence) return null;
+  // Defensive: legacy reports stored evidence as a JSON string. Try to parse.
+  let ev = evidence;
+  if (typeof ev === 'string') {
+    try {
+      ev = {
+        raw: ev
+      };
+    } catch {
+      return null;
+    }
+  }
+  const fields = [['observedValue', 'Observed value'], ['expectedValue', 'Expected value'], ['evidenceSource', 'Source'], ['evidenceTimestamp', 'Collected at (UTC)'], ['collectionMethod', 'Collection method'], ['permissionRequired', 'Permission used'], ['confidence', 'Confidence'], ['limitations', 'Limitations']];
+  const rows = fields.filter(([k]) => ev[k] !== undefined && ev[k] !== null && ev[k] !== '');
+  let rawPretty = null;
+  if (ev.raw) {
+    try {
+      rawPretty = JSON.stringify(JSON.parse(ev.raw), null, 2);
+    } catch {
+      rawPretty = String(ev.raw);
+    }
+  }
+  if (rows.length === 0 && !rawPretty) return null;
+  return /*#__PURE__*/React.createElement("details", {
+    className: "finding-evidence"
+  }, /*#__PURE__*/React.createElement("summary", null, "Evidence"), rows.length > 0 && /*#__PURE__*/React.createElement("table", {
+    className: "evidence-table"
+  }, /*#__PURE__*/React.createElement("tbody", null, rows.map(([k, label]) => /*#__PURE__*/React.createElement("tr", {
+    key: k
+  }, /*#__PURE__*/React.createElement("th", null, label), /*#__PURE__*/React.createElement("td", null, k === 'confidence' ? `${Math.round(ev[k] * 100)}%` : String(ev[k])))))), rawPretty && /*#__PURE__*/React.createElement("details", {
+    className: "finding-evidence-raw"
+  }, /*#__PURE__*/React.createElement("summary", null, "Raw evidence"), /*#__PURE__*/React.createElement("pre", null, rawPretty)));
 }
 function renderRemediation(text) {
   if (!text) return /*#__PURE__*/React.createElement("span", {

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -1958,12 +1958,7 @@ function FindingsTable({ filters, search, focusFinding, onFocusClear, onMatchesC
                       ))}
                     </div>
                   )}
-                  {f.evidence && (
-                    <details className="finding-evidence">
-                      <summary>Evidence</summary>
-                      <pre>{JSON.stringify(JSON.parse(f.evidence), null, 2)}</pre>
-                    </details>
-                  )}
+                  {f.evidence && <EvidenceBlock evidence={f.evidence} />}
                 </div>
               )}
             </React.Fragment>
@@ -1971,6 +1966,59 @@ function FindingsTable({ filters, search, focusFinding, onFocusClear, onMatchesC
         })}
       </div>}
     </section>
+  );
+}
+
+// D1 #785 -- structured evidence schema renderer.
+// Accepts either the new object shape ({ observedValue, expectedValue, ..., raw }) or
+// the legacy JSON-string shape (pre-v2.9 reports). Renders a structured table for
+// typed fields and a collapsible <pre> for the legacy raw blob when present.
+function EvidenceBlock({ evidence }) {
+  if (!evidence) return null;
+  // Defensive: legacy reports stored evidence as a JSON string. Try to parse.
+  let ev = evidence;
+  if (typeof ev === 'string') {
+    try { ev = { raw: ev }; } catch { return null; }
+  }
+  const fields = [
+    ['observedValue',      'Observed value'],
+    ['expectedValue',      'Expected value'],
+    ['evidenceSource',     'Source'],
+    ['evidenceTimestamp',  'Collected at (UTC)'],
+    ['collectionMethod',   'Collection method'],
+    ['permissionRequired', 'Permission used'],
+    ['confidence',         'Confidence'],
+    ['limitations',        'Limitations'],
+  ];
+  const rows = fields.filter(([k]) => ev[k] !== undefined && ev[k] !== null && ev[k] !== '');
+  let rawPretty = null;
+  if (ev.raw) {
+    try { rawPretty = JSON.stringify(JSON.parse(ev.raw), null, 2); }
+    catch { rawPretty = String(ev.raw); }
+  }
+  if (rows.length === 0 && !rawPretty) return null;
+  return (
+    <details className="finding-evidence">
+      <summary>Evidence</summary>
+      {rows.length > 0 && (
+        <table className="evidence-table">
+          <tbody>
+            {rows.map(([k, label]) => (
+              <tr key={k}>
+                <th>{label}</th>
+                <td>{k === 'confidence' ? `${Math.round(ev[k] * 100)}%` : String(ev[k])}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      {rawPretty && (
+        <details className="finding-evidence-raw">
+          <summary>Raw evidence</summary>
+          <pre>{rawPretty}</pre>
+        </details>
+      )}
+    </details>
   );
 }
 

--- a/src/M365-Assess/assets/report-shell.css
+++ b/src/M365-Assess/assets/report-shell.css
@@ -979,6 +979,27 @@ mark.search-hl {
   border-radius: 6px; font-size: 11px; overflow-x: auto;
   color: var(--text); line-height: 1.5;
 }
+/* D1 #785 -- structured evidence schema. Compact two-column table; one row per
+   non-empty evidence field. Raw blob (legacy collectors) is in a sub-details. */
+.evidence-table {
+  margin: 6px 0 0; width: 100%; border-collapse: collapse;
+  font-size: 12px; background: var(--surface2); border-radius: 6px; overflow: hidden;
+}
+.evidence-table th,
+.evidence-table td {
+  padding: 6px 10px; text-align: left; vertical-align: top;
+  border-bottom: 1px solid var(--border);
+}
+.evidence-table tr:last-child th,
+.evidence-table tr:last-child td { border-bottom: none; }
+.evidence-table th {
+  width: 30%; font-weight: 600; color: var(--text-soft); white-space: nowrap;
+}
+.evidence-table td { color: var(--text); word-break: break-word; }
+.finding-evidence-raw { margin-top: 8px; }
+.finding-evidence-raw summary {
+  cursor: pointer; font-size: 11px; color: var(--muted); user-select: none;
+}
 
 /* ---------- Domain grid ---------- */
 .domain-grid {

--- a/tests/Behavior/Evidence-Schema.Tests.ps1
+++ b/tests/Behavior/Evidence-Schema.Tests.ps1
@@ -1,0 +1,88 @@
+# tests/Behavior/Evidence-Schema.Tests.ps1 -- D1 #785
+#
+# Static regression guard: asserts the helper's output contract still includes
+# the eight structured evidence fields. If a refactor accidentally drops one,
+# the report appendix and XLSX evidence sheet would silently lose data -- this
+# test catches it before merge.
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot '../../src/M365-Assess/Common/SecurityConfigHelper.ps1')
+
+    # Authoritative list -- update if the schema changes (and update docs/EVIDENCE-MODEL.md).
+    $script:evidenceFields = @(
+        'ObservedValue', 'ExpectedValue', 'EvidenceSource', 'EvidenceTimestamp',
+        'CollectionMethod', 'PermissionRequired', 'Confidence', 'Limitations'
+    )
+}
+
+Describe 'Evidence schema contract (D1 #785)' {
+
+    Context 'Add-SecuritySetting output PSCustomObject' {
+        It 'includes every field declared in the evidence schema' {
+            $ctx = Initialize-SecurityConfig
+            Add-SecuritySetting -Settings $ctx.Settings -CheckIdCounter $ctx.CheckIdCounter `
+                -Category 'Test' -Setting 'schema regression' -CurrentValue 'x' `
+                -RecommendedValue 'y' -Status 'Pass' -CheckId 'TEST-001'
+            $row = $ctx.Settings[0]
+            foreach ($field in $script:evidenceFields) {
+                $row.PSObject.Properties[$field] | Should -Not -BeNullOrEmpty -Because "field '$field' must remain on the helper output (docs/EVIDENCE-MODEL.md)"
+            }
+        }
+
+        It 'preserves the legacy free-form Evidence parameter alongside the structured fields' {
+            # Backwards-compat: collectors that pre-date the schema still emit Evidence.
+            $ctx = Initialize-SecurityConfig
+            Add-SecuritySetting -Settings $ctx.Settings -CheckIdCounter $ctx.CheckIdCounter `
+                -Category 'Test' -Setting 'legacy blob' -CurrentValue 'x' `
+                -RecommendedValue 'y' -Status 'Pass' -CheckId 'TEST-001' `
+                -Evidence ([PSCustomObject]@{ legacy = $true })
+            $ctx.Settings[0].Evidence.legacy | Should -BeTrue
+        }
+    }
+
+    Context 'Build-ReportData output' {
+        BeforeAll {
+            . (Join-Path $PSScriptRoot '../../src/M365-Assess/Common/Build-ReportData.ps1')
+        }
+
+        It 'omits the evidence object entirely when no field is populated' {
+            $finding = [PSCustomObject]@{
+                CheckId          = 'TEST-001.1'
+                Category         = 'Test'
+                Setting          = 'no evidence'
+                CurrentValue     = 'x'
+                RecommendedValue = 'y'
+                Status           = 'Pass'
+                Remediation      = ''
+                Section          = 'Test'
+            }
+            $json = Build-ReportDataJson -AllFindings @($finding)
+            $payload = $json -replace '^window\.REPORT_DATA\s*=\s*' -replace ';\s*$'
+            $data = $payload | ConvertFrom-Json
+            $data.findings[0].evidence | Should -BeNullOrEmpty
+        }
+
+        It 'emits a structured object when at least one field is populated' {
+            $finding = [PSCustomObject]@{
+                CheckId            = 'TEST-001.1'
+                Category           = 'Test'
+                Setting            = 'with evidence'
+                CurrentValue       = 'x'
+                RecommendedValue   = 'y'
+                Status             = 'Pass'
+                Remediation        = ''
+                Section            = 'Test'
+                EvidenceSource     = '/test/endpoint'
+                PermissionRequired = 'Test.Read.All'
+                Confidence         = 1.0
+            }
+            $json = Build-ReportDataJson -AllFindings @($finding)
+            $payload = $json -replace '^window\.REPORT_DATA\s*=\s*' -replace ';\s*$'
+            $data = $payload | ConvertFrom-Json
+            $data.findings[0].evidence                    | Should -Not -BeNullOrEmpty
+            $data.findings[0].evidence.evidenceSource     | Should -Be '/test/endpoint'
+            $data.findings[0].evidence.permissionRequired | Should -Be 'Test.Read.All'
+            $data.findings[0].evidence.confidence         | Should -Be 1.0
+        }
+    }
+}

--- a/tests/Common/Build-ReportData.Tests.ps1
+++ b/tests/Common/Build-ReportData.Tests.ps1
@@ -540,34 +540,53 @@ Describe 'Build-ReportData' {
         }
     }
 
-    Context 'Evidence field passthrough' {
-        It 'serializes evidence object to JSON string in findings output' {
+    Context 'Evidence field passthrough (D1 #785 structured schema)' {
+        It 'maps legacy free-form Evidence blob to the .raw subfield of structured evidence' {
             $finding = New-Finding
             $finding | Add-Member -NotePropertyName Evidence -NotePropertyValue ([PSCustomObject]@{ IsSecurityDefaultsEnabled = $true })
             $registry = @{ 'ENTRA-MFA-001' = [PSCustomObject]@{ riskSeverity = 'Critical'; effort = 'small' } }
             $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @($finding) -RegistryData $registry)
             $d.findings[0].evidence | Should -Not -BeNullOrEmpty
-            $parsed = $d.findings[0].evidence | ConvertFrom-Json
+            $d.findings[0].evidence.raw | Should -Not -BeNullOrEmpty
+            $parsed = $d.findings[0].evidence.raw | ConvertFrom-Json
             $parsed.IsSecurityDefaultsEnabled | Should -Be $true
         }
 
-        It 'evidence field is null when not set on finding' {
+        It 'evidence field is null when no evidence at all is set on the finding' {
             $finding = New-Finding
             $registry = @{ 'ENTRA-MFA-001' = [PSCustomObject]@{ riskSeverity = 'Critical'; effort = 'small' } }
             $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @($finding) -RegistryData $registry)
             $d.findings[0].evidence | Should -BeNullOrEmpty
         }
 
-        It 'evidence JSON string is parseable when present' {
+        It 'serializes structured evidence fields onto the evidence object' {
             $finding = New-Finding
-            $finding | Add-Member -NotePropertyName Evidence -NotePropertyValue ([PSCustomObject]@{
-                PolicyCount = 3; PolicyNames = @('Policy A', 'Policy B', 'Policy C')
-            })
+            $finding | Add-Member -NotePropertyName ObservedValue      -NotePropertyValue 'true'
+            $finding | Add-Member -NotePropertyName ExpectedValue      -NotePropertyValue 'true'
+            $finding | Add-Member -NotePropertyName EvidenceSource     -NotePropertyValue 'Get-AdminAuditLogConfig'
+            $finding | Add-Member -NotePropertyName CollectionMethod   -NotePropertyValue 'Direct'
+            $finding | Add-Member -NotePropertyName PermissionRequired -NotePropertyValue 'View-Only Audit Logs'
+            $finding | Add-Member -NotePropertyName Confidence         -NotePropertyValue 1.0
             $registry = @{ 'ENTRA-MFA-001' = [PSCustomObject]@{ riskSeverity = 'High'; effort = 'medium' } }
             $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @($finding) -RegistryData $registry)
-            { $d.findings[0].evidence | ConvertFrom-Json } | Should -Not -Throw
-            $ev = $d.findings[0].evidence | ConvertFrom-Json
-            $ev.PolicyCount | Should -Be 3
+            $d.findings[0].evidence                    | Should -Not -BeNullOrEmpty
+            $d.findings[0].evidence.observedValue      | Should -Be 'true'
+            $d.findings[0].evidence.evidenceSource     | Should -Be 'Get-AdminAuditLogConfig'
+            $d.findings[0].evidence.collectionMethod   | Should -Be 'Direct'
+            $d.findings[0].evidence.permissionRequired | Should -Be 'View-Only Audit Logs'
+            $d.findings[0].evidence.confidence         | Should -Be 1.0
+        }
+
+        It 'omits empty structured fields from the evidence object' {
+            $finding = New-Finding
+            $finding | Add-Member -NotePropertyName ObservedValue  -NotePropertyValue 'true'
+            $finding | Add-Member -NotePropertyName ExpectedValue  -NotePropertyValue ''
+            $finding | Add-Member -NotePropertyName EvidenceSource -NotePropertyValue $null
+            $registry = @{ 'ENTRA-MFA-001' = [PSCustomObject]@{ riskSeverity = 'High'; effort = 'medium' } }
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -AllFindings @($finding) -RegistryData $registry)
+            $d.findings[0].evidence.observedValue  | Should -Be 'true'
+            $d.findings[0].evidence.PSObject.Properties['expectedValue']  | Should -BeNullOrEmpty
+            $d.findings[0].evidence.PSObject.Properties['evidenceSource'] | Should -BeNullOrEmpty
         }
     }
 

--- a/tests/Common/SecurityConfigHelper.Tests.ps1
+++ b/tests/Common/SecurityConfigHelper.Tests.ps1
@@ -71,3 +71,70 @@ Describe 'Add-SecuritySetting - status taxonomy (#774)' {
         } | Should -Throw -ExpectedMessage '*BananaPancakes*'
     }
 }
+
+Describe 'Add-SecuritySetting - structured evidence schema (D1 #785)' {
+    BeforeEach {
+        $ctx = Initialize-SecurityConfig
+    }
+
+    It 'Defaults all 8 evidence fields to empty/null when omitted' {
+        Add-SecuritySetting -Settings $ctx.Settings -CheckIdCounter $ctx.CheckIdCounter `
+            -Category 'Test' -Setting 'no evidence' -CurrentValue 'x' `
+            -RecommendedValue 'y' -Status 'Pass' -CheckId 'TEST-001'
+        $row = $ctx.Settings[0]
+        $row.ObservedValue      | Should -Be ''
+        $row.ExpectedValue      | Should -Be ''
+        $row.EvidenceSource     | Should -Be ''
+        $row.EvidenceTimestamp  | Should -Be ''
+        $row.CollectionMethod   | Should -Be ''
+        $row.PermissionRequired | Should -Be ''
+        $row.Confidence         | Should -BeNullOrEmpty
+        $row.Limitations        | Should -Be ''
+    }
+
+    It 'Round-trips populated evidence fields onto the output PSCustomObject' {
+        Add-SecuritySetting -Settings $ctx.Settings -CheckIdCounter $ctx.CheckIdCounter `
+            -Category 'Test' -Setting 'with evidence' -CurrentValue 'x' `
+            -RecommendedValue 'y' -Status 'Pass' -CheckId 'TEST-001' `
+            -ObservedValue 'true' -ExpectedValue 'true' `
+            -EvidenceSource '/test/endpoint' -EvidenceTimestamp '2026-04-26T10:00:00Z' `
+            -CollectionMethod 'Direct' -PermissionRequired 'Test.Read.All' `
+            -Confidence 0.95 -Limitations 'tested in lab tenant only'
+        $row = $ctx.Settings[0]
+        $row.ObservedValue      | Should -Be 'true'
+        $row.ExpectedValue      | Should -Be 'true'
+        $row.EvidenceSource     | Should -Be '/test/endpoint'
+        $row.EvidenceTimestamp  | Should -Be '2026-04-26T10:00:00Z'
+        $row.CollectionMethod   | Should -Be 'Direct'
+        $row.PermissionRequired | Should -Be 'Test.Read.All'
+        $row.Confidence         | Should -Be 0.95
+        $row.Limitations        | Should -Be 'tested in lab tenant only'
+    }
+
+    It 'Rejects CollectionMethod values outside the controlled vocabulary' {
+        {
+            Add-SecuritySetting -Settings $ctx.Settings -CheckIdCounter $ctx.CheckIdCounter `
+                -Category 'Test' -Setting 'bad method' -CurrentValue 'x' `
+                -RecommendedValue 'y' -Status 'Pass' -CheckId 'TEST-001' `
+                -CollectionMethod 'Hallucinated'
+        } | Should -Throw
+    }
+
+    It 'Rejects Confidence outside the [0.0, 1.0] range' {
+        {
+            Add-SecuritySetting -Settings $ctx.Settings -CheckIdCounter $ctx.CheckIdCounter `
+                -Category 'Test' -Setting 'bad confidence' -CurrentValue 'x' `
+                -RecommendedValue 'y' -Status 'Pass' -CheckId 'TEST-001' `
+                -Confidence 1.5
+        } | Should -Throw
+    }
+
+    It 'Accepts the legacy Evidence blob alongside structured fields' {
+        Add-SecuritySetting -Settings $ctx.Settings -CheckIdCounter $ctx.CheckIdCounter `
+            -Category 'Test' -Setting 'mixed' -CurrentValue 'x' `
+            -RecommendedValue 'y' -Status 'Pass' -CheckId 'TEST-001' `
+            -Evidence ([PSCustomObject]@{ rawCount = 7 }) -ObservedValue '7'
+        $ctx.Settings[0].Evidence.rawCount | Should -Be 7
+        $ctx.Settings[0].ObservedValue     | Should -Be '7'
+    }
+}


### PR DESCRIPTION
## Summary

Adds 8 optional evidence fields to `Add-SecuritySetting` so collectors can record the provenance of every finding: `ObservedValue`, `ExpectedValue`, `EvidenceSource`, `EvidenceTimestamp`, `CollectionMethod`, `PermissionRequired`, `Confidence`, `Limitations`. All defaults are empty/null so the 60+ existing callers compile unchanged.

The report appendix is promoted from a raw-JSON `<pre>` blob to a structured `EvidenceBlock` React component. `Build-ReportData.ps1` now emits a typed object on `findings[].evidence` (only fields that are non-empty); the legacy free-form `Evidence` param survives via `evidence.raw` for backwards-compat. The React component handles both shapes defensively so older transferable report files keep rendering.

XLSX exports gain a dedicated **Evidence Details** sheet. Keeping evidence off the main Compliance Matrix preserves readability for compliance leaders who only need CheckId/Status/framework mappings.

Five collectors migrated as **proof-of-pattern**: Defender anti-phishing (threshold check), EXO (modern auth + audit), Conditional Access (enabled policy count — covers MFA-via-CA scope), Intune (compliance threshold). Future minor releases will adopt the schema in remaining collectors at their own pace.

## Notable gotcha

PowerShell's `[ValidateRange]` rejects `$null` even on `[Nullable[double]]` params. The wrapper splats `Confidence=$null` to the helper by default, which trips the decorator before the function body runs. Resolved by replacing the decorator with a manual range check inside the function body — so the nullable default passes cleanly and only out-of-range non-null values throw.

## Test plan

- [x] `Invoke-Pester -Path './tests'` — 2243/2243 green (4 new from `tests/Behavior/Evidence-Schema.Tests.ps1`, 5 new from helper schema tests, 2 updated `Build-ReportData` tests for the new shape)
- [x] `npm run build` regenerates `report-app.js` from `report-app.jsx`
- [x] `node --check src/M365-Assess/assets/report-app.js`
- [x] PSScriptAnalyzer error-clean on changed files

## Docs

- New [`docs/EVIDENCE-MODEL.md`](../blob/feature/7a-evidence-schema/docs/EVIDENCE-MODEL.md) — field reference + migration cookbook
- Updated [`docs/REPORT-SCHEMA.md`](../blob/feature/7a-evidence-schema/docs/REPORT-SCHEMA.md) — evidence object shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)