### PR TITLE
fix(baseline): repair parser binding causing silent HTML report failure (v2.9.1)

### DIFF
--- a/.claude/rules/releases.md
+++ b/.claude/rules/releases.md
@@ -1,0 +1,79 @@
+---
+description: Version bump and release workflow rules
+globs: ["*.ps1", "*.psd1", "README.md", "CHANGELOG.md"]
+---
+
+# Version Bump and Release Rules
+
+## Version Increments Require Explicit Permission
+
+**NEVER bump the assessment version without asking the user first.** Even if the work clearly warrants a version bump, always ask:
+
+> "This work warrants a version bump to X.Y.Z. Should I increment the version?"
+
+Wait for explicit approval before touching any version location listed in `.claude/rules/versions.md`.
+
+## Every Version Bump Gets a GitHub Release
+
+When the user approves a version bump, follow this sequence:
+
+1. **Update all version locations** listed in `.claude/rules/versions.md` (all 14 locations in a single pass)
+2. **Update CHANGELOG.md** with a new section for the version, documenting all changes since the last release
+3. **Commit** the version bump and changelog update; open a PR
+4. **WAIT for live tenant verification** (see next section) — do not merge yet
+5. **After the user reports the live test passed**, merge the version-bump PR
+6. **Then** create the GitHub release tag:
+   ```bash
+   gh release create vX.Y.Z --title "vX.Y.Z" --notes-file - <<< "$(changelog excerpt)"
+   ```
+7. The tag triggers `release.yml`, which runs validate + create-release + PSGallery publish
+
+## Live Tenant Verification Is a Hard Precondition
+
+**Before tagging, releasing, or publishing — a human MUST run an end-to-end live tenant assessment and physically validate the output. No exceptions, regardless of release size.**
+
+CI green is necessary but not sufficient. CI runs against synthetic fixtures; real Microsoft Graph / EXO / SharePoint behavior is a separate verification surface. v2.9.0 shipped to PSGallery with two distinct bugs that broke HTML report generation — neither caught by CI, both caught immediately by the first live tenant test:
+
+1. A PowerShell parser-binding bug in `Get-BaselineTrend` that silently dropped the HTML when `-AutoBaseline` was supplied
+2. A `ConvertTo-Json` array-shape mismatch in `PermissionsPanel` that threw at render time and unmounted the entire React app, leaving a black screen
+
+Both shipped because no human ran the assessment against a real tenant before tagging.
+
+### The verification checklist
+
+The user runs each step. The agent does NOT have credentials for a live tenant — the agent waits.
+
+1. **Run** `Invoke-M365Assessment -TenantId <tenant>` with the parameter set that exercises the new feature(s) being released. For releases with baseline / drift / report changes, **always include `-AutoBaseline`** — that path historically hides bugs that fixture tests miss
+2. **Open the HTML report** in a browser. Click through the sections that changed. Confirm new components render and old ones still work. **A black or blank screen is a runtime React error** — open dev tools console to see the stack
+3. **Validate the XLSX** if matrix changes shipped: open it, look at the new sheets, confirm framework-mapping columns still display and counts make sense
+4. **Inspect the assessment folder** for unexpected absence of files. The v2.9.0 baseline bug manifested as "no HTML, only CSVs" — only visible by listing the folder
+5. **Read the `_Assessment-Log_*.txt`** for any WARN-level entries that indicate something silently failed. The orchestrator catches and logs rather than aborts; silent failures hide in the log
+
+### When the live test fails
+
+File a bug-fix PR, push to the version-bump branch, restart the verification cycle. The version-bump PR does not merge until live verification passes.
+
+### What counts as approval
+
+Only an explicit "live test passed" / "looks good after running it" / equivalent message from the user authorizes the merge + tag step. A "looks good" on the version-bump PR alone is approval to **discuss merging**, not to tag and publish — the agent must still wait for the live-test confirmation.
+
+If the user has not yet run the live test, the agent does not tag or publish, even if every other gate is green.
+
+## Changelog Format
+
+Follow [Keep a Changelog](https://keepachangelog.com/) conventions:
+
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+
+### Added
+### Changed
+### Fixed
+### Removed
+```
+
+## Semver Rules
+
+- **MAJOR** (1.0.0): Breaking changes to output format, removed collectors, or changed parameters
+- **MINOR** (0.X.0): New collectors, new checks, new report sections, new parameters
+- **PATCH** (0.0.X): Bug fixes, documentation, cosmetic report changes, dependency updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to M365 Assess are documented here. This project uses [Conve
 
 ## [Unreleased]
 
+## [2.9.1] - 2026-04-26
+
+Hotfix to v2.9.0.
+
+### Fixed
+- **HTML report generation silently failed when `-AutoBaseline` was supplied.** PowerShell's parser interpreted `New-Object -TypeName System.Collections.Generic.Dictionary[string, System.IO.DirectoryInfo]` (introduced in C1 #780 / v2.9.0) as an array literal — the comma between the two type parameters became the array operator, producing `Cannot convert 'System.Object[]' to the type 'System.String' required by parameter 'TypeName'` at runtime. Switched to `::new()` which parses the type literal unambiguously. Added the previously-missing `tests/Common/Get-BaselineTrend.Tests.ps1` regression suite — the bug slipped through because the function had zero Pester coverage and the runtime parse only fails inside the `Build-ReportData` -> `Build-SectionHtml` -> `Get-BaselineTrend` call stack
+- **Report-generation failures no longer get swallowed silently.** The `catch` block in `Invoke-M365Assessment.ps1` now also calls `Write-Warning` and points at the log file path, instead of writing only to the assessment log. A consultant running a 5-minute assessment shouldn't have to grep the log to discover the report didn't generate
+
 ## [2.9.0] - 2026-04-26
 
 The **Trust Hardening** release. Surfaced by an external review on 2026-04-25; closed all 30+ child issues + the parent epic (#766) over Sprints 1-9.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ All notable changes to M365 Assess are documented here. This project uses [Conve
 
 ## [2.9.1] - 2026-04-26
 
-Hotfix to v2.9.0.
+Hotfix to v2.9.0. Caught by live-tenant validation post-tag — the underlying lesson is also addressed by a new `.claude/rules/releases.md` rule requiring live verification before any future tag/publish.
 
 ### Fixed
+- **HTML report rendered as a blank black screen** when `window.REPORT_DATA.permissions.sections.<X>.required` came back empty. `ConvertTo-Json` round-trips empty arrays as `null` and single-element arrays as bare scalars; the new `PermissionsPanel` React component (#812 / v2.9.0) called `.join()` on the field directly. Empty `required: []` for sections like `Email` (which uses EXO, not Graph) became `null`, the call threw, and React unmounted the entire app tree. Fixed by routing all three array fields (`required`, `missing`, top-level `missing`) through an `asArray` coercion helper inside the component
 - **HTML report generation silently failed when `-AutoBaseline` was supplied.** PowerShell's parser interpreted `New-Object -TypeName System.Collections.Generic.Dictionary[string, System.IO.DirectoryInfo]` (introduced in C1 #780 / v2.9.0) as an array literal — the comma between the two type parameters became the array operator, producing `Cannot convert 'System.Object[]' to the type 'System.String' required by parameter 'TypeName'` at runtime. Switched to `::new()` which parses the type literal unambiguously. Added the previously-missing `tests/Common/Get-BaselineTrend.Tests.ps1` regression suite — the bug slipped through because the function had zero Pester coverage and the runtime parse only fails inside the `Build-ReportData` -> `Build-SectionHtml` -> `Get-BaselineTrend` call stack
 - **Report-generation failures no longer get swallowed silently.** The `catch` block in `Invoke-M365Assessment.ps1` now also calls `Write-Warning` and points at the log file path, instead of writing only to the assessment log. A consultant running a 5-minute assessment shouldn't have to grep the log to discover the report didn't generate
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [![Coverage](https://img.shields.io/badge/coverage-check%20CI-informational)](https://github.com/Galvnyz/M365-Assess/actions/workflows/ci.yml)
 [![PowerShell 7.x](https://img.shields.io/badge/PowerShell-7.x-blue?logo=powershell&logoColor=white)](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows)
 [![Read-Only](https://img.shields.io/badge/Operations-Read--Only-brightgreen)](.)
-[![Version](https://img.shields.io/badge/version-2.9.0-blue)](.)
+[![Version](https://img.shields.io/badge/version-2.9.1-blue)](.)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 </div>

--- a/src/M365-Assess/Common/Get-BaselineTrend.ps1
+++ b/src/M365-Assess/Common/Get-BaselineTrend.ps1
@@ -61,7 +61,14 @@ function Get-BaselineTrend {
     # both so post-v2.9.0 baselines (GUID-keyed) and pre-v2.9.0 baselines
     # (TenantId-keyed) both feed the trend chart.
     $safeTenant = $TenantId -replace '[^\w\.\-]', '_'
-    $matchedDirs = New-Object -TypeName System.Collections.Generic.Dictionary[string, System.IO.DirectoryInfo]
+    # NB: must use ::new() not `New-Object -TypeName ...` here -- the comma in
+    # the generic Dictionary type name is parsed as the array operator by
+    # PowerShell when bound to -TypeName, producing 'Cannot convert Object[] to
+    # System.String required by parameter TypeName' at runtime. ::new() parses
+    # the [...] unambiguously as a type literal. Bug surfaced in v2.9.0 when a
+    # real tenant ran with -AutoBaseline; HTML report generation died inside
+    # the catch in Invoke-M365Assessment.ps1 and silently dropped the report.
+    $matchedDirs = [System.Collections.Generic.Dictionary[string, System.IO.DirectoryInfo]]::new()
     foreach ($d in (Get-ChildItem -Path $BaselinesRoot -Directory -Filter "*_${safeTenant}" -ErrorAction SilentlyContinue)) {
         if (-not $matchedDirs.ContainsKey($d.FullName)) { $matchedDirs[$d.FullName] = $d }
     }

--- a/src/M365-Assess/Invoke-M365Assessment.ps1
+++ b/src/M365-Assess/Invoke-M365Assessment.ps1
@@ -1355,7 +1355,14 @@ if (Test-Path -Path $reportScriptPath) {
         }
     }
     catch {
-        Write-AssessmentLog -Level WARN -Message "HTML report generation failed: $($_.Exception.Message)"
+        # Surface report-generation failures to BOTH the log file AND the console.
+        # This block exists so a partial-data run still leaves the per-collector
+        # CSVs on disk, but a SILENT failure here means consultants run a 5-minute
+        # assessment and never find out the report didn't generate. Show it.
+        $msg = "HTML report generation failed: $($_.Exception.Message)"
+        Write-AssessmentLog -Level WARN -Message $msg
+        Write-Warning $msg
+        Write-Host "    See $script:logFilePath for the full error context." -ForegroundColor Yellow
     }
 }
 

--- a/src/M365-Assess/M365-Assess.psd1
+++ b/src/M365-Assess/M365-Assess.psd1
@@ -3,7 +3,7 @@
     # Generated: 2026-03-08
 
     RootModule        = 'M365-Assess.psm1'
-    ModuleVersion     = '2.9.0'
+    ModuleVersion     = '2.9.1'
     GUID              = 'f7e3b2a1-4c5d-6e8f-9a0b-1c2d3e4f5a6b'
     Author            = 'Galvnyz'
     CompanyName       = 'Community'
@@ -242,7 +242,7 @@
             IconUri      = 'https://raw.githubusercontent.com/Galvnyz/M365-Assess/main/src/M365-Assess/assets/m365-assess-logo.png'
             LicenseUri   = 'https://github.com/Galvnyz/M365-Assess/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/Galvnyz/M365-Assess'
-            ReleaseNotes = 'v2.9.0 - Trust Hardening release. Adds standardized evidence schema (8 optional fields on Add-SecuritySetting; HTML appendix + XLSX Evidence Details sheet), sanitized evidence package (-EvidencePackage + -Redact with deterministic SHA-256 hash tokens), license-adjusted scoring views (6-tab toggle on executive summary), remediation export formats (Export-M365Remediation: GitHub Issues markdown, executive-summary markdown, Jira CSV, technical backlog), HTML Permissions panel surfacing app-role/scope deficits, deprecation warnings on the 13 legacy Get-M365*SecurityConfig wrappers (removal in v3.0.0), Linux/macOS cross-platform smoke lane, behavioral test suite (29 tests). Previous earlier work in this window: data-handling docs, sovereign cloud support matrix, React provenance + npm audit, baseline storage normalized to tenant GUID, mocked Graph/EXO fixture infrastructure.'
+            ReleaseNotes = 'v2.9.1 - Hotfix. PowerShell parser ambiguity in Get-BaselineTrend caused HTML report generation to fail silently when -AutoBaseline was supplied: New-Object -TypeName System.Collections.Generic.Dictionary[string, System.IO.DirectoryInfo] was parsed as an array literal, yielding "Cannot convert Object[] to System.String required by parameter TypeName" inside Build-ReportData -- and the catch block in Invoke-M365Assessment swallowed the failure to a WARN log line. Switched to ::new() which parses unambiguously, made the report-generation catch block also Write-Warning to console so silent failures stop happening, added regression test coverage for Get-BaselineTrend (no prior tests). v2.9.0: Trust Hardening release with evidence schema, sanitized evidence package, license-adjusted scoring views, remediation export formats, HTML Permissions panel, wrapper deprecation, cross-platform smoke lane, behavioral tests.'
         }
     }
 }

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -916,8 +916,12 @@ function ScoringViews() {
 function PermissionsPanel() {
   const p = D.permissions;
   if (!p || !p.sections) return null;
+  // ConvertTo-Json round-trips empty arrays as null and single-element arrays
+  // as bare scalars. Coerce defensively so .join() / .length / .map() always work.
+  const asArray = v => Array.isArray(v) ? v : v == null ? [] : [v];
   const sections = Object.entries(p.sections);
   const allOk = sections.every(([, s]) => s.ok);
+  const missingTotal = asArray(p.missing).length;
   return /*#__PURE__*/React.createElement("section", {
     className: "permissions-panel",
     id: "permissions"
@@ -925,22 +929,26 @@ function PermissionsPanel() {
     className: "section-header"
   }, /*#__PURE__*/React.createElement("h2", null, "Permissions"), /*#__PURE__*/React.createElement("div", {
     className: "section-sub"
-  }, p.authMode, " auth | ", sections.length, " section", sections.length === 1 ? '' : 's', " checked | ", allOk ? 'all granted' : `${(p.missing || []).length} role(s) missing`)), /*#__PURE__*/React.createElement("table", {
+  }, p.authMode, " auth | ", sections.length, " section", sections.length === 1 ? '' : 's', " checked | ", allOk ? 'all granted' : `${missingTotal} role(s) missing`)), /*#__PURE__*/React.createElement("table", {
     className: "permissions-table"
-  }, /*#__PURE__*/React.createElement("thead", null, /*#__PURE__*/React.createElement("tr", null, /*#__PURE__*/React.createElement("th", null, "Section"), /*#__PURE__*/React.createElement("th", null, "Required"), /*#__PURE__*/React.createElement("th", null, "Missing"), /*#__PURE__*/React.createElement("th", null, "Status"))), /*#__PURE__*/React.createElement("tbody", null, sections.map(([name, s]) => /*#__PURE__*/React.createElement("tr", {
-    key: name
-  }, /*#__PURE__*/React.createElement("td", null, /*#__PURE__*/React.createElement("strong", null, name)), /*#__PURE__*/React.createElement("td", null, s.required && s.required.length ? s.required.join(', ') : /*#__PURE__*/React.createElement("span", {
-    className: "muted"
-  }, "none")), /*#__PURE__*/React.createElement("td", null, s.missing && s.missing.length ? s.missing.map((m, i) => /*#__PURE__*/React.createElement("span", {
-    key: i,
-    className: "status-badge unknown"
-  }, m)) : /*#__PURE__*/React.createElement("span", {
-    className: "muted"
-  }, "\u2014")), /*#__PURE__*/React.createElement("td", null, s.ok ? /*#__PURE__*/React.createElement("span", {
-    className: "status-badge pass"
-  }, "OK") : /*#__PURE__*/React.createElement("span", {
-    className: "status-badge fail"
-  }, "deficit")))))));
+  }, /*#__PURE__*/React.createElement("thead", null, /*#__PURE__*/React.createElement("tr", null, /*#__PURE__*/React.createElement("th", null, "Section"), /*#__PURE__*/React.createElement("th", null, "Required"), /*#__PURE__*/React.createElement("th", null, "Missing"), /*#__PURE__*/React.createElement("th", null, "Status"))), /*#__PURE__*/React.createElement("tbody", null, sections.map(([name, s]) => {
+    const req = asArray(s.required);
+    const miss = asArray(s.missing);
+    return /*#__PURE__*/React.createElement("tr", {
+      key: name
+    }, /*#__PURE__*/React.createElement("td", null, /*#__PURE__*/React.createElement("strong", null, name)), /*#__PURE__*/React.createElement("td", null, req.length ? req.join(', ') : /*#__PURE__*/React.createElement("span", {
+      className: "muted"
+    }, "none")), /*#__PURE__*/React.createElement("td", null, miss.length ? miss.map((m, i) => /*#__PURE__*/React.createElement("span", {
+      key: i,
+      className: "status-badge unknown"
+    }, m)) : /*#__PURE__*/React.createElement("span", {
+      className: "muted"
+    }, "\u2014")), /*#__PURE__*/React.createElement("td", null, s.ok ? /*#__PURE__*/React.createElement("span", {
+      className: "status-badge pass"
+    }, "OK") : /*#__PURE__*/React.createElement("span", {
+      className: "status-badge fail"
+    }, "deficit")));
+  }))));
 }
 
 // ======================== Posture hero ========================

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -534,14 +534,18 @@ function ScoringViews() {
 function PermissionsPanel() {
   const p = D.permissions;
   if (!p || !p.sections) return null;
+  // ConvertTo-Json round-trips empty arrays as null and single-element arrays
+  // as bare scalars. Coerce defensively so .join() / .length / .map() always work.
+  const asArray = v => Array.isArray(v) ? v : (v == null ? [] : [v]);
   const sections = Object.entries(p.sections);
   const allOk = sections.every(([, s]) => s.ok);
+  const missingTotal = asArray(p.missing).length;
   return (
     <section className="permissions-panel" id="permissions">
       <div className="section-header">
         <h2>Permissions</h2>
         <div className="section-sub">
-          {p.authMode} auth | {sections.length} section{sections.length===1?'':'s'} checked | {allOk ? 'all granted' : `${(p.missing || []).length} role(s) missing`}
+          {p.authMode} auth | {sections.length} section{sections.length===1?'':'s'} checked | {allOk ? 'all granted' : `${missingTotal} role(s) missing`}
         </div>
       </div>
       <table className="permissions-table">
@@ -549,18 +553,22 @@ function PermissionsPanel() {
           <tr><th>Section</th><th>Required</th><th>Missing</th><th>Status</th></tr>
         </thead>
         <tbody>
-          {sections.map(([name, s]) => (
-            <tr key={name}>
-              <td><strong>{name}</strong></td>
-              <td>{s.required && s.required.length ? s.required.join(', ') : <span className="muted">none</span>}</td>
-              <td>
-                {s.missing && s.missing.length
-                  ? s.missing.map((m, i) => <span key={i} className="status-badge unknown">{m}</span>)
-                  : <span className="muted">&mdash;</span>}
-              </td>
-              <td>{s.ok ? <span className="status-badge pass">OK</span> : <span className="status-badge fail">deficit</span>}</td>
-            </tr>
-          ))}
+          {sections.map(([name, s]) => {
+            const req = asArray(s.required);
+            const miss = asArray(s.missing);
+            return (
+              <tr key={name}>
+                <td><strong>{name}</strong></td>
+                <td>{req.length ? req.join(', ') : <span className="muted">none</span>}</td>
+                <td>
+                  {miss.length
+                    ? miss.map((m, i) => <span key={i} className="status-badge unknown">{m}</span>)
+                    : <span className="muted">&mdash;</span>}
+                </td>
+                <td>{s.ok ? <span className="status-badge pass">OK</span> : <span className="status-badge fail">deficit</span>}</td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </section>

--- a/tests/Common/Get-BaselineTrend.Tests.ps1
+++ b/tests/Common/Get-BaselineTrend.Tests.ps1
@@ -1,0 +1,70 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '../../src/M365-Assess/Common/Get-BaselineTrend.ps1')
+
+    function New-FakeBaseline {
+        param(
+            [string]$Root,
+            [string]$Label,
+            [string]$Suffix,
+            [DateTime]$SavedAt,
+            [hashtable]$StatusCounts = @{ Pass = 1; Fail = 0; Warning = 0 }
+        )
+        $folder = Join-Path $Root "${Label}_${Suffix}"
+        New-Item -Path $folder -ItemType Directory -Force | Out-Null
+        $manifest = @{ Label = $Label; SavedAt = $SavedAt.ToUniversalTime().ToString('o'); Version = '2.9.0' }
+        $manifest | ConvertTo-Json | Set-Content -Path (Join-Path $folder 'manifest.json') -Encoding UTF8
+        # One synthetic security-config JSON with the documented shape.
+        $rows = foreach ($s in $StatusCounts.Keys) {
+            1..$StatusCounts[$s] | ForEach-Object { @{ CheckId = "X-$s-$_"; Status = $s } }
+        }
+        @($rows) | ConvertTo-Json | Set-Content -Path (Join-Path $folder 'sample-config.json') -Encoding UTF8
+    }
+}
+
+Describe 'Get-BaselineTrend (regression: TypeName parser binding)' {
+
+    BeforeEach {
+        # TestDrive is shared per-Describe; clean to keep tests independent.
+        $script:root = Join-Path $TestDrive 'Baselines'
+        if (Test-Path $script:root) { Remove-Item -Path $script:root -Recurse -Force }
+        New-Item -Path $script:root -ItemType Directory -Force | Out-Null
+    }
+
+    It 'does not throw the Object[] -> System.String TypeName binding error (v2.9.0 hotfix)' {
+        # Regression: in v2.9.0 the implementation used
+        #   New-Object -TypeName System.Collections.Generic.Dictionary[string, ...]
+        # which the PS parser can interpret as an array literal -- producing
+        # 'Cannot convert Object[] to System.String required by parameter TypeName'
+        # at runtime, only when called from the report path, not from tests
+        # that mocked around the line.
+        New-FakeBaseline -Root $script:root -Label 'auto_2026-04-26' `
+            -Suffix 'contoso.onmicrosoft.com' -SavedAt (Get-Date)
+        { Get-BaselineTrend -BaselinesRoot $script:root -TenantId 'contoso.onmicrosoft.com' } |
+            Should -Not -Throw
+    }
+
+    It 'returns one snapshot when one baseline matches the legacy TenantId suffix' {
+        New-FakeBaseline -Root $script:root -Label 'auto_2026-04-26' `
+            -Suffix 'contoso.onmicrosoft.com' -SavedAt (Get-Date)
+        $result = @(Get-BaselineTrend -BaselinesRoot $script:root -TenantId 'contoso.onmicrosoft.com')
+        $result.Count | Should -Be 1
+    }
+
+    It 'unions GUID-suffixed AND legacy TenantId-suffixed baselines (C1 #780)' {
+        # Legacy folder
+        New-FakeBaseline -Root $script:root -Label 'auto_2026-04-20' `
+            -Suffix 'contoso.onmicrosoft.com' -SavedAt (Get-Date).AddDays(-6)
+        # GUID-keyed folder
+        $guid = '11111111-2222-3333-4444-555555555555'
+        New-FakeBaseline -Root $script:root -Label 'auto_2026-04-26' `
+            -Suffix $guid -SavedAt (Get-Date)
+        $result = @(Get-BaselineTrend -BaselinesRoot $script:root `
+            -TenantId 'contoso.onmicrosoft.com' -TenantGuid $guid)
+        $result.Count | Should -Be 2
+    }
+
+    It 'returns an empty array when the baselines root does not exist' {
+        $result = @(Get-BaselineTrend -BaselinesRoot (Join-Path $TestDrive 'nope') -TenantId 'x.onmicrosoft.com')
+        $result.Count | Should -Be 0
+    }
+}


### PR DESCRIPTION
## Summary

Live-tenant test against `dz9m` caught a real bug shipped in v2.9.0. When `-AutoBaseline` was supplied, HTML report generation silently failed and the user got a folder full of CSVs but no HTML.

## Root cause

`Get-BaselineTrend.ps1` line 64 (introduced by C1 #780 in v2.9.0) called:

```powershell
New-Object -TypeName System.Collections.Generic.Dictionary[string, System.IO.DirectoryInfo]
```

PowerShell's parser interpreted `[string, System.IO.DirectoryInfo]` as an array literal — the comma operator at the outer scope — producing `Cannot convert 'System.Object[]' to the type 'System.String' required by parameter 'TypeName'` at runtime. The `catch` block in `Invoke-M365Assessment.ps1` then swallowed the failure into a `WARN` log line, so the only signal was "there's no HTML report in the output folder."

## Two fixes

1. **Switch to `::new()`** in `Get-BaselineTrend.ps1`. The bracketed type literal parses unambiguously inside `[Type]::new()`. Added the previously-missing `tests/Common/Get-BaselineTrend.Tests.ps1` regression suite — the bug slipped through because the function had zero Pester coverage and the parse failure only manifests inside the `Build-ReportData` -> `Build-SectionHtml` -> `Get-BaselineTrend` call stack.
2. **Report-generation catch block now `Write-Warning`s to console** and points at the log file path, instead of writing only to the assessment log. Silent failures of a 5-minute assessment that produces no HTML are user-hostile — the `catch` should preserve partial CSV output (its purpose) without hiding what went wrong.

## Bumps

- `psd1` ModuleVersion 2.9.0 → 2.9.1
- `psd1` ReleaseNotes
- README badge 2.9.0 → 2.9.1
- CHANGELOG gains a `[2.9.1]` hotfix entry

## Test plan

- [x] `Invoke-Pester` 444/444 green (4 new regression tests for `Get-BaselineTrend`)
- [x] Manual repro confirms `Get-BaselineTrend` now returns expected snapshot data
- [x] First regression test explicitly asserts the `Object[] -> System.String` binding error doesn't reproduce
- [ ] Live-tenant rerun with `-AutoBaseline` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)