### PR TITLE
ci: release-candidate auto-tagging workflow (closes #722)

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,80 @@
+name: Release Candidate
+# #722: pushes to a `release-candidate` branch get auto-tagged as
+# vX.Y.Z-rc.N (where X.Y.Z is the current manifest version and N is
+# the next available RC counter). The tag triggers release.yml's
+# existing `tags: ['v*']` path -- which creates a GitHub pre-release
+# (prerelease=true thanks to the '-' in the tag) and skips PSGallery
+# publish (release.yml line 92 gates on '!contains(github.ref, '-')').
+#
+# Soak window before tagging stable: cut a release-candidate branch,
+# let CI run, optionally promote to a few internal users via GH
+# pre-release artifacts, then tag the stable v2.9.0 from main as
+# usual.
+
+on:
+  push:
+    branches: [release-candidate]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Compute the RC tag without creating it'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  tag-rc:
+    name: Auto-tag release candidate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # need full history for tag listing
+
+      - name: Read manifest version
+        id: version
+        shell: pwsh
+        run: |
+          $v = (Import-PowerShellDataFile -Path ./src/M365-Assess/M365-Assess.psd1).ModuleVersion
+          "version=$v" >> $env:GITHUB_OUTPUT
+          Write-Host "Manifest version: $v"
+
+      - name: Compute next RC number
+        id: rc
+        shell: bash
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          PATTERN="v${VERSION}-rc."
+          # List existing rc tags for this version, sort numerically, pick the next.
+          NEXT=1
+          if git tag -l "${PATTERN}*" | grep -q .; then
+            HIGHEST=$(git tag -l "${PATTERN}*" \
+              | sed "s|^${PATTERN}||" \
+              | sort -n | tail -1)
+            NEXT=$((HIGHEST + 1))
+          fi
+          TAG="v${VERSION}-rc.${NEXT}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Next RC tag: $TAG"
+
+      - name: Create + push tag
+        if: ${{ inputs.dry_run != true }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ steps.rc.outputs.tag }}"
+          # Tag the current commit (the one that just landed on release-candidate)
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release candidate $TAG"
+          git push origin "$TAG"
+          echo "::notice::Tagged $TAG -- release.yml will now build the GH pre-release."
+
+      - name: Dry-run summary
+        if: ${{ inputs.dry_run == true }}
+        run: |
+          echo "DRY RUN -- would create tag: ${{ steps.rc.outputs.tag }}"
+          echo "Skipping git tag/push."

--- a/docs/RELEASE-PROCESS.md
+++ b/docs/RELEASE-PROCESS.md
@@ -146,6 +146,51 @@ Publishing to PSGallery is currently manual; the maintainer pushes via `Publish-
 
 ---
 
+## Release candidates (#722)
+
+For changes you want to soak before tagging stable:
+
+```bash
+# Cut an RC branch from main
+git checkout main && git pull --ff-only
+git checkout -b release-candidate
+git push -u origin release-candidate
+```
+
+Pushing to `release-candidate` triggers `.github/workflows/release-candidate.yml`, which:
+
+1. Reads the manifest version (e.g. `2.9.0`)
+2. Counts existing `v2.9.0-rc.*` tags
+3. Creates the next RC tag (e.g. `v2.9.0-rc.1`)
+4. Pushes the tag
+
+Pushing the tag triggers `.github/workflows/release.yml`, which:
+
+- Marks the GitHub release as `prerelease: true` (because the tag contains `-`)
+- **Skips PSGallery publish** (release.yml gates `!contains(github.ref, '-')`)
+
+So RCs land as **GitHub-only pre-releases**, safely visible to early testers without touching PSGallery.
+
+### Iterating on an RC
+
+Subsequent pushes to `release-candidate` produce `v2.9.0-rc.2`, `rc.3`, etc. The workflow auto-increments by listing existing tags, so you don't have to track the counter.
+
+### Promoting an RC to stable
+
+Once an RC has soaked enough:
+
+1. Open a PR from `release-candidate` -> `main`
+2. Merge as usual
+3. Follow the standard release flow above (version bump if needed, tag, GH release, PSGallery publish)
+
+The stable tag (`v2.9.0`) and the RC tags (`v2.9.0-rc.1`, etc.) coexist; they all show in `git tag --list`.
+
+### Dry-run
+
+Use the `workflow_dispatch` trigger with `dry_run: true` to compute what RC number would be assigned without actually creating the tag. Useful when you're unsure whether a previous run already produced an RC.
+
+---
+
 ## Branch protection
 
 `main` requires:


### PR DESCRIPTION
## Summary

Adds a soak-window path so changes can ship as GitHub pre-releases before being promoted to stable + PSGallery.

Pushes to a `release-candidate` branch trigger the new `release-candidate.yml` workflow, which:

1. Reads the manifest version (e.g. `2.9.0`)
2. Counts existing `v<version>-rc.*` tags
3. Creates the next tag (`v2.9.0-rc.1`, then `rc.2`, `rc.3`, ...)
4. Pushes the tag — triggering `release.yml`'s existing `tags: ['v*']` path

## How it composes with existing release.yml

The downstream `release.yml` machinery already handles RC tags correctly:

- `prerelease: contains(version, '-')` → marks as **GH pre-release**
- PSGallery publish gated on `!contains(github.ref, '-')` → **skipped** for RCs

So RCs land as GitHub-only pre-releases, safely visible to early testers without touching PSGallery. Stable promotion is the existing `v<version>` tag flow on `main`.

## Scope kept tight

Per the locked plan: workflow-only. Branch protection on `release-candidate`, distribution-channel split (`-AllowPrerelease` on `Install-Module`), and version-bump automation are explicitly out of scope — they each warrant their own milestone.

## Docs

`docs/RELEASE-PROCESS.md` gains a "Release candidates (#722)" section with the cut-RC, iterate, and promote flows plus the dry-run escape hatch.

## Test plan

- [x] Workflow YAML parses (no syntax errors)
- [x] Smoke regression: 357/357 green
- [ ] First real RC creation will validate the auto-incrementing tag math (test plan: cut a `release-candidate` branch from main once this merges, push, verify `v2.9.0-rc.1` appears as a GH pre-release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)