### PR TITLE
feat(report): license-adjusted scoring views (closes #786)

### DIFF
--- a/docs/SCORING.md
+++ b/docs/SCORING.md
@@ -1,0 +1,104 @@
+# Scoring Model
+
+## What this is
+
+M365-Assess produces a primary headline score on every report (the "strict-rule Pass%"), and a set of secondary scoring views that consultants can toggle between to support different conversations: technical security, compliance audit, license-aware planning, quick wins, etc.
+
+The headline score is **invariant** -- it doesn't change based on tab selection, so the auditor-facing number is stable. The tabs are exploration tools, not redefinitions of "score."
+
+---
+
+## Headline: Strict-Rule Pass%
+
+```
+Pass% = Pass / (Pass + Fail + Warning)
+```
+
+- Numerator: `Pass`
+- Denominator: `Pass + Fail + Warning`
+- **Excluded from both**: `Review`, `Info`, `Skipped`, `Unknown`, `NotApplicable`, `NotLicensed`
+
+This is the rule from #802 / `docs/CHECK-STATUS-MODEL.md`. Every consumer of the score (KPI tiles, section bucket scores, framework totals, XLSX `Pass Rate %`) follows it.
+
+The justification: not-collected results can never inflate or deflate the score. If you couldn't assess a control, the score doesn't pretend it was either passed or failed.
+
+---
+
+## Tab views (D2 #786)
+
+The tabs appear in the executive-summary panel of the HTML report, below the headline. Three of the six are scoring formulas; three are curated finding lists.
+
+### 1. Security Risk (default)
+
+Same formula as the headline; included as a tab so consultants always see the strict-rule number even when they've toggled away.
+
+```
+Pass / (Pass + Fail + Warning)
+```
+
+### 2. Compliance Readiness
+
+Counts `Review` findings as ready, since "needs review" usually means "auditor will accept with attestation."
+
+```
+(Pass + Review) / (Pass + Fail + Warning + Review)
+```
+
+`Skipped`, `Unknown`, `NotApplicable`, `NotLicensed` are still excluded -- you can't be ready for a control you literally cannot assess.
+
+### 3. License-Adjusted
+
+Strips `NotLicensed` from both numerator and denominator. SMBs without E5 don't get penalised for E5-only controls they cannot enable.
+
+```
+Pass / (Pass + Fail + Warning, where status != NotLicensed)
+```
+
+This view is most useful when discussing a customer's posture *given their current licenses* without conflating it with what they'd get if they upgraded.
+
+### 4. Quick Wins (list)
+
+Findings with `status = Fail` AND `effort` of `small` or `low`, sorted by severity (critical → high → medium → low → none → info). Top 8 shown; "more" link deep-links to the filtered findings table.
+
+This is the consultant's "what should we fix first" answer. High-impact, low-effort failures are by definition the highest-leverage remediation.
+
+### 5. Requires Licensing (list)
+
+All `status = NotLicensed` findings. Surfaces controls blocked by missing license SKUs -- candidates for an upgrade discussion. Not penalised in the License-Adjusted score above; this list is the upsell counterpart to that score.
+
+### 6. Manual Validation (list)
+
+All `status = Review` findings. These need human verification (audit log review, evidence collection, attestation). Surfacing them as a list makes the consultant's manual-validation work visible up-front rather than buried in the findings table.
+
+---
+
+## Why three scores, not one weighted score
+
+A weighted composite ("60% technical risk + 30% compliance + 10% license adjustment") would feel scientific but would obscure the trade-offs. Different conversations call for different framings:
+
+| Audience | Right view |
+|---|---|
+| CISO / security architect | Security Risk |
+| Compliance / audit lead | Compliance Readiness |
+| Account exec / customer success | License-Adjusted |
+| MSP technician planning the next sprint | Quick Wins |
+| Sales engineer scoping an upgrade | Requires Licensing |
+| Auditor preparing fieldwork | Manual Validation |
+
+A single composite would force these conversations to reverse-engineer the weights. Surfacing them as named tabs lets each role pick the framing they care about.
+
+---
+
+## Where the math lives
+
+- `src/M365-Assess/assets/report-app.jsx` -- the `SCORING_VIEWS` array near the top defines each view; helpers `computeSecurityRiskScore`, `computeComplianceReadinessScore`, `computeLicenseAdjustedScore`, `getQuickWins`, `getRequiresLicensing`, `getManualValidation` are pure functions of `FINDINGS`.
+- `tests/Behavior/Report-Math.Tests.ps1` -- PowerShell-side regression for the strict-rule denominator (#802); lives at the data-layer boundary so the contract stays asserted across language seams.
+- `docs/CHECK-STATUS-MODEL.md` -- the canonical taxonomy these formulas operate on.
+
+---
+
+## See also
+
+- [`CHECK-STATUS-MODEL.md`](CHECK-STATUS-MODEL.md) -- the 9-status taxonomy and denominator rules
+- [`REPORT-SCHEMA.md`](REPORT-SCHEMA.md) -- the `findings[]` shape these formulas read
+- [`EVIDENCE-MODEL.md`](EVIDENCE-MODEL.md) -- the structured evidence schema (`Limitations` field can change how you interpret a Manual Validation finding)

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -761,6 +761,154 @@ function Topbar({
   }, /*#__PURE__*/React.createElement(Icon.sliders, null)))));
 }
 
+// ======================== Scoring views (D2 #786) ========================
+// Six named views for the executive summary -- the headline strict-rule Pass%
+// stays in the score card; these views are secondary perspectives consultants
+// toggle between. See docs/SCORING.md for the per-view denominator math.
+//
+// 3 score views (return a number/percentage):
+const computeSecurityRiskScore = arr => {
+  // Same as the headline: Pass / (Pass + Fail + Warning).
+  const denom = scoreDenom(arr);
+  if (denom === 0) return null;
+  const pass = (arr || []).filter(f => f.status === 'Pass').length;
+  return Math.round(pass / denom * 100);
+};
+const computeComplianceReadinessScore = arr => {
+  // Compliance lens: count Review (manual-validation findings) AS Pass-equivalent
+  // since "needs review" usually means "the auditor will accept it with attestation."
+  // Excludes Skipped/Unknown/NotApplicable/NotLicensed -- you can't be ready for
+  // a control you literally cannot assess.
+  const items = (arr || []).filter(f => ['Pass', 'Fail', 'Warning', 'Review'].includes(f.status));
+  if (items.length === 0) return null;
+  const ready = items.filter(f => f.status === 'Pass' || f.status === 'Review').length;
+  return Math.round(ready / items.length * 100);
+};
+const computeLicenseAdjustedScore = arr => {
+  // Strips out NotLicensed entirely from BOTH numerator and denominator. SMBs
+  // without E5 don't get penalised for E5-only controls they cannot enable.
+  const items = (arr || []).filter(f => SCORED_STATUSES.has(f.status) && f.status !== 'NotLicensed');
+  if (items.length === 0) return null;
+  const pass = items.filter(f => f.status === 'Pass').length;
+  return Math.round(pass / items.length * 100);
+};
+// 3 list views (return an array of findings, sorted/filtered for the workflow):
+const getQuickWins = arr => {
+  // Fail status × low effort, sorted by severity (critical > high > medium > low > none).
+  const sevOrder = {
+    critical: 0,
+    high: 1,
+    medium: 2,
+    low: 3,
+    none: 4,
+    info: 5
+  };
+  return (arr || []).filter(f => f.status === 'Fail' && (f.effort === 'small' || f.effort === 'low')).sort((a, b) => (sevOrder[a.severity] ?? 99) - (sevOrder[b.severity] ?? 99));
+};
+const getRequiresLicensing = arr => (arr || []).filter(f => f.status === 'NotLicensed');
+const getManualValidation = arr => (arr || []).filter(f => f.status === 'Review');
+const SCORING_VIEWS = [{
+  id: 'security-risk',
+  label: 'Security Risk',
+  kind: 'score',
+  compute: computeSecurityRiskScore,
+  blurb: 'Strict rule: Pass / (Pass + Fail + Warning). Matches the headline.'
+}, {
+  id: 'compliance',
+  label: 'Compliance Readiness',
+  kind: 'score',
+  compute: computeComplianceReadinessScore,
+  blurb: 'Counts Review-status findings as ready (auditor will accept with attestation).'
+}, {
+  id: 'license-adjusted',
+  label: 'License-Adjusted',
+  kind: 'score',
+  compute: computeLicenseAdjustedScore,
+  blurb: 'Excludes NotLicensed from both numerator and denominator -- fair to SMBs without E5.'
+}, {
+  id: 'quick-wins',
+  label: 'Quick Wins',
+  kind: 'list',
+  collect: getQuickWins,
+  blurb: 'Failing controls with small remediation effort, sorted by severity.'
+}, {
+  id: 'requires-licensing',
+  label: 'Requires Licensing',
+  kind: 'list',
+  collect: getRequiresLicensing,
+  blurb: 'Findings blocked by missing license SKUs -- candidates for upgrade discussion.'
+}, {
+  id: 'manual-validation',
+  label: 'Manual Validation',
+  kind: 'list',
+  collect: getManualValidation,
+  blurb: 'Review-status findings that need human verification (audit log review, evidence collection).'
+}];
+function ScoringViews() {
+  const [active, setActive] = useState('security-risk');
+  const view = SCORING_VIEWS.find(v => v.id === active) || SCORING_VIEWS[0];
+  let body;
+  if (view.kind === 'score') {
+    const value = view.compute(FINDINGS);
+    body = /*#__PURE__*/React.createElement("div", {
+      className: "scoring-view-body"
+    }, /*#__PURE__*/React.createElement("div", {
+      className: "scoring-view-num"
+    }, value === null ? '—' : `${value}%`), /*#__PURE__*/React.createElement("div", {
+      className: "scoring-view-blurb"
+    }, view.blurb));
+  } else {
+    const items = view.collect(FINDINGS);
+    body = /*#__PURE__*/React.createElement("div", {
+      className: "scoring-view-body"
+    }, /*#__PURE__*/React.createElement("div", {
+      className: "scoring-view-blurb"
+    }, view.blurb), items.length === 0 ? /*#__PURE__*/React.createElement("div", {
+      className: "scoring-view-empty"
+    }, "No findings match this view.") : /*#__PURE__*/React.createElement("ul", {
+      className: "scoring-view-list"
+    }, items.slice(0, 8).map(f => /*#__PURE__*/React.createElement("li", {
+      key: f.checkId
+    }, /*#__PURE__*/React.createElement("span", {
+      className: 'sev-pill sev-' + (f.severity || 'medium')
+    }, f.severity || 'medium'), /*#__PURE__*/React.createElement("a", {
+      href: "#findings-anchor",
+      onClick: e => {
+        e.preventDefault();
+        document.getElementById('findings-anchor')?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'start'
+        });
+      }
+    }, f.setting), /*#__PURE__*/React.createElement("span", {
+      className: "scoring-view-domain"
+    }, f.domain))), items.length > 8 && /*#__PURE__*/React.createElement("li", {
+      className: "scoring-view-more"
+    }, "+ ", items.length - 8, " more \u2014 see ", /*#__PURE__*/React.createElement("a", {
+      href: "#findings-anchor",
+      onClick: e => {
+        e.preventDefault();
+        document.getElementById('findings-anchor')?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'start'
+        });
+      }
+    }, "findings table"))));
+  }
+  return /*#__PURE__*/React.createElement("div", {
+    className: "scoring-views"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "scoring-views-tabs",
+    role: "tablist"
+  }, SCORING_VIEWS.map(v => /*#__PURE__*/React.createElement("button", {
+    key: v.id,
+    role: "tab",
+    "aria-selected": v.id === active,
+    className: 'scoring-views-tab' + (v.id === active ? ' active' : ''),
+    onClick: () => setActive(v.id)
+  }, v.label))), body);
+}
+
 // ======================== Posture hero ========================
 function Posture() {
   const score = parseFloat(SCORE.Percentage);
@@ -889,7 +1037,7 @@ function Posture() {
       width: pct(pass, scoreDenom(FINDINGS)) + '%',
       background: 'var(--success)'
     }
-  })))), /*#__PURE__*/React.createElement(MFABreakdown, null))), /*#__PURE__*/React.createElement(ExecSummaryRow, null), critical > 0 && /*#__PURE__*/React.createElement("div", {
+  })))), /*#__PURE__*/React.createElement(MFABreakdown, null))), /*#__PURE__*/React.createElement(ExecSummaryRow, null), /*#__PURE__*/React.createElement(ScoringViews, null), critical > 0 && /*#__PURE__*/React.createElement("div", {
     className: "banner"
   }, /*#__PURE__*/React.createElement("div", {
     className: "banner-icon"

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -410,6 +410,123 @@ function Topbar({ search, setSearch, searchMatches, matchIdx, onAdvanceMatch, on
   );
 }
 
+// ======================== Scoring views (D2 #786) ========================
+// Six named views for the executive summary -- the headline strict-rule Pass%
+// stays in the score card; these views are secondary perspectives consultants
+// toggle between. See docs/SCORING.md for the per-view denominator math.
+//
+// 3 score views (return a number/percentage):
+const computeSecurityRiskScore = arr => {
+  // Same as the headline: Pass / (Pass + Fail + Warning).
+  const denom = scoreDenom(arr);
+  if (denom === 0) return null;
+  const pass = (arr || []).filter(f => f.status === 'Pass').length;
+  return Math.round((pass / denom) * 100);
+};
+const computeComplianceReadinessScore = arr => {
+  // Compliance lens: count Review (manual-validation findings) AS Pass-equivalent
+  // since "needs review" usually means "the auditor will accept it with attestation."
+  // Excludes Skipped/Unknown/NotApplicable/NotLicensed -- you can't be ready for
+  // a control you literally cannot assess.
+  const items = (arr || []).filter(f => ['Pass', 'Fail', 'Warning', 'Review'].includes(f.status));
+  if (items.length === 0) return null;
+  const ready = items.filter(f => f.status === 'Pass' || f.status === 'Review').length;
+  return Math.round((ready / items.length) * 100);
+};
+const computeLicenseAdjustedScore = arr => {
+  // Strips out NotLicensed entirely from BOTH numerator and denominator. SMBs
+  // without E5 don't get penalised for E5-only controls they cannot enable.
+  const items = (arr || []).filter(f => SCORED_STATUSES.has(f.status) && f.status !== 'NotLicensed');
+  if (items.length === 0) return null;
+  const pass = items.filter(f => f.status === 'Pass').length;
+  return Math.round((pass / items.length) * 100);
+};
+// 3 list views (return an array of findings, sorted/filtered for the workflow):
+const getQuickWins = arr => {
+  // Fail status × low effort, sorted by severity (critical > high > medium > low > none).
+  const sevOrder = { critical: 0, high: 1, medium: 2, low: 3, none: 4, info: 5 };
+  return (arr || [])
+    .filter(f => f.status === 'Fail' && (f.effort === 'small' || f.effort === 'low'))
+    .sort((a, b) => (sevOrder[a.severity] ?? 99) - (sevOrder[b.severity] ?? 99));
+};
+const getRequiresLicensing = arr => (arr || []).filter(f => f.status === 'NotLicensed');
+const getManualValidation  = arr => (arr || []).filter(f => f.status === 'Review');
+
+const SCORING_VIEWS = [
+  { id: 'security-risk',     label: 'Security Risk',           kind: 'score', compute: computeSecurityRiskScore,
+    blurb: 'Strict rule: Pass / (Pass + Fail + Warning). Matches the headline.' },
+  { id: 'compliance',        label: 'Compliance Readiness',    kind: 'score', compute: computeComplianceReadinessScore,
+    blurb: 'Counts Review-status findings as ready (auditor will accept with attestation).' },
+  { id: 'license-adjusted',  label: 'License-Adjusted',        kind: 'score', compute: computeLicenseAdjustedScore,
+    blurb: 'Excludes NotLicensed from both numerator and denominator -- fair to SMBs without E5.' },
+  { id: 'quick-wins',        label: 'Quick Wins',              kind: 'list',  collect: getQuickWins,
+    blurb: 'Failing controls with small remediation effort, sorted by severity.' },
+  { id: 'requires-licensing',label: 'Requires Licensing',      kind: 'list',  collect: getRequiresLicensing,
+    blurb: 'Findings blocked by missing license SKUs -- candidates for upgrade discussion.' },
+  { id: 'manual-validation', label: 'Manual Validation',       kind: 'list',  collect: getManualValidation,
+    blurb: 'Review-status findings that need human verification (audit log review, evidence collection).' },
+];
+
+function ScoringViews() {
+  const [active, setActive] = useState('security-risk');
+  const view = SCORING_VIEWS.find(v => v.id === active) || SCORING_VIEWS[0];
+  let body;
+  if (view.kind === 'score') {
+    const value = view.compute(FINDINGS);
+    body = (
+      <div className="scoring-view-body">
+        <div className="scoring-view-num">
+          {value === null ? '—' : `${value}%`}
+        </div>
+        <div className="scoring-view-blurb">{view.blurb}</div>
+      </div>
+    );
+  } else {
+    const items = view.collect(FINDINGS);
+    body = (
+      <div className="scoring-view-body">
+        <div className="scoring-view-blurb">{view.blurb}</div>
+        {items.length === 0 ? (
+          <div className="scoring-view-empty">No findings match this view.</div>
+        ) : (
+          <ul className="scoring-view-list">
+            {items.slice(0, 8).map(f => (
+              <li key={f.checkId}>
+                <span className={'sev-pill sev-' + (f.severity || 'medium')}>{f.severity || 'medium'}</span>
+                <a href="#findings-anchor" onClick={e => {
+                  e.preventDefault();
+                  document.getElementById('findings-anchor')?.scrollIntoView({behavior:'smooth',block:'start'});
+                }}>{f.setting}</a>
+                <span className="scoring-view-domain">{f.domain}</span>
+              </li>
+            ))}
+            {items.length > 8 && (
+              <li className="scoring-view-more">+ {items.length - 8} more — see <a href="#findings-anchor" onClick={e => {
+                e.preventDefault();
+                document.getElementById('findings-anchor')?.scrollIntoView({behavior:'smooth',block:'start'});
+              }}>findings table</a></li>
+            )}
+          </ul>
+        )}
+      </div>
+    );
+  }
+  return (
+    <div className="scoring-views">
+      <div className="scoring-views-tabs" role="tablist">
+        {SCORING_VIEWS.map(v => (
+          <button key={v.id} role="tab" aria-selected={v.id === active}
+            className={'scoring-views-tab' + (v.id === active ? ' active' : '')}
+            onClick={() => setActive(v.id)}>
+            {v.label}
+          </button>
+        ))}
+      </div>
+      {body}
+    </div>
+  );
+}
+
 // ======================== Posture hero ========================
 function Posture() {
   const score = parseFloat(SCORE.Percentage);
@@ -494,6 +611,7 @@ function Posture() {
         </div>
       </div>
       <ExecSummaryRow/>
+      <ScoringViews/>
       {critical > 0 && (
         <div className="banner">
           <div className="banner-icon">!</div>

--- a/src/M365-Assess/assets/report-shell.css
+++ b/src/M365-Assess/assets/report-shell.css
@@ -1001,6 +1001,47 @@ mark.search-hl {
   cursor: pointer; font-size: 11px; color: var(--muted); user-select: none;
 }
 
+/* ---------- Scoring views (D2 #786) ---------- */
+.scoring-views {
+  margin-top: 16px; padding: 14px 16px;
+  background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
+}
+.scoring-views-tabs {
+  display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 12px;
+  padding-bottom: 10px; border-bottom: 1px solid var(--border);
+}
+.scoring-views-tab {
+  padding: 6px 12px; font-size: 12px; font-weight: 500;
+  color: var(--text-soft); background: var(--surface2); border: 1px solid var(--border);
+  border-radius: 999px; cursor: pointer; transition: all .15s;
+}
+.scoring-views-tab:hover { color: var(--text); border-color: var(--accent); }
+.scoring-views-tab.active {
+  color: var(--bg); background: var(--accent); border-color: var(--accent); font-weight: 600;
+}
+.scoring-view-body { display: flex; flex-direction: column; gap: 8px; }
+.scoring-view-num {
+  font-size: 36px; font-weight: 700; color: var(--text); line-height: 1;
+}
+.scoring-view-blurb { font-size: 13px; color: var(--text-soft); }
+.scoring-view-empty {
+  font-size: 12px; color: var(--muted); font-style: italic; padding: 8px 0;
+}
+.scoring-view-list {
+  list-style: none; padding: 0; margin: 4px 0 0;
+  display: flex; flex-direction: column; gap: 4px;
+}
+.scoring-view-list li {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 12px; padding: 4px 0;
+}
+.scoring-view-list a { color: var(--text); text-decoration: none; flex: 1; }
+.scoring-view-list a:hover { color: var(--accent); text-decoration: underline; }
+.scoring-view-domain {
+  font-size: 11px; color: var(--muted); white-space: nowrap;
+}
+.scoring-view-more { color: var(--muted); font-size: 11px; padding-top: 4px !important; }
+
 /* ---------- Domain grid ---------- */
 .domain-grid {
   display: grid;


### PR DESCRIPTION
## Summary

Adds a tab/toggle component to the executive-summary panel of the HTML report. Six named views consultants switch between depending on audience -- the headline strict-rule Pass% in the score card stays **invariant** per the locked plan.

| Tab | Kind | Formula / criterion |
|---|---|---|
| **Security Risk** (default) | Score | `Pass / (Pass + Fail + Warning)` — same as headline |
| Compliance Readiness | Score | `(Pass + Review) / (Pass + Fail + Warning + Review)` |
| License-Adjusted | Score | Excludes `NotLicensed` from numerator and denominator |
| Quick Wins | List | `Fail` × `small`/`low` effort, sorted by severity |
| Requires Licensing | List | All `NotLicensed` (upgrade candidates) |
| Manual Validation | List | All `Review` status |

## Why six views, not a weighted composite

A single weighted score would obscure the trade-offs. Different audiences (CISO, audit lead, account exec, MSP technician, sales engineer, auditor) want different framings. Named tabs let each role pick the framing they care about.

## Test plan
- [x] `Invoke-Pester -Path './tests'` — 2268/2268 green (JS-only changes; no PS regression)
- [x] `npm run build` regenerates `report-app.js` from `report-app.jsx`
- [x] `node --check src/M365-Assess/assets/report-app.js` passes
- [x] CSS additions for tab strip + body in `report-shell.css`
- [x] No localStorage (per the existing report policy — report is a transferable file)

## Docs

New [`docs/SCORING.md`](../blob/feature/8a-license-adjusted-scoring/docs/SCORING.md) documents each view's denominator, the audience-to-view mapping, and where the math lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)