### PR TITLE
feat(report): UI polish bundle (#834 + #835 + #836)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "m365-assess-report",
       "version": "1.0.0",
       "devDependencies": {
-        "@babel/cli": "^7.24.0",
-        "@babel/core": "^7.24.0",
-        "@babel/preset-react": "^7.24.0"
+        "@babel/cli": "^7.28.0",
+        "@babel/core": "^7.28.0",
+        "@babel/preset-react": "^7.28.0"
       }
     },
     "node_modules/@babel/cli": {

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -461,29 +461,6 @@ function Sidebar({
     className: 'nav-subitem' + (activeSubsection === 'identity-email' ? ' active' : ''),
     onClick: closeIfMobile
   }, "Email auth")))), /*#__PURE__*/React.createElement("div", {
-    className: "nav-label nav-label-collapsible",
-    style: {
-      marginTop: 14
-    },
-    onClick: () => setDomainsCollapsed(c => !c)
-  }, /*#__PURE__*/React.createElement("span", null, "Domains"), /*#__PURE__*/React.createElement("span", {
-    className: "nav-label-chev"
-  }, domainsCollapsed ? '+' : '−')), !domainsCollapsed && domains.map(d => {
-    const fails = domainCounts.fail[d] || 0;
-    const total = domainCounts.total[d] || 0;
-    return /*#__PURE__*/React.createElement("a", {
-      href: "#findings-anchor",
-      key: d,
-      onClick: e => {
-        e.preventDefault();
-        onDomainJump(d);
-        closeIfMobile();
-      },
-      className: 'nav-item' + (activeDomain === d ? ' active' : '')
-    }, /*#__PURE__*/React.createElement("span", null, d), /*#__PURE__*/React.createElement("span", {
-      className: 'count' + (fails ? ' pill-fail' : '')
-    }, fails || total));
-  }), /*#__PURE__*/React.createElement("div", {
     className: "nav-label nav-label-emphasis",
     style: {
       marginTop: 14
@@ -519,7 +496,33 @@ function Sidebar({
     className: "nav-subitem"
   }, "Later ", /*#__PURE__*/React.createElement("span", {
     className: "count"
-  }, ROADMAP_COUNTS.later)))))), /*#__PURE__*/React.createElement("div", {
+  }, ROADMAP_COUNTS.later))), it.id === 'findings' && /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement("a", {
+    href: "#findings-anchor",
+    onClick: e => {
+      e.preventDefault();
+      setDomainsCollapsed(c => !c);
+    },
+    className: "nav-item"
+  }, /*#__PURE__*/React.createElement("span", null, "Domains"), /*#__PURE__*/React.createElement("span", {
+    className: "nav-expand-icon"
+  }, domainsCollapsed ? '+' : '−')), !domainsCollapsed && /*#__PURE__*/React.createElement("div", {
+    className: "nav-subitems"
+  }, domains.map(d => {
+    const fails = domainCounts.fail[d] || 0;
+    const total = domainCounts.total[d] || 0;
+    return /*#__PURE__*/React.createElement("a", {
+      href: "#findings-anchor",
+      key: d,
+      onClick: e => {
+        e.preventDefault();
+        onDomainJump(d);
+        closeIfMobile();
+      },
+      className: 'nav-subitem' + (activeDomain === d ? ' active' : '')
+    }, /*#__PURE__*/React.createElement("span", null, d), /*#__PURE__*/React.createElement("span", {
+      className: 'count' + (fails ? ' pill-fail' : '')
+    }, fails || total));
+  })))))), /*#__PURE__*/React.createElement("div", {
     className: "sidebar-cards"
   }, /*#__PURE__*/React.createElement("div", {
     className: "sc-card"
@@ -850,10 +853,11 @@ function ScoringViews() {
   let body;
   if (view.kind === 'score') {
     const value = view.compute(FINDINGS);
+    const tier = value === null ? '' : value >= 80 ? ' tier-good' : value >= 60 ? ' tier-warn' : ' tier-bad';
     body = /*#__PURE__*/React.createElement("div", {
       className: "scoring-view-body"
     }, /*#__PURE__*/React.createElement("div", {
-      className: "scoring-view-num"
+      className: 'scoring-view-num' + tier
     }, value === null ? '—' : `${value}%`), /*#__PURE__*/React.createElement("div", {
       className: "scoring-view-blurb"
     }, view.blurb));
@@ -895,7 +899,16 @@ function ScoringViews() {
       }
     }, "findings table"))));
   }
-  return /*#__PURE__*/React.createElement("div", {
+  return /*#__PURE__*/React.createElement("section", {
+    className: "block",
+    id: "scoring"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "section-head"
+  }, /*#__PURE__*/React.createElement("span", {
+    className: "eyebrow"
+  }, "01c \xB7 Scoring"), /*#__PURE__*/React.createElement("h2", null, "Posture views by audience"), /*#__PURE__*/React.createElement("div", {
+    className: "hr"
+  })), /*#__PURE__*/React.createElement("div", {
     className: "scoring-views"
   }, /*#__PURE__*/React.createElement("div", {
     className: "scoring-views-tabs",
@@ -906,7 +919,7 @@ function ScoringViews() {
     "aria-selected": v.id === active,
     className: 'scoring-views-tab' + (v.id === active ? ' active' : ''),
     onClick: () => setActive(v.id)
-  }, v.label))), body);
+  }, v.label))), body));
 }
 
 // ======================== Permissions panel (#812 B2 followup) ========================
@@ -922,14 +935,29 @@ function PermissionsPanel() {
   const sections = Object.entries(p.sections);
   const allOk = sections.every(([, s]) => s.ok);
   const missingTotal = asArray(p.missing).length;
-  return /*#__PURE__*/React.createElement("section", {
-    className: "permissions-panel",
-    id: "permissions"
+  const labelStyle = {
+    fontSize: 12,
+    color: 'var(--muted)',
+    textTransform: 'uppercase',
+    letterSpacing: '.08em',
+    fontWeight: 600,
+    marginBottom: 6
+  };
+  return /*#__PURE__*/React.createElement("div", {
+    className: "card",
+    id: "permissions",
+    style: {
+      marginTop: 14
+    }
   }, /*#__PURE__*/React.createElement("div", {
-    className: "section-header"
-  }, /*#__PURE__*/React.createElement("h2", null, "Permissions"), /*#__PURE__*/React.createElement("div", {
-    className: "section-sub"
-  }, p.authMode, " auth | ", sections.length, " section", sections.length === 1 ? '' : 's', " checked | ", allOk ? 'all granted' : `${missingTotal} role(s) missing`)), /*#__PURE__*/React.createElement("table", {
+    style: labelStyle
+  }, "Permissions used by this run"), /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 12,
+      color: 'var(--text-soft)',
+      marginBottom: 10
+    }
+  }, p.authMode, " auth \xB7 ", sections.length, " section", sections.length === 1 ? '' : 's', " checked \xB7 ", allOk ? 'all granted' : `${missingTotal} role(s) missing`), /*#__PURE__*/React.createElement("table", {
     className: "permissions-table"
   }, /*#__PURE__*/React.createElement("thead", null, /*#__PURE__*/React.createElement("tr", null, /*#__PURE__*/React.createElement("th", null, "Section"), /*#__PURE__*/React.createElement("th", null, "Required"), /*#__PURE__*/React.createElement("th", null, "Missing"), /*#__PURE__*/React.createElement("th", null, "Status"))), /*#__PURE__*/React.createElement("tbody", null, sections.map(([name, s]) => {
     const req = asArray(s.required);
@@ -1079,7 +1107,7 @@ function Posture() {
       width: pct(pass, scoreDenom(FINDINGS)) + '%',
       background: 'var(--success)'
     }
-  })))), /*#__PURE__*/React.createElement(MFABreakdown, null))), /*#__PURE__*/React.createElement(ExecSummaryRow, null), /*#__PURE__*/React.createElement(ScoringViews, null), critical > 0 && /*#__PURE__*/React.createElement("div", {
+  })))), /*#__PURE__*/React.createElement(MFABreakdown, null))), /*#__PURE__*/React.createElement(ExecSummaryRow, null), critical > 0 && /*#__PURE__*/React.createElement("div", {
     className: "banner"
   }, /*#__PURE__*/React.createElement("div", {
     className: "banner-icon"
@@ -4329,7 +4357,7 @@ function Appendix() {
       textAlign: 'right',
       fontFamily: 'var(--font-mono)'
     }
-  }, String(ad.lastSync).slice(0, 19).replace('T', ' ')))))))));
+  }, String(ad.lastSync).slice(0, 19).replace('T', ' '))))))), /*#__PURE__*/React.createElement(PermissionsPanel, null)));
 }
 function StatusDot({
   ok,
@@ -4698,14 +4726,14 @@ function App() {
     onFinalize: handleFinalize,
     onReset: handleResetAll,
     hiddenCount: hiddenFindings.size
-  }), /*#__PURE__*/React.createElement(Overview, null), /*#__PURE__*/React.createElement(Posture, null), /*#__PURE__*/React.createElement(TrendChart, null), /*#__PURE__*/React.createElement(FrameworkQuilt, {
+  }), /*#__PURE__*/React.createElement(Overview, null), /*#__PURE__*/React.createElement(Posture, null), /*#__PURE__*/React.createElement(ScoringViews, null), /*#__PURE__*/React.createElement(TrendChart, null), /*#__PURE__*/React.createElement(FrameworkQuilt, {
     onSelect: onFrameworkSelect,
     selected: filters.framework[0],
     onProfileSelect: onProfileSelect,
     activeProfiles: filters.profile || []
   }), /*#__PURE__*/React.createElement(DomainRollup, {
     onJump: onDomainJump
-  }), /*#__PURE__*/React.createElement(PermissionsPanel, null), /*#__PURE__*/React.createElement("div", {
+  }), /*#__PURE__*/React.createElement("div", {
     id: "findings-anchor"
   }), /*#__PURE__*/React.createElement("div", {
     style: {

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -229,23 +229,6 @@ function Sidebar({ active, activeSubsection, counts, domainCounts, activeDomain,
               )}
             </React.Fragment>
           ))}
-          <div className="nav-label nav-label-collapsible" style={{marginTop:14}}
-               onClick={() => setDomainsCollapsed(c => !c)}>
-            <span>Domains</span>
-            <span className="nav-label-chev">{domainsCollapsed ? '+' : '−'}</span>
-          </div>
-          {!domainsCollapsed && domains.map(d => {
-            const fails = domainCounts.fail[d] || 0;
-            const total = domainCounts.total[d] || 0;
-            return (
-              <a href="#findings-anchor" key={d}
-                 onClick={(e)=>{ e.preventDefault(); onDomainJump(d); closeIfMobile(); }}
-                 className={'nav-item' + (activeDomain===d?' active':'')}>
-                <span>{d}</span>
-                <span className={'count' + (fails ? ' pill-fail' : '')}>{fails || total}</span>
-              </a>
-            );
-          })}
           <div className="nav-label nav-label-emphasis" style={{marginTop:14}}>Findings &amp; action</div>
           {details.map(it => (
             <React.Fragment key={it.id}>
@@ -264,6 +247,32 @@ function Sidebar({ active, activeSubsection, counts, domainCounts, activeDomain,
                   <a href="#roadmap-next"  className="nav-subitem">Next  <span className="count">{ROADMAP_COUNTS.soon}</span></a>
                   <a href="#roadmap-later" className="nav-subitem">Later <span className="count">{ROADMAP_COUNTS.later}</span></a>
                 </div>
+              )}
+              {it.id === 'findings' && (
+                <React.Fragment>
+                  <a href="#findings-anchor"
+                     onClick={e => { e.preventDefault(); setDomainsCollapsed(c => !c); }}
+                     className="nav-item">
+                    <span>Domains</span>
+                    <span className="nav-expand-icon">{domainsCollapsed ? '+' : '−'}</span>
+                  </a>
+                  {!domainsCollapsed && (
+                    <div className="nav-subitems">
+                      {domains.map(d => {
+                        const fails = domainCounts.fail[d] || 0;
+                        const total = domainCounts.total[d] || 0;
+                        return (
+                          <a href="#findings-anchor" key={d}
+                             onClick={(e)=>{ e.preventDefault(); onDomainJump(d); closeIfMobile(); }}
+                             className={'nav-subitem' + (activeDomain===d?' active':'')}>
+                            <span>{d}</span>
+                            <span className={'count' + (fails ? ' pill-fail' : '')}>{fails || total}</span>
+                          </a>
+                        );
+                      })}
+                    </div>
+                  )}
+                </React.Fragment>
               )}
             </React.Fragment>
           ))}
@@ -473,9 +482,10 @@ function ScoringViews() {
   let body;
   if (view.kind === 'score') {
     const value = view.compute(FINDINGS);
+    const tier = value === null ? '' : value >= 80 ? ' tier-good' : value >= 60 ? ' tier-warn' : ' tier-bad';
     body = (
       <div className="scoring-view-body">
-        <div className="scoring-view-num">
+        <div className={'scoring-view-num' + tier}>
           {value === null ? '—' : `${value}%`}
         </div>
         <div className="scoring-view-blurb">{view.blurb}</div>
@@ -512,18 +522,25 @@ function ScoringViews() {
     );
   }
   return (
-    <div className="scoring-views">
-      <div className="scoring-views-tabs" role="tablist">
-        {SCORING_VIEWS.map(v => (
-          <button key={v.id} role="tab" aria-selected={v.id === active}
-            className={'scoring-views-tab' + (v.id === active ? ' active' : '')}
-            onClick={() => setActive(v.id)}>
-            {v.label}
-          </button>
-        ))}
+    <section className="block" id="scoring">
+      <div className="section-head">
+        <span className="eyebrow">01c · Scoring</span>
+        <h2>Posture views by audience</h2>
+        <div className="hr"/>
       </div>
-      {body}
-    </div>
+      <div className="scoring-views">
+        <div className="scoring-views-tabs" role="tablist">
+          {SCORING_VIEWS.map(v => (
+            <button key={v.id} role="tab" aria-selected={v.id === active}
+              className={'scoring-views-tab' + (v.id === active ? ' active' : '')}
+              onClick={() => setActive(v.id)}>
+              {v.label}
+            </button>
+          ))}
+        </div>
+        {body}
+      </div>
+    </section>
   );
 }
 
@@ -540,13 +557,12 @@ function PermissionsPanel() {
   const sections = Object.entries(p.sections);
   const allOk = sections.every(([, s]) => s.ok);
   const missingTotal = asArray(p.missing).length;
+  const labelStyle = {fontSize:12,color:'var(--muted)',textTransform:'uppercase',letterSpacing:'.08em',fontWeight:600,marginBottom:6};
   return (
-    <section className="permissions-panel" id="permissions">
-      <div className="section-header">
-        <h2>Permissions</h2>
-        <div className="section-sub">
-          {p.authMode} auth | {sections.length} section{sections.length===1?'':'s'} checked | {allOk ? 'all granted' : `${missingTotal} role(s) missing`}
-        </div>
+    <div className="card" id="permissions" style={{marginTop:14}}>
+      <div style={labelStyle}>Permissions used by this run</div>
+      <div style={{fontSize:12,color:'var(--text-soft)',marginBottom:10}}>
+        {p.authMode} auth · {sections.length} section{sections.length===1?'':'s'} checked · {allOk ? 'all granted' : `${missingTotal} role(s) missing`}
       </div>
       <table className="permissions-table">
         <thead>
@@ -571,7 +587,7 @@ function PermissionsPanel() {
           })}
         </tbody>
       </table>
-    </section>
+    </div>
   );
 }
 
@@ -659,7 +675,6 @@ function Posture() {
         </div>
       </div>
       <ExecSummaryRow/>
-      <ScoringViews/>
       {critical > 0 && (
         <div className="banner">
           <div className="banner-icon">!</div>
@@ -2747,7 +2762,9 @@ function Appendix() {
             </table>
           </div>
         )}
-      </div></>}
+      </div>
+      <PermissionsPanel/>
+      </>}
     </section>
   );
 }
@@ -2997,10 +3014,10 @@ function App() {
         />
         <Overview/>
         <Posture/>
+        <ScoringViews/>
         <TrendChart/>
         <FrameworkQuilt onSelect={onFrameworkSelect} selected={filters.framework[0]} onProfileSelect={onProfileSelect} activeProfiles={filters.profile || []}/>
         <DomainRollup onJump={onDomainJump}/>
-        <PermissionsPanel/>
         <div id="findings-anchor"/>
         <div style={{marginTop:20}}/>
         <FilterBar filters={filters} setFilters={setFilters} counts={counts} total={FINDINGS.length} search={search} setSearch={setSearch}/>

--- a/src/M365-Assess/assets/report-shell.css
+++ b/src/M365-Assess/assets/report-shell.css
@@ -102,18 +102,6 @@ a:hover { text-decoration: underline; }
   text-transform: uppercase; letter-spacing: 0.08em;
   color: var(--muted); padding: 0 8px 8px 8px;
 }
-.nav-label-collapsible {
-  display: flex; align-items: center; justify-content: space-between;
-  cursor: pointer; user-select: none;
-  padding-left: 10px; padding-right: 10px;
-  transition: color .15s;
-}
-.nav-label-collapsible:hover { color: var(--text-soft); }
-.nav-label-chev {
-  font-size: 14px; font-weight: 400; line-height: 1;
-  color: var(--muted); opacity: .7;
-  flex-shrink: 0;
-}
 .nav-label-emphasis {
   color: var(--accent-text, var(--accent));
   border-top: 1px solid color-mix(in srgb, var(--accent) 35%, var(--border));
@@ -1046,10 +1034,6 @@ mark.search-hl {
 .scoring-view-num.tier-bad  { color: var(--danger-text); }
 
 /* ---------- Permissions panel (#812 B2 followup) ---------- */
-.permissions-panel {
-  margin: 24px 0; padding: 18px 20px;
-  background: var(--surface); border: 1px solid var(--border); border-radius: 12px;
-}
 .permissions-table {
   width: 100%; border-collapse: collapse; margin-top: 12px; font-size: 13px;
 }

--- a/src/M365-Assess/assets/report-shell.css
+++ b/src/M365-Assess/assets/report-shell.css
@@ -1041,6 +1041,9 @@ mark.search-hl {
   font-size: 11px; color: var(--muted); white-space: nowrap;
 }
 .scoring-view-more { color: var(--muted); font-size: 11px; padding-top: 4px !important; }
+.scoring-view-num.tier-good { color: var(--success-text); }
+.scoring-view-num.tier-warn { color: var(--warn-text); }
+.scoring-view-num.tier-bad  { color: var(--danger-text); }
 
 /* ---------- Permissions panel (#812 B2 followup) ---------- */
 .permissions-panel {


### PR DESCRIPTION
## Summary

Three sprint-current UI issues bundled into a single PR so the report's mandatory live-tenant verification cycle (per `.claude/rules/releases.md`) only runs once instead of three times.

- **#834** — Move `PermissionsPanel` into Appendix (was wedged between Domain rollup and findings table; now lives next to tenant info / MFA / CA cards). `id=\"permissions\"` anchor preserved.
- **#835** — Wrap `ScoringViews` in a proper `<section id=\"scoring\">` with eyebrow `01c · Scoring` + h2; tier-color the big % number (≥80 green / 60–79 amber / <60 red) using `--success-text` / `--warn-text` / `--danger-text` (theme-safe contrast). Pulled out of `Posture` so the section owns its own scroll-anchor without nested `.block` margins.
- **#836** — Demote DOMAINS from a top-level sidebar group to a collapsible sub-tree under FINDINGS & ACTION. Reuses existing `domainsCollapsed` state and `.nav-subitems` CSS — no new styles. \"Domain posture\" link under EXECUTIVE preserved (it's a separate destination, not the per-domain filter).

Closes #834, closes #835, closes #836.

## Files

- `src/M365-Assess/assets/report-app.jsx` — all three issues (Sidebar, ScoringViews wrapper, PermissionsPanel call site + render helper)
- `src/M365-Assess/assets/report-shell.css` — three new `.scoring-view-num.tier-*` rules (3 lines)
- `src/M365-Assess/assets/report-app.js` — regenerated via `npm run build` (CI gate)
- `package-lock.json` — incidental sync from `npm install` (devDep ranges already at ^7.28.0 in package.json)

## Test plan

Local checks (already passed):
- [x] `npm run build` clean
- [x] `node --check src/M365-Assess/assets/report-app.js` clean
- [x] `Invoke-Pester -Path './tests'` — 2285/2285 pass

**Live-tenant verification (BLOCKING per `.claude/rules/releases.md`):**

```powershell
Invoke-M365Assessment -TenantId <tenant> -AutoBaseline
```

#834:
- [ ] Top-of-report: Permissions panel NO LONGER between Domain rollup and findings
- [ ] Open Appendix · tenant — Permissions card renders with tenant/MFA/CA siblings
- [ ] `…report.html#permissions` deep-link still scrolls correctly

#835:
- [ ] \"01c · Scoring\" eyebrow + \"Posture views by audience\" h2 above tab strip
- [ ] Big % number is GREEN if ≥80, AMBER if 60–79, RED if <60 across all 3 score tabs
- [ ] All 4 themes (Neon / Console / Saas / High-Contrast) — tier colors readable
- [ ] List-view tabs (Quick Wins / Requires Licensing / Manual Validation) — sev-pill chips show real severity colors

#836:
- [ ] DOMAINS no longer a top-level sidebar group
- [ ] Domains row inside FINDINGS & ACTION; +/− expand/collapse works
- [ ] Each domain still jumps to filtered findings table
- [ ] \"All findings\" still clears domain filter
- [ ] \"Domain posture\" under EXECUTIVE still works (separate destination)
- [ ] Mobile width (<720px): expand/collapse works inside slide-out nav

Cross-cutting:
- [ ] Assessment folder has `.html`, `.xlsx`, `.json`, log file, CSVs — no silent absence
- [ ] DevTools console clean on report load (no React errors)
- [ ] `_Assessment-Log_*.txt` no WARN-level surprises

## Out of scope

- No version bump in this PR — needs explicit user approval AFTER live-test passes (candidate: v2.9.2 patch)
- No CHANGELOG.md edit — paired with the version bump step
- No new sidebar entry for the new `#scoring` anchor (issue asked only for the anchor; flag if you want one)
- No `docs/REPORT-SCHEMA.md` change — grep found no prose describing PermissionsPanel placement, so nothing to update

🤖 Generated with [Claude Code](https://claude.com/claude-code)