### PR TITLE
feat(api): deprecate legacy collector wrappers (closes #782)

### DIFF
--- a/src/M365-Assess/M365-Assess.psm1
+++ b/src/M365-Assess/M365-Assess.psm1
@@ -20,24 +20,39 @@ Get-ChildItem -Path "$PSScriptRoot\Orchestrator\*.ps1" | ForEach-Object { . $_.F
 # ------------------------------------------------------------------
 # Public cmdlet wrappers for security-config collectors
 #
-# These thin wrappers delegate to the existing collector scripts,
-# allowing them to be called as module-level commands:
-#   Import-Module M365-Assess
-#   Get-M365ExoSecurityConfig -OutputPath .\results.csv
-#
-# Each collector is a standalone script that handles its own
-# connection checks, data collection, and output formatting.
+# C3 #782 -- DEPRECATED in v2.9.0. These thin wrappers will be removed
+# in v3.0.0. The supported invocation surface is Invoke-M365Assessment
+# with a -Section parameter. Each wrapper emits a one-time-per-session
+# Write-Warning at first call so existing scripts keep working but
+# users get notice. See the per-function .NOTES blocks for migration.
 # ------------------------------------------------------------------
+
+# Once-per-session deprecation tracker -- avoids spamming the warning
+# when a script calls the same wrapper 50 times.
+$script:WrapperDeprecationWarned = @{}
+function Show-WrapperDeprecation {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$WrapperName,
+        [Parameter(Mandatory)] [string]$ReplacementSection
+    )
+    if ($script:WrapperDeprecationWarned[$WrapperName]) { return }
+    $script:WrapperDeprecationWarned[$WrapperName] = $true
+    Write-Warning ("$WrapperName is deprecated and will be removed in v3.0.0. " +
+        "Use 'Invoke-M365Assessment -Section $ReplacementSection' instead.")
+}
 
 function Get-M365ExoSecurityConfig {
     <#
     .SYNOPSIS
         Collects Exchange Online security configuration settings.
-    .PARAMETER OutputPath
-        Optional path to export results as CSV.
+    .NOTES
+        DEPRECATED (C3 #782). Will be removed in v3.0.0.
+        Replacement: Invoke-M365Assessment -Section Email
     #>
     [CmdletBinding()]
     param([string]$OutputPath)
+    Show-WrapperDeprecation -WrapperName 'Get-M365ExoSecurityConfig' -ReplacementSection 'Email'
     & "$PSScriptRoot\Exchange-Online\Get-ExoSecurityConfig.ps1" @PSBoundParameters
 }
 
@@ -45,12 +60,9 @@ function Get-M365DnsSecurityConfig {
     <#
     .SYNOPSIS
         Evaluates DNS authentication records (SPF, DKIM, DMARC).
-    .PARAMETER OutputPath
-        Optional path to export results as CSV.
-    .PARAMETER AcceptedDomains
-        Pre-cached accepted domain objects.
-    .PARAMETER DkimConfigs
-        Pre-cached DKIM signing configuration objects.
+    .NOTES
+        DEPRECATED (C3 #782). Will be removed in v3.0.0.
+        Replacement: Invoke-M365Assessment -Section Email
     #>
     [CmdletBinding()]
     param(
@@ -58,6 +70,7 @@ function Get-M365DnsSecurityConfig {
         [object[]]$AcceptedDomains,
         [object[]]$DkimConfigs
     )
+    Show-WrapperDeprecation -WrapperName 'Get-M365DnsSecurityConfig' -ReplacementSection 'Email'
     & "$PSScriptRoot\Exchange-Online\Get-DnsSecurityConfig.ps1" @PSBoundParameters
 }
 
@@ -65,11 +78,12 @@ function Get-M365EntraSecurityConfig {
     <#
     .SYNOPSIS
         Collects Entra ID security configuration settings.
-    .PARAMETER OutputPath
-        Optional path to export results as CSV.
+    .NOTES
+        DEPRECATED (C3 #782). Will be removed in v3.0.0. Replacement: Invoke-M365Assessment -Section Identity
     #>
     [CmdletBinding()]
     param([string]$OutputPath)
+    Show-WrapperDeprecation -WrapperName 'Get-M365EntraSecurityConfig' -ReplacementSection 'Identity'
     & "$PSScriptRoot\Entra\Get-EntraSecurityConfig.ps1" @PSBoundParameters
 }
 
@@ -77,11 +91,12 @@ function Get-M365CASecurityConfig {
     <#
     .SYNOPSIS
         Evaluates Conditional Access policies against CIS requirements.
-    .PARAMETER OutputPath
-        Optional path to export results as CSV.
+    .NOTES
+        DEPRECATED (C3 #782). Will be removed in v3.0.0. Replacement: Invoke-M365Assessment -Section Identity
     #>
     [CmdletBinding()]
     param([string]$OutputPath)
+    Show-WrapperDeprecation -WrapperName 'Get-M365CASecurityConfig' -ReplacementSection 'Identity'
     & "$PSScriptRoot\Entra\Get-CASecurityConfig.ps1" @PSBoundParameters
 }
 
@@ -89,11 +104,12 @@ function Get-M365EntAppSecurityConfig {
     <#
     .SYNOPSIS
         Evaluates enterprise application and service principal security posture.
-    .PARAMETER OutputPath
-        Optional path to export results as CSV.
+    .NOTES
+        DEPRECATED (C3 #782). Will be removed in v3.0.0. Replacement: Invoke-M365Assessment -Section Identity
     #>
     [CmdletBinding()]
     param([string]$OutputPath)
+    Show-WrapperDeprecation -WrapperName 'Get-M365EntAppSecurityConfig' -ReplacementSection 'Identity'
     & "$PSScriptRoot\Entra\Get-EntAppSecurityConfig.ps1" @PSBoundParameters
 }
 
@@ -101,11 +117,12 @@ function Get-M365IntuneSecurityConfig {
     <#
     .SYNOPSIS
         Evaluates Intune/Endpoint Manager security settings.
-    .PARAMETER OutputPath
-        Optional path to export results as CSV.
+    .NOTES
+        DEPRECATED (C3 #782). Will be removed in v3.0.0. Replacement: Invoke-M365Assessment -Section Intune
     #>
     [CmdletBinding()]
     param([string]$OutputPath)
+    Show-WrapperDeprecation -WrapperName 'Get-M365IntuneSecurityConfig' -ReplacementSection 'Intune'
     & "$PSScriptRoot\Intune\Get-IntuneSecurityConfig.ps1" @PSBoundParameters
 }
 
@@ -113,11 +130,12 @@ function Get-M365DefenderSecurityConfig {
     <#
     .SYNOPSIS
         Collects Microsoft Defender for Office 365 security configuration.
-    .PARAMETER OutputPath
-        Optional path to export results as CSV.
+    .NOTES
+        DEPRECATED (C3 #782). Will be removed in v3.0.0. Replacement: Invoke-M365Assessment -Section Security
     #>
     [CmdletBinding()]
     param([string]$OutputPath)
+    Show-WrapperDeprecation -WrapperName 'Get-M365DefenderSecurityConfig' -ReplacementSection 'Security'
     & "$PSScriptRoot\Security\Get-DefenderSecurityConfig.ps1" @PSBoundParameters
 }
 
@@ -125,11 +143,12 @@ function Get-M365ComplianceSecurityConfig {
     <#
     .SYNOPSIS
         Collects Purview/Compliance security configuration settings.
-    .PARAMETER OutputPath
-        Optional path to export results as CSV.
+    .NOTES
+        DEPRECATED (C3 #782). Will be removed in v3.0.0. Replacement: Invoke-M365Assessment -Section Security
     #>
     [CmdletBinding()]
     param([string]$OutputPath)
+    Show-WrapperDeprecation -WrapperName 'Get-M365ComplianceSecurityConfig' -ReplacementSection 'Security'
     & "$PSScriptRoot\Security\Get-ComplianceSecurityConfig.ps1" @PSBoundParameters
 }
 
@@ -137,11 +156,12 @@ function Get-M365SharePointSecurityConfig {
     <#
     .SYNOPSIS
         Collects SharePoint Online security configuration settings.
-    .PARAMETER OutputPath
-        Optional path to export results as CSV.
+    .NOTES
+        DEPRECATED (C3 #782). Will be removed in v3.0.0. Replacement: Invoke-M365Assessment -Section Collaboration
     #>
     [CmdletBinding()]
     param([string]$OutputPath)
+    Show-WrapperDeprecation -WrapperName 'Get-M365SharePointSecurityConfig' -ReplacementSection 'Collaboration'
     & "$PSScriptRoot\Collaboration\Get-SharePointSecurityConfig.ps1" @PSBoundParameters
 }
 
@@ -149,11 +169,12 @@ function Get-M365TeamsSecurityConfig {
     <#
     .SYNOPSIS
         Collects Microsoft Teams security configuration settings.
-    .PARAMETER OutputPath
-        Optional path to export results as CSV.
+    .NOTES
+        DEPRECATED (C3 #782). Will be removed in v3.0.0. Replacement: Invoke-M365Assessment -Section Collaboration
     #>
     [CmdletBinding()]
     param([string]$OutputPath)
+    Show-WrapperDeprecation -WrapperName 'Get-M365TeamsSecurityConfig' -ReplacementSection 'Collaboration'
     & "$PSScriptRoot\Collaboration\Get-TeamsSecurityConfig.ps1" @PSBoundParameters
 }
 
@@ -161,11 +182,12 @@ function Get-M365FormsSecurityConfig {
     <#
     .SYNOPSIS
         Collects Microsoft Forms security configuration settings.
-    .PARAMETER OutputPath
-        Optional path to export results as CSV.
+    .NOTES
+        DEPRECATED (C3 #782). Will be removed in v3.0.0. Replacement: Invoke-M365Assessment -Section Collaboration
     #>
     [CmdletBinding()]
     param([string]$OutputPath)
+    Show-WrapperDeprecation -WrapperName 'Get-M365FormsSecurityConfig' -ReplacementSection 'Collaboration'
     & "$PSScriptRoot\Collaboration\Get-FormsSecurityConfig.ps1" @PSBoundParameters
 }
 
@@ -173,11 +195,12 @@ function Get-M365PowerBISecurityConfig {
     <#
     .SYNOPSIS
         Collects Power BI security and tenant configuration settings.
-    .PARAMETER OutputPath
-        Optional path to export results as CSV.
+    .NOTES
+        DEPRECATED (C3 #782). Will be removed in v3.0.0. Replacement: Invoke-M365Assessment -Section PowerBI
     #>
     [CmdletBinding()]
     param([string]$OutputPath)
+    Show-WrapperDeprecation -WrapperName 'Get-M365PowerBISecurityConfig' -ReplacementSection 'PowerBI'
     & "$PSScriptRoot\PowerBI\Get-PowerBISecurityConfig.ps1" @PSBoundParameters
 }
 
@@ -185,11 +208,12 @@ function Get-M365PurviewRetentionConfig {
     <#
     .SYNOPSIS
         Collects Purview data lifecycle retention compliance policy configuration.
-    .PARAMETER OutputPath
-        Optional path to export results as CSV.
+    .NOTES
+        DEPRECATED (C3 #782). Will be removed in v3.0.0. Replacement: Invoke-M365Assessment -Section Security
     #>
     [CmdletBinding()]
     param([string]$OutputPath)
+    Show-WrapperDeprecation -WrapperName 'Get-M365PurviewRetentionConfig' -ReplacementSection 'Security'
     & "$PSScriptRoot\Purview\Get-PurviewRetentionConfig.ps1" @PSBoundParameters
 }
 

--- a/tests/Behavior/Wrapper-Deprecation.Tests.ps1
+++ b/tests/Behavior/Wrapper-Deprecation.Tests.ps1
@@ -1,0 +1,76 @@
+# tests/Behavior/Wrapper-Deprecation.Tests.ps1 -- C3 #782
+#
+# Regression guard: every legacy Get-M365*SecurityConfig / *RetentionConfig
+# wrapper must emit a deprecation Write-Warning at first call. Once-per-session
+# semantics: a second call from the same session is silent (a script that
+# loops calling the same wrapper shouldn't spam).
+
+BeforeAll {
+    # Static check only -- we don't import the module here because the
+    # wrappers depend on Microsoft.Graph etc. that may not be installed.
+    $script:psm1Path = (Resolve-Path (Join-Path $PSScriptRoot '../../src/M365-Assess/M365-Assess.psm1')).Path
+    $script:content  = Get-Content $script:psm1Path -Raw
+
+    # Authoritative list of wrappers slated for removal in v3.0.0.
+    $script:wrappers = @(
+        'Get-M365ExoSecurityConfig'
+        'Get-M365DnsSecurityConfig'
+        'Get-M365EntraSecurityConfig'
+        'Get-M365CASecurityConfig'
+        'Get-M365EntAppSecurityConfig'
+        'Get-M365IntuneSecurityConfig'
+        'Get-M365DefenderSecurityConfig'
+        'Get-M365ComplianceSecurityConfig'
+        'Get-M365SharePointSecurityConfig'
+        'Get-M365TeamsSecurityConfig'
+        'Get-M365FormsSecurityConfig'
+        'Get-M365PowerBISecurityConfig'
+        'Get-M365PurviewRetentionConfig'
+    )
+}
+
+Describe 'Wrapper deprecation (C3 #782)' {
+
+    It 'declares Show-WrapperDeprecation helper' {
+        $script:content | Should -Match 'function Show-WrapperDeprecation'
+    }
+
+    It 'tracks once-per-session via a script-scoped hashtable' {
+        # Avoids spamming the warning when a script loops a wrapper 50 times.
+        $script:content | Should -Match '\$script:WrapperDeprecationWarned'
+    }
+
+    It 'emits a v3.0.0 removal notice in the warning text' {
+        $script:content | Should -Match 'will be removed in v3\.0\.0'
+        $script:content | Should -Match 'Invoke-M365Assessment -Section'
+    }
+
+    It 'every legacy wrapper invokes Show-WrapperDeprecation' {
+        $missing = @()
+        foreach ($name in $script:wrappers) {
+            # The function body for $name should contain the helper call.
+            # Simpler form: a regex that captures function-block + helper presence.
+            $pattern = "function $([regex]::Escape($name))\s*\{[\s\S]*?Show-WrapperDeprecation -WrapperName '$([regex]::Escape($name))'"
+            if ($script:content -notmatch $pattern) {
+                $missing += $name
+            }
+        }
+        if ($missing.Count -gt 0) {
+            throw "These wrappers are missing the deprecation call:`n$(($missing) -join "`n")"
+        }
+    }
+
+    It 'every legacy wrapper documents the replacement -Section in .NOTES' {
+        $missing = @()
+        foreach ($name in $script:wrappers) {
+            # The function .NOTES block should contain the migration phrase.
+            $pattern = "function $([regex]::Escape($name))\s*\{[\s\S]*?DEPRECATED \(C3 #782\)"
+            if ($script:content -notmatch $pattern) {
+                $missing += $name
+            }
+        }
+        if ($missing.Count -gt 0) {
+            throw "These wrappers are missing the DEPRECATED .NOTES marker:`n$(($missing) -join "`n")"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

C3 ratification: **Invoke-only is the canonical surface going forward.** Adds a one-time-per-session `Write-Warning` to each of the 13 legacy `Get-M365*SecurityConfig` / `*RetentionConfig` wrappers naming their v3.0.0 removal date and pointing to the `Invoke-M365Assessment -Section` replacement.

Wrappers stay exported in v2.9.x so existing scripts keep working — just with audible warnings. Full removal ships in v3.0.0 (separate milestone).

## Departure from the locked plan

The plan said both **"remove from FunctionsToExport in v2.9.0"** AND **"add deprecation warning."** That's contradictory: a removed function can't be called to emit the warning. Implemented the standard two-stage deprecation pattern:
- v2.9 warns + still exports
- v3.0 removes

Documented in each function's `.NOTES` block.

## Once-per-session semantics

A script-scoped hashtable (`$script:WrapperDeprecationWarned`) tracks which wrappers have already warned. A loop calling the same wrapper 50 times produces one warning, not 50.

## Test plan

- [x] `Invoke-Pester -Path './tests'` — 2287/2287 green
- [x] New `tests/Behavior/Wrapper-Deprecation.Tests.ps1` (5 tests):
  - `Show-WrapperDeprecation` helper exists
  - Once-per-session tracker exists
  - Every legacy wrapper invokes the helper with its own name
  - Every legacy wrapper carries the `DEPRECATED (C3 #782)` `.NOTES` marker
  - Warning text mentions v3.0.0 + the migration path

🤖 Generated with [Claude Code](https://claude.com/claude-code)