### PR TITLE
fix(report): surface app-role deficits in HTML Permissions panel (closes #812)

### DIFF
--- a/src/M365-Assess/Common/Build-ReportData.ps1
+++ b/src/M365-Assess/Common/Build-ReportData.ps1
@@ -97,7 +97,13 @@ function Build-ReportDataJson {
         [hashtable]$CmmcHandoff = $null,
 
         [Parameter()]
-        [switch]$IncludeTrend
+        [switch]$IncludeTrend,
+
+        # #812 -- per-section app-role / scope deficits surfaced on the React
+        # Permissions panel. Loaded from <AssessmentFolder>/_PermissionDeficits.json
+        # by Export-AssessmentReport when present.
+        [Parameter()]
+        [object]$PermissionDeficits = $null
     )
 
     # ------------------------------------------------------------------
@@ -428,6 +434,7 @@ function Build-ReportDataJson {
         trendOptIn     = [bool]$IncludeTrend
         cmmcHandoff    = $CmmcHandoff
         cmmcCoverage   = $cmmcCoverage
+        permissions    = $PermissionDeficits
     }
 
     # ------------------------------------------------------------------

--- a/src/M365-Assess/Common/Export-AssessmentReport.ps1
+++ b/src/M365-Assess/Common/Export-AssessmentReport.ps1
@@ -170,6 +170,18 @@ if (-not $OutputPath) {
 $xlsxName   = if ($reportDomainPrefix) { "_Compliance-Matrix_$reportDomainPrefix.xlsx" } else { '_Compliance-Matrix.xlsx' }
 $reportTitle = if ($TenantName -ne 'M365 Tenant') { "$TenantName — M365 Security Assessment" } else { 'M365 Security Assessment' }
 
+# #812: load the deficit map written by Test-GraphPermissions / Test-GraphAppRolePermissions.
+# Hashtable[]/PSCustomObject is fine -- Build-ReportDataJson just passes it through.
+$permissionDeficits = $null
+$deficitPath = Join-Path -Path $AssessmentFolder -ChildPath '_PermissionDeficits.json'
+if (Test-Path -Path $deficitPath) {
+    try {
+        $permissionDeficits = Get-Content -Path $deficitPath -Raw | ConvertFrom-Json
+    } catch {
+        Write-Warning "Could not parse $deficitPath -- skipping Permissions panel data: $($_.Exception.Message)"
+    }
+}
+
 $reportJson = Build-ReportDataJson `
     -AllFindings    $allCisFindings `
     -SectionData    $sectionData `
@@ -178,7 +190,8 @@ $reportJson = Build-ReportDataJson `
     -XlsxFileName   $xlsxName `
     -FrameworkDefs  $allFrameworks `
     -CmmcHandoff    $cmmcHandoff `
-    -IncludeTrend:  $IncludeTrend
+    -IncludeTrend:  $IncludeTrend `
+    -PermissionDeficits $permissionDeficits
 
 # ------------------------------------------------------------------
 # Assemble HTML and write output

--- a/src/M365-Assess/Orchestrator/Connect-RequiredService.ps1
+++ b/src/M365-Assess/Orchestrator/Connect-RequiredService.ps1
@@ -96,7 +96,10 @@ function Connect-RequiredService {
             if ($svc -eq 'Graph' -and -not $script:graphPermissionsChecked) {
                 $script:graphPermissionsChecked = $true
                 if (Get-Command -Name Test-GraphPermissions -ErrorAction SilentlyContinue) {
-                    Test-GraphPermissions -RequiredScopes $graphScopes -SectionScopeMap $sectionScopeMap -ActiveSections $Section
+                    # #812: pass assessment folder so the deficit map is written for
+                    # the HTML Permissions panel + the evidence package to consume.
+                    Test-GraphPermissions -RequiredScopes $graphScopes -SectionScopeMap $sectionScopeMap `
+                        -ActiveSections $Section -OutputFolder $assessmentFolder
                 }
             }
 

--- a/src/M365-Assess/Orchestrator/Test-GraphPermissions.ps1
+++ b/src/M365-Assess/Orchestrator/Test-GraphPermissions.ps1
@@ -17,6 +17,58 @@
 # docs/PERMISSIONS.md (B7 #778). Idempotent re-source on each load.
 . (Join-Path -Path $PSScriptRoot -ChildPath '..\Setup\PermissionDefinitions.ps1')
 
+function Write-PermissionDeficitsFile {
+    <#
+    .SYNOPSIS
+        Writes _PermissionDeficits.json with structured per-section deficit data.
+    .DESCRIPTION
+        Companion to Test-GraphAppRolePermissions / Test-GraphPermissions
+        (#812 B2 followup). The HTML report's Permissions panel and the evidence
+        package both consume this file. The shape is forward-compatible -- new
+        keys can be added without breaking older readers.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$OutputFolder,
+        [Parameter(Mandatory)] [ValidateSet('Delegated', 'AppOnly')] [string]$AuthMode,
+        [Parameter(Mandatory)] [string[]]$ActiveSections,
+        [Parameter()] [object]$RequiredRoles,   # HashSet[string] or [string[]]
+        [Parameter()] [object]$GrantedRoles,    # HashSet[string] or [string[]]
+        [Parameter()] [object]$MissingByRole = @(),
+        [Parameter()] [hashtable]$PerSection = @{}
+    )
+
+    $reqArr = @($RequiredRoles | Where-Object { $_ })
+    $grtArr = @($GrantedRoles  | Where-Object { $_ })
+    $missArr = @($MissingByRole | Where-Object { $_ })
+
+    # Per-section view: which roles each section needs, and which are missing.
+    $sectionDeficits = [ordered]@{}
+    foreach ($s in ($ActiveSections | Sort-Object -Unique)) {
+        $required = if ($PerSection.ContainsKey($s)) { @($PerSection[$s]) } else { @() }
+        $missing  = @($required | Where-Object { $missArr -icontains $_ })
+        $sectionDeficits[$s] = [ordered]@{
+            required = $required
+            missing  = $missing
+            ok       = ($missing.Count -eq 0)
+        }
+    }
+
+    $payload = [ordered]@{
+        schemaVersion  = '1.0'
+        authMode       = $AuthMode
+        generatedAtUtc = (Get-Date).ToUniversalTime().ToString('o')
+        activeSections = $ActiveSections
+        required       = $reqArr
+        granted        = $grtArr
+        missing        = $missArr
+        sections       = $sectionDeficits
+    }
+    $path = Join-Path -Path $OutputFolder -ChildPath '_PermissionDeficits.json'
+    $payload | ConvertTo-Json -Depth 6 | Set-Content -Path $path -Encoding UTF8
+    Write-AssessmentLog -Level INFO -Message "Wrote permission deficit map: $path" -Section 'Setup'
+}
+
 function Test-GraphAppRolePermissions {
     <#
     .SYNOPSIS
@@ -37,6 +89,10 @@ function Test-GraphAppRolePermissions {
         The Get-MgContext output for the current Graph connection.
     .PARAMETER ActiveSections
         Section names the user selected for this run.
+    .PARAMETER OutputFolder
+        Optional. When supplied, writes _PermissionDeficits.json into this folder
+        with the structured deficit map so the HTML report's Permissions panel
+        and the evidence package can surface it (#812 B2 followup).
     #>
     [CmdletBinding()]
     param(
@@ -44,7 +100,10 @@ function Test-GraphAppRolePermissions {
         [object]$Context,
 
         [Parameter(Mandatory)]
-        [string[]]$ActiveSections
+        [string[]]$ActiveSections,
+
+        [Parameter()]
+        [string]$OutputFolder
     )
 
     $clientId = $Context.ClientId
@@ -117,6 +176,11 @@ function Test-GraphAppRolePermissions {
         if ($missing.Count -eq 0) {
             Write-Host "    $([char]0x2714) All $($requiredRoles.Count) required Graph app role(s) granted" -ForegroundColor Green
             Write-AssessmentLog -Level INFO -Message "Graph app-role validation passed ($($requiredRoles.Count) roles)" -Section 'Setup'
+            if ($OutputFolder -and (Test-Path -Path $OutputFolder -PathType Container)) {
+                Write-PermissionDeficitsFile -OutputFolder $OutputFolder -AuthMode 'AppOnly' `
+                    -ActiveSections $ActiveSections -RequiredRoles $requiredRoles -GrantedRoles $grantedRoles `
+                    -MissingByRole @() -PerSection $perSection
+            }
             return
         }
 
@@ -146,6 +210,12 @@ function Test-GraphAppRolePermissions {
         Write-Host ''
 
         Write-AssessmentLog -Level WARN -Message "Missing Graph app roles: $($missing -join ', ')" -Section 'Setup'
+
+        if ($OutputFolder -and (Test-Path -Path $OutputFolder -PathType Container)) {
+            Write-PermissionDeficitsFile -OutputFolder $OutputFolder -AuthMode 'AppOnly' `
+                -ActiveSections $ActiveSections -RequiredRoles $requiredRoles -GrantedRoles $grantedRoles `
+                -MissingByRole $missing -PerSection $perSection
+        }
     }
     catch {
         # Structured "could not verify" warning per the AC -- never silent.
@@ -176,6 +246,10 @@ function Test-GraphPermissions {
         Hashtable mapping section names to their required scope arrays.
     .PARAMETER ActiveSections
         Array of section names the user selected.
+    .PARAMETER OutputFolder
+        Optional. When supplied, writes _PermissionDeficits.json into this folder
+        so the HTML report's Permissions panel and the evidence package can
+        surface the deficit map (#812 B2 followup).
     #>
     [CmdletBinding()]
     param(
@@ -186,7 +260,10 @@ function Test-GraphPermissions {
         [hashtable]$SectionScopeMap,
 
         [Parameter(Mandatory)]
-        [string[]]$ActiveSections
+        [string[]]$ActiveSections,
+
+        [Parameter()]
+        [string]$OutputFolder
     )
 
     $context = Get-MgContext -ErrorAction SilentlyContinue
@@ -201,7 +278,7 @@ function Test-GraphPermissions {
     # Hand off to the app-role validator instead of skipping silently.
     if ($grantedScopes.Count -eq 0 -or ($grantedScopes.Count -eq 1 -and $grantedScopes[0] -eq '.default')) {
         Write-Host '    i App-only auth detected -- validating Graph app role assignments instead of delegated scopes...' -ForegroundColor DarkGray
-        Test-GraphAppRolePermissions -Context $context -ActiveSections $ActiveSections
+        Test-GraphAppRolePermissions -Context $context -ActiveSections $ActiveSections -OutputFolder $OutputFolder
         return
     }
 
@@ -212,6 +289,11 @@ function Test-GraphPermissions {
     if ($missingScopes.Count -eq 0) {
         Write-Host "    $([char]0x2714) All $($RequiredScopes.Count) required Graph scopes granted" -ForegroundColor Green
         Write-AssessmentLog -Level INFO -Message "Graph scope validation passed ($($RequiredScopes.Count) scopes)" -Section 'Setup'
+        if ($OutputFolder -and (Test-Path -Path $OutputFolder -PathType Container)) {
+            Write-PermissionDeficitsFile -OutputFolder $OutputFolder -AuthMode 'Delegated' `
+                -ActiveSections $ActiveSections -RequiredRoles $RequiredScopes -GrantedRoles $grantedScopes `
+                -MissingByRole @() -PerSection $SectionScopeMap
+        }
         return
     }
 
@@ -253,4 +335,10 @@ function Test-GraphPermissions {
     Write-Host ''
 
     Write-AssessmentLog -Level WARN -Message "Missing Graph scopes: $($missingScopes -join ', ')" -Section 'Setup'
+
+    if ($OutputFolder -and (Test-Path -Path $OutputFolder -PathType Container)) {
+        Write-PermissionDeficitsFile -OutputFolder $OutputFolder -AuthMode 'Delegated' `
+            -ActiveSections $ActiveSections -RequiredRoles $RequiredScopes -GrantedRoles $grantedScopes `
+            -MissingByRole $missingScopes -PerSection $SectionScopeMap
+    }
 }

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -909,6 +909,40 @@ function ScoringViews() {
   }, v.label))), body);
 }
 
+// ======================== Permissions panel (#812 B2 followup) ========================
+// Renders the deficit map written by Test-GraphPermissions / Test-GraphAppRolePermissions.
+// Source: window.REPORT_DATA.permissions; null when the assessment ran without
+// the deficit-write seam (older runs, SkipConnection mode, etc.).
+function PermissionsPanel() {
+  const p = D.permissions;
+  if (!p || !p.sections) return null;
+  const sections = Object.entries(p.sections);
+  const allOk = sections.every(([, s]) => s.ok);
+  return /*#__PURE__*/React.createElement("section", {
+    className: "permissions-panel",
+    id: "permissions"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "section-header"
+  }, /*#__PURE__*/React.createElement("h2", null, "Permissions"), /*#__PURE__*/React.createElement("div", {
+    className: "section-sub"
+  }, p.authMode, " auth | ", sections.length, " section", sections.length === 1 ? '' : 's', " checked | ", allOk ? 'all granted' : `${(p.missing || []).length} role(s) missing`)), /*#__PURE__*/React.createElement("table", {
+    className: "permissions-table"
+  }, /*#__PURE__*/React.createElement("thead", null, /*#__PURE__*/React.createElement("tr", null, /*#__PURE__*/React.createElement("th", null, "Section"), /*#__PURE__*/React.createElement("th", null, "Required"), /*#__PURE__*/React.createElement("th", null, "Missing"), /*#__PURE__*/React.createElement("th", null, "Status"))), /*#__PURE__*/React.createElement("tbody", null, sections.map(([name, s]) => /*#__PURE__*/React.createElement("tr", {
+    key: name
+  }, /*#__PURE__*/React.createElement("td", null, /*#__PURE__*/React.createElement("strong", null, name)), /*#__PURE__*/React.createElement("td", null, s.required && s.required.length ? s.required.join(', ') : /*#__PURE__*/React.createElement("span", {
+    className: "muted"
+  }, "none")), /*#__PURE__*/React.createElement("td", null, s.missing && s.missing.length ? s.missing.map((m, i) => /*#__PURE__*/React.createElement("span", {
+    key: i,
+    className: "status-badge unknown"
+  }, m)) : /*#__PURE__*/React.createElement("span", {
+    className: "muted"
+  }, "\u2014")), /*#__PURE__*/React.createElement("td", null, s.ok ? /*#__PURE__*/React.createElement("span", {
+    className: "status-badge pass"
+  }, "OK") : /*#__PURE__*/React.createElement("span", {
+    className: "status-badge fail"
+  }, "deficit")))))));
+}
+
 // ======================== Posture hero ========================
 function Posture() {
   const score = parseFloat(SCORE.Percentage);
@@ -4663,7 +4697,7 @@ function App() {
     activeProfiles: filters.profile || []
   }), /*#__PURE__*/React.createElement(DomainRollup, {
     onJump: onDomainJump
-  }), /*#__PURE__*/React.createElement("div", {
+  }), /*#__PURE__*/React.createElement(PermissionsPanel, null), /*#__PURE__*/React.createElement("div", {
     id: "findings-anchor"
   }), /*#__PURE__*/React.createElement("div", {
     style: {

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -527,6 +527,46 @@ function ScoringViews() {
   );
 }
 
+// ======================== Permissions panel (#812 B2 followup) ========================
+// Renders the deficit map written by Test-GraphPermissions / Test-GraphAppRolePermissions.
+// Source: window.REPORT_DATA.permissions; null when the assessment ran without
+// the deficit-write seam (older runs, SkipConnection mode, etc.).
+function PermissionsPanel() {
+  const p = D.permissions;
+  if (!p || !p.sections) return null;
+  const sections = Object.entries(p.sections);
+  const allOk = sections.every(([, s]) => s.ok);
+  return (
+    <section className="permissions-panel" id="permissions">
+      <div className="section-header">
+        <h2>Permissions</h2>
+        <div className="section-sub">
+          {p.authMode} auth | {sections.length} section{sections.length===1?'':'s'} checked | {allOk ? 'all granted' : `${(p.missing || []).length} role(s) missing`}
+        </div>
+      </div>
+      <table className="permissions-table">
+        <thead>
+          <tr><th>Section</th><th>Required</th><th>Missing</th><th>Status</th></tr>
+        </thead>
+        <tbody>
+          {sections.map(([name, s]) => (
+            <tr key={name}>
+              <td><strong>{name}</strong></td>
+              <td>{s.required && s.required.length ? s.required.join(', ') : <span className="muted">none</span>}</td>
+              <td>
+                {s.missing && s.missing.length
+                  ? s.missing.map((m, i) => <span key={i} className="status-badge unknown">{m}</span>)
+                  : <span className="muted">&mdash;</span>}
+              </td>
+              <td>{s.ok ? <span className="status-badge pass">OK</span> : <span className="status-badge fail">deficit</span>}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}
+
 // ======================== Posture hero ========================
 function Posture() {
   const score = parseFloat(SCORE.Percentage);
@@ -2952,6 +2992,7 @@ function App() {
         <TrendChart/>
         <FrameworkQuilt onSelect={onFrameworkSelect} selected={filters.framework[0]} onProfileSelect={onProfileSelect} activeProfiles={filters.profile || []}/>
         <DomainRollup onJump={onDomainJump}/>
+        <PermissionsPanel/>
         <div id="findings-anchor"/>
         <div style={{marginTop:20}}/>
         <FilterBar filters={filters} setFilters={setFilters} counts={counts} total={FINDINGS.length} search={search} setSearch={setSearch}/>

--- a/src/M365-Assess/assets/report-shell.css
+++ b/src/M365-Assess/assets/report-shell.css
@@ -1042,6 +1042,28 @@ mark.search-hl {
 }
 .scoring-view-more { color: var(--muted); font-size: 11px; padding-top: 4px !important; }
 
+/* ---------- Permissions panel (#812 B2 followup) ---------- */
+.permissions-panel {
+  margin: 24px 0; padding: 18px 20px;
+  background: var(--surface); border: 1px solid var(--border); border-radius: 12px;
+}
+.permissions-table {
+  width: 100%; border-collapse: collapse; margin-top: 12px; font-size: 13px;
+}
+.permissions-table th,
+.permissions-table td {
+  padding: 8px 10px; text-align: left; vertical-align: top;
+  border-bottom: 1px solid var(--border);
+}
+.permissions-table th {
+  font-weight: 600; color: var(--text-soft); background: var(--surface2);
+}
+.permissions-table tr:last-child td { border-bottom: none; }
+.permissions-table .status-badge {
+  display: inline-block; padding: 2px 8px; margin: 2px 4px 2px 0;
+  font-size: 11px; font-weight: 500; border-radius: 999px;
+}
+
 /* ---------- Domain grid ---------- */
 .domain-grid {
   display: grid;

--- a/tests/Common/Build-ReportData.Tests.ps1
+++ b/tests/Common/Build-ReportData.Tests.ps1
@@ -540,6 +540,30 @@ Describe 'Build-ReportData' {
         }
     }
 
+    Context 'Permission deficits passthrough (#812 B2 followup)' {
+        It 'surfaces the deficit object on REPORT_DATA.permissions when supplied' {
+            $deficits = [PSCustomObject]@{
+                schemaVersion = '1.0'
+                authMode      = 'AppOnly'
+                missing       = @('Reports.Read.All')
+                sections      = @{
+                    Identity = @{ required = @('Policy.Read.All','Reports.Read.All'); missing = @('Reports.Read.All'); ok = $false }
+                    Email    = @{ required = @(); missing = @(); ok = $true }
+                }
+            }
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson -PermissionDeficits $deficits)
+            $d.permissions                                    | Should -Not -BeNullOrEmpty
+            $d.permissions.authMode                           | Should -Be 'AppOnly'
+            $d.permissions.sections.Identity.ok               | Should -BeFalse
+            $d.permissions.sections.Email.ok                  | Should -BeTrue
+        }
+
+        It 'leaves REPORT_DATA.permissions null when no deficit data is provided' {
+            $d = ConvertFrom-ReportDataJson (Build-ReportDataJson)
+            $d.permissions | Should -BeNullOrEmpty
+        }
+    }
+
     Context 'Evidence field passthrough (D1 #785 structured schema)' {
         It 'maps legacy free-form Evidence blob to the .raw subfield of structured evidence' {
             $finding = New-Finding

--- a/tests/Orchestrator/Write-PermissionDeficitsFile.Tests.ps1
+++ b/tests/Orchestrator/Write-PermissionDeficitsFile.Tests.ps1
@@ -1,0 +1,55 @@
+BeforeAll {
+    # Stub Write-AssessmentLog so the helper can call it without the orchestrator scope.
+    function Write-AssessmentLog { param($Level, $Message, $Section) }
+    . (Join-Path $PSScriptRoot '../../src/M365-Assess/Orchestrator/Test-GraphPermissions.ps1')
+}
+
+Describe 'Write-PermissionDeficitsFile (#812 B2 followup)' {
+    BeforeEach {
+        $script:folder = Join-Path $TestDrive 'Assessment_test'
+        New-Item -Path $script:folder -ItemType Directory -Force | Out-Null
+    }
+
+    It 'writes _PermissionDeficits.json with the documented schema' {
+        $perSection = @{
+            Identity = @('Policy.Read.All', 'Reports.Read.All')
+            Email    = @()
+        }
+        Write-PermissionDeficitsFile -OutputFolder $script:folder -AuthMode 'AppOnly' `
+            -ActiveSections @('Identity', 'Email') `
+            -RequiredRoles @('Policy.Read.All', 'Reports.Read.All') `
+            -GrantedRoles @('Policy.Read.All') `
+            -MissingByRole @('Reports.Read.All') `
+            -PerSection $perSection
+
+        $jsonPath = Join-Path $script:folder '_PermissionDeficits.json'
+        $jsonPath | Should -Exist
+        $payload = Get-Content $jsonPath -Raw | ConvertFrom-Json
+        $payload.schemaVersion | Should -Be '1.0'
+        $payload.authMode      | Should -Be 'AppOnly'
+        $payload.missing       | Should -Contain 'Reports.Read.All'
+        $payload.sections.Identity.ok      | Should -BeFalse
+        $payload.sections.Identity.missing | Should -Contain 'Reports.Read.All'
+        $payload.sections.Email.ok         | Should -BeTrue
+    }
+
+    It 'records ok=true for every section when nothing is missing' {
+        Write-PermissionDeficitsFile -OutputFolder $script:folder -AuthMode 'Delegated' `
+            -ActiveSections @('Identity') `
+            -RequiredRoles @('Policy.Read.All') `
+            -GrantedRoles @('Policy.Read.All') `
+            -MissingByRole @() `
+            -PerSection @{ Identity = @('Policy.Read.All') }
+
+        $payload = Get-Content (Join-Path $script:folder '_PermissionDeficits.json') -Raw | ConvertFrom-Json
+        $payload.sections.Identity.ok | Should -BeTrue
+    }
+
+    It 'records the auth mode (Delegated vs AppOnly)' {
+        Write-PermissionDeficitsFile -OutputFolder $script:folder -AuthMode 'Delegated' `
+            -ActiveSections @('Identity') -RequiredRoles @() -GrantedRoles @() -MissingByRole @() `
+            -PerSection @{ Identity = @() }
+        $payload = Get-Content (Join-Path $script:folder '_PermissionDeficits.json') -Raw | ConvertFrom-Json
+        $payload.authMode | Should -Be 'Delegated'
+    }
+}


### PR DESCRIPTION
## Summary

B2 follow-up: `Test-GraphPermissions` / `Test-GraphAppRolePermissions` already detect missing scopes/roles per section, but until now the data only flowed to console output. This PR threads the deficit map through to the HTML report so consultants can see at a glance which sections may be producing incomplete results because of insufficient permissions.

## Producer side

- New `Write-PermissionDeficitsFile` helper in `Test-GraphPermissions.ps1` emits `_PermissionDeficits.json` into the assessment folder (schema v1.0, forward-compat).
- Both `Test-GraphPermissions` (delegated) and `Test-GraphAppRolePermissions` (app-only) gain an optional `-OutputFolder` param. When supplied, they write the deficit JSON on every code path (success + missing).
- `Connect-RequiredService.ps1` threads `$assessmentFolder` through to the call.

## Consumer side

- `Build-ReportData.ps1` gets a new `-PermissionDeficits` param. Surfaces the structured object on `REPORT_DATA.permissions`; null when no data is available.
- `Export-AssessmentReport.ps1` reads `_PermissionDeficits.json` and passes it through to `Build-ReportDataJson`.
- New `PermissionsPanel` React component in `report-app.jsx` renders a per-section deficit table (required / missing / status). Inserts between `DomainRollup` and the findings table.
- ~25 lines of CSS reusing existing `status-badge` classes.

## Cross-package benefit

`Export-EvidencePackage.ps1` already references `_PermissionDeficits.json` (it bundles it as `permissions-summary.json` in the auditor handoff ZIP). Until this PR, that file didn't exist — the package fell back to a stub. Now it's actually populated.

## Test plan
- [x] `Invoke-Pester -Path './tests'` — 2292/2292 green (5 new)
- [x] `npm run build` regenerates `report-app.js`
- [x] `node --check` passes on the .js mirror
- [ ] Visual confirmation against a real assessment run is recommended but not blocking — the data flow is exercised by unit tests, the React component renders only when the structured data is present, and the CSS reuses already-tested classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)