### PR TITLE
feat(report,invoke): Sequence column + -SaveBaseline switch (closes #840 + #809)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,8 @@ Invoke-M365Assessment -Section Tenant,Identity,Licensing,Email,Intune,Security,C
 | `-SkipPurview` | switch | | Skip Purview/DLP collector and connection (saves ~46s) |
 | `-DryRun` | switch | | Preview sections, services, scopes, and check counts without connecting |
 | `-OpenReport` | switch | | Auto-open the HTML report in the default browser after generation |
-| `-SaveBaseline` | string | | Save a policy baseline snapshot with this label for future drift comparison |
+| `-SaveBaseline` | switch | | Save a policy baseline snapshot for future drift comparison. Auto-labels as `manual-<timestamp>`; combine with `-BaselineLabel` for a custom label |
+| `-BaselineLabel` | string | | Optional custom label to use with `-SaveBaseline` (e.g. `'sprint-end'`). Ignored without `-SaveBaseline` |
 | `-CompareBaseline` | string | | Compare the current run against a previously saved baseline and show drift in the XLSX |
 | `-AutoBaseline` | switch | | Automatically save and compare against the most recent baseline for this tenant |
 | `-ListBaselines` | switch | | List all saved baselines for the current tenant and exit |

--- a/docs/RUN.md
+++ b/docs/RUN.md
@@ -122,8 +122,11 @@ Skips the Purview (Security & Compliance) connection, saving approximately 46 se
 ### Baseline and Drift Tracking
 
 ```powershell
-# Save a named baseline after an assessment
-Invoke-M365Assessment -TenantId 'contoso.onmicrosoft.com' -SaveBaseline 'PreChange'
+# Save an auto-labelled baseline after an assessment (label = manual-<timestamp>)
+Invoke-M365Assessment -TenantId 'contoso.onmicrosoft.com' -SaveBaseline
+
+# Save with a custom label
+Invoke-M365Assessment -TenantId 'contoso.onmicrosoft.com' -SaveBaseline -BaselineLabel 'PreChange'
 
 # Compare against a previous baseline (adds Drift sheet to XLSX)
 Invoke-M365Assessment -TenantId 'contoso.onmicrosoft.com' -CompareBaseline 'PreChange'

--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -86,9 +86,10 @@ Orchestrates all M365 assessment collector scripts to produce a folder of CSV re
 | `SkipPurview` | switch | No | Skip the Purview (Security & Compliance) connection and DLP/retention collectors (saves ~46s of latency). |
 | `DryRun` | switch | No | Show a dry-run preview of sections, services, Graph scopes, and check counts without connecting or collecting data. |
 | `OpenReport` | switch | No | Open the HTML report in the default browser after generation. |
-| `SaveBaseline` | string | No | Save a named policy baseline snapshot after the assessment completes (e.g., `PreChange`). Stored under `<OutputFolder>/Baselines/`. |
+| `SaveBaseline` | switch | No | Save a policy baseline snapshot after the assessment completes. Auto-labels as `manual-<timestamp>`; combine with `-BaselineLabel` for a custom label. Stored under `<OutputFolder>/Baselines/`. |
+| `BaselineLabel` | string | No | Optional custom label to use with `-SaveBaseline` (e.g. `PreChange`). Ignored without `-SaveBaseline`. |
 | `CompareBaseline` | string | No | Compare results against a previously saved baseline and add a Drift sheet to the XLSX output. |
-| `AutoBaseline` | switch | No | Automatically save a baseline named `Auto` after every successful run. Enables drift tracking without manual `-SaveBaseline` calls. |
+| `AutoBaseline` | switch | No | Automatically save a baseline named `auto-<timestamp>` after every successful run AND auto-compare to the previous auto baseline. Enables drift tracking without manual `-SaveBaseline` calls. |
 | `ListBaselines` | switch | No | List all saved baselines for the tenant and exit without running an assessment. |
 
 **Output:** Assessment folder containing CSV reports, an HTML report, optional XLSX compliance matrix, and optional PDF.

--- a/src/M365-Assess/Common/Export-ComplianceMatrix.ps1
+++ b/src/M365-Assess/Common/Export-ComplianceMatrix.ps1
@@ -429,7 +429,18 @@ if ($preparedByHeader) {
     $matrixParams['TitleSize']            = 11
     $matrixParams['TitleBackgroundColor'] = [System.Drawing.Color]::FromArgb(219, 234, 254)
 }
-$sortedFindings | Export-Excel @matrixParams
+# Issue #840: project Horizon → Sequence at export time, marking Pass rows as 'Done'
+# so no cell is empty. The source object's Horizon property stays untouched —
+# downstream consumers (Roadmap sheet line 566, Export-M365Remediation) still
+# read $_.Horizon, where Pass remains '' and Roadmap correctly excludes it.
+$matrixCols = foreach ($propName in $sortedFindings[0].PSObject.Properties.Name) {
+    if ($propName -eq 'Horizon') {
+        @{ Name = 'Sequence'; Expression = { if ($_.Status -eq 'Pass') { 'Done' } else { $_.Horizon } }.GetNewClosure() }
+    } else {
+        $propName
+    }
+}
+$sortedFindings | Select-Object -Property $matrixCols | Export-Excel @matrixParams
 
 # Sheet 2 - Summary (with profile/maturity sub-rows for CIS and CMMC)
 $summaryParams = @{
@@ -641,10 +652,10 @@ if ($evidenceRows -and @($evidenceRows).Count -gt 0) {
 # ------------------------------------------------------------------
 $pkg = Open-ExcelPackage -Path $outputFile
 
-# Matrix sheet - color-code Status, Horizon, RiskSeverity, and ImpactSeverity columns
+# Matrix sheet - color-code Status, Sequence, RiskSeverity, and ImpactSeverity columns
 $matrixSheet = $pkg.Workbook.Worksheets['Compliance Matrix']
 $statusCol      = 4   # Column D = Status
-$horizonCol     = 5   # Column E = Horizon (issue #715)
+$sequenceCol    = 5   # Column E = Sequence (issue #715, renamed in #840)
 $riskSevCol     = 6   # Column F = RiskSeverity
 $impactSevCol   = 7   # Column G = ImpactSeverity
 $lastRow = $matrixSheet.Dimension.End.Row
@@ -664,12 +675,14 @@ for ($r = 2; $r -le $lastRow; $r++) {
         'NotLicensed'   { $matrixSheet.Cells[$r, $statusCol].Style.Font.Color.SetColor([System.Drawing.Color]::FromArgb(109, 40, 217));  $matrixSheet.Cells[$r, $statusCol].Style.Fill.PatternType = 'Solid'; $matrixSheet.Cells[$r, $statusCol].Style.Fill.BackgroundColor.SetColor([System.Drawing.Color]::FromArgb(237, 233, 254)) }
     }
 
-    # Issue #715: color the Horizon cell so consultants can scan Now/Next/Later visually
-    $horizonVal = $matrixSheet.Cells[$r, $horizonCol].Value
-    switch ($horizonVal) {
-        'now'   { $matrixSheet.Cells[$r, $horizonCol].Style.Font.Color.SetColor([System.Drawing.Color]::FromArgb(185, 28, 28));  $matrixSheet.Cells[$r, $horizonCol].Style.Fill.PatternType = 'Solid'; $matrixSheet.Cells[$r, $horizonCol].Style.Fill.BackgroundColor.SetColor([System.Drawing.Color]::FromArgb(254, 226, 226)) }
-        'soon'  { $matrixSheet.Cells[$r, $horizonCol].Style.Font.Color.SetColor([System.Drawing.Color]::FromArgb(146, 64, 14));  $matrixSheet.Cells[$r, $horizonCol].Style.Fill.PatternType = 'Solid'; $matrixSheet.Cells[$r, $horizonCol].Style.Fill.BackgroundColor.SetColor([System.Drawing.Color]::FromArgb(254, 243, 199)) }
-        'later' { $matrixSheet.Cells[$r, $horizonCol].Style.Font.Color.SetColor([System.Drawing.Color]::FromArgb(30, 64, 175));  $matrixSheet.Cells[$r, $horizonCol].Style.Fill.PatternType = 'Solid'; $matrixSheet.Cells[$r, $horizonCol].Style.Fill.BackgroundColor.SetColor([System.Drawing.Color]::FromArgb(219, 234, 254)) }
+    # Issue #715: color the Sequence cell so consultants can scan Now/Next/Later/Done visually
+    # Issue #840: 'Done' added (Pass rows) using the same green palette as the Pass status cell
+    $sequenceVal = $matrixSheet.Cells[$r, $sequenceCol].Value
+    switch ($sequenceVal) {
+        'now'   { $matrixSheet.Cells[$r, $sequenceCol].Style.Font.Color.SetColor([System.Drawing.Color]::FromArgb(185, 28, 28));  $matrixSheet.Cells[$r, $sequenceCol].Style.Fill.PatternType = 'Solid'; $matrixSheet.Cells[$r, $sequenceCol].Style.Fill.BackgroundColor.SetColor([System.Drawing.Color]::FromArgb(254, 226, 226)) }
+        'soon'  { $matrixSheet.Cells[$r, $sequenceCol].Style.Font.Color.SetColor([System.Drawing.Color]::FromArgb(146, 64, 14));  $matrixSheet.Cells[$r, $sequenceCol].Style.Fill.PatternType = 'Solid'; $matrixSheet.Cells[$r, $sequenceCol].Style.Fill.BackgroundColor.SetColor([System.Drawing.Color]::FromArgb(254, 243, 199)) }
+        'later' { $matrixSheet.Cells[$r, $sequenceCol].Style.Font.Color.SetColor([System.Drawing.Color]::FromArgb(30, 64, 175));  $matrixSheet.Cells[$r, $sequenceCol].Style.Fill.PatternType = 'Solid'; $matrixSheet.Cells[$r, $sequenceCol].Style.Fill.BackgroundColor.SetColor([System.Drawing.Color]::FromArgb(219, 234, 254)) }
+        'Done'  { $matrixSheet.Cells[$r, $sequenceCol].Style.Font.Color.SetColor([System.Drawing.Color]::FromArgb(21, 128, 61));   $matrixSheet.Cells[$r, $sequenceCol].Style.Fill.PatternType = 'Solid'; $matrixSheet.Cells[$r, $sequenceCol].Style.Fill.BackgroundColor.SetColor([System.Drawing.Color]::FromArgb(220, 252, 231)) }
     }
 
     $sevVal = $matrixSheet.Cells[$r, $riskSevCol].Value

--- a/src/M365-Assess/Invoke-M365Assessment.ps1
+++ b/src/M365-Assess/Invoke-M365Assessment.ps1
@@ -74,9 +74,22 @@
     sets -CompactReport. Override with -CompactReport:$false to keep the
     full report structure.
 .PARAMETER SaveBaseline
-    Label for a new baseline snapshot. Saves the current assessment results
-    to a Baselines subfolder under the output folder. Use with -CompareBaseline
-    on a later run to detect policy drift.
+    Save the current assessment as a baseline snapshot under the output folder's
+    Baselines subfolder. Use with -CompareBaseline on a later run to detect
+    policy drift.
+
+    Switch form:
+      -SaveBaseline                                  Auto-labels as 'manual-yyyyMMdd-HHmmss'.
+      -SaveBaseline -BaselineLabel '<label>'         Saves under the supplied label (e.g. 'sprint-end').
+
+    For unattended/scheduled runs that auto-compare to the previous run, prefer
+    -AutoBaseline (saves under 'auto-<timestamp>' and reads the most-recent auto
+    baseline back automatically).
+.PARAMETER BaselineLabel
+    Optional custom label for the baseline snapshot. Only takes effect when
+    -SaveBaseline is also supplied. Without -SaveBaseline this parameter is ignored.
+    The label is sanitized by Export-AssessmentBaseline; non-word characters
+    become underscores.
 .PARAMETER CompareBaseline
     Label of a previously saved baseline to compare against. Generates a drift
     report highlighting settings that changed since the baseline was captured.
@@ -236,8 +249,16 @@ param(
     [Parameter()]
     [switch]$DryRun,
 
+    # Issue #809: -SaveBaseline is now a switch (was [string]). Pass it bare to
+    # save under an auto-generated 'manual-<timestamp>' label, OR combine with
+    # -BaselineLabel to use a custom label. Breaking change for callers that
+    # previously did `-SaveBaseline 'mylabel'` -- migrate to
+    # `-SaveBaseline -BaselineLabel 'mylabel'`.
     [Parameter()]
-    [string]$SaveBaseline,
+    [switch]$SaveBaseline,
+
+    [Parameter()]
+    [string]$BaselineLabel,
 
     [Parameter()]
     [string]$CompareBaseline,
@@ -1228,11 +1249,18 @@ $driftBaselineTimestamp = ''
 $tenantIdentity = Resolve-TenantIdentity -TenantIdInput $TenantId -Environment $M365Environment
 
 if ($SaveBaseline) {
-    Write-AssessmentLog -Level INFO -Message "Saving baseline '$SaveBaseline'..."
+    # Issue #809: -SaveBaseline is a switch; -BaselineLabel supplies an optional
+    # custom label. Without -BaselineLabel, auto-generate 'manual-<timestamp>'.
+    $resolvedLabel = if ($BaselineLabel) {
+        $BaselineLabel
+    } else {
+        "manual-$(Get-Date -Format 'yyyyMMdd-HHmmss')"
+    }
+    Write-AssessmentLog -Level INFO -Message "Saving baseline '$resolvedLabel'..."
     $savedBaselineDir = Export-AssessmentBaseline `
         -AssessmentFolder $assessmentFolder `
         -OutputFolder $OutputFolder `
-        -Label $SaveBaseline `
+        -Label $resolvedLabel `
         -TenantId $TenantId `
         -TenantGuid $tenantIdentity.Guid `
         -DisplayName $tenantIdentity.DisplayName `

--- a/tests/Invoke-M365Assessment.Tests.ps1
+++ b/tests/Invoke-M365Assessment.Tests.ps1
@@ -88,6 +88,33 @@ Describe 'Invoke-M365Assessment - syntax and structure' {
         $param | Should -Not -BeNullOrEmpty
     }
 
+    # Issue #809: -SaveBaseline is a switch (was [string]). PowerShell parameter
+    # binding does not allow a single non-switch param to accept both `-X` (no value)
+    # and `-X 'foo'` (string value). The two-param shape is the cleanest fix:
+    #   -SaveBaseline                       -> auto label 'manual-<timestamp>'
+    #   -SaveBaseline -BaselineLabel 'foo'  -> custom label 'foo'
+    It '-SaveBaseline is declared as [switch]' {
+        $paramBlock = $script:ast.FindAll(
+            { param($node) $node -is [System.Management.Automation.Language.ParameterAst] },
+            $true
+        )
+        $param = $paramBlock | Where-Object { $_.Name.VariablePath.UserPath -eq 'SaveBaseline' }
+        $param | Should -Not -BeNullOrEmpty
+        $typeAttr = $param.Attributes | Where-Object { $_ -is [System.Management.Automation.Language.TypeConstraintAst] }
+        $typeAttr.TypeName.Name | Should -Be 'switch' -Because '-SaveBaseline must be a switch so it accepts the bare-flag form'
+    }
+
+    It '-BaselineLabel is declared as [string]' {
+        $paramBlock = $script:ast.FindAll(
+            { param($node) $node -is [System.Management.Automation.Language.ParameterAst] },
+            $true
+        )
+        $param = $paramBlock | Where-Object { $_.Name.VariablePath.UserPath -eq 'BaselineLabel' }
+        $param | Should -Not -BeNullOrEmpty -Because 'a separate -BaselineLabel param carries the optional custom label'
+        $typeAttr = $param.Attributes | Where-Object { $_ -is [System.Management.Automation.Language.TypeConstraintAst] }
+        $typeAttr.TypeName.Name | Should -Be 'string'
+    }
+
     It 'requires PowerShell 7.0 or higher' {
         $scriptContent = Get-Content -Path $script:scriptPath -Raw
         $scriptContent | Should -Match '#Requires -Version 7'


### PR DESCRIPTION
## Summary

Bundles two sprint-current items into one PR / one live-test cycle, per the team's batch-tiny-changes pattern.

- **#840** — Compliance Matrix XLSX: rename `Horizon` column to `Sequence`; mark Pass-status rows as `Done` (was empty) with green color-coding
- **#809** — `-SaveBaseline` papercut: bare `-SaveBaseline` now works (auto-labels as `manual-<timestamp>`); custom labels move to a new `-BaselineLabel` companion parameter

## Important: #809 ships as a BREAKING CHANGE

`-SaveBaseline 'mylabel'` no longer works. Migrate to `-SaveBaseline -BaselineLabel 'mylabel'`.

The issue body's "Option A" (`[string]$SaveBaseline = ''`) was empirically verified to NOT work in PowerShell — the empty-string default only applies when the parameter is omitted entirely, not when called bare. PowerShell parameter binding does not allow a single non-switch parameter to accept BOTH `-X` (bare flag form, requires `[switch]`) AND `-X 'foo'` (labelled form, requires `[string]`). The cleanest fix that honors the user's primary request (bare `-SaveBaseline` works) is the two-parameter shape.

CHANGELOG entry will land in the v2.9.2 bump PR with a clear migration note.

## Files

| File | Change |
|---|---|
| `src/M365-Assess/Common/Export-ComplianceMatrix.ps1` | #840: Select-Object projection at export, color-code Done with green palette |
| `src/M365-Assess/Invoke-M365Assessment.ps1` | #809: `-SaveBaseline` to `[switch]`, add `-BaselineLabel`, body normalizes label, help text updated |
| `tests/Invoke-M365Assessment.Tests.ps1` | #809: AST-based tests for new param shapes |
| `README.md`, `docs/cmdlet-reference.md`, `docs/RUN.md` | #809: docs updated to show new switch + label syntax |

## Test plan

Local checks (passed):
- [x] `Invoke-Pester -Path './tests'` — 2287/2287 pass (2 new for #809 param shape)
- [x] PSScriptAnalyzer — no new warnings on changed lines

**Live tenant verification** (per `.claude/rules/releases.md`):

```powershell
Invoke-M365Assessment -ProfileName <your-profile> -AutoBaseline
```

For #840 (open `_Compliance-Matrix_*.xlsx`):
- [ ] Compliance Matrix sheet column header reads `Sequence`, NOT `Horizon`
- [ ] Every Pass-status row shows `Done` (no blank cells)
- [ ] Done cells get a green fill matching the Pass status color
- [ ] Now/Next/Later cells still color-coded as before
- [ ] Remediation Roadmap sheet (sheet 2): unchanged — Pass rows still excluded, headers still `Horizon | CheckId | ...`

For #809:
```powershell
Invoke-M365Assessment -ProfileName <your-profile> -SaveBaseline                         # NEW: bare form, saves as manual-<timestamp>
Invoke-M365Assessment -ProfileName <your-profile> -SaveBaseline -BaselineLabel 'demo'   # NEW: custom-label form
```
- [ ] Bare call: `<output>/Baselines/manual-yyyyMMdd-HHmmss_<tenant>/` folder created
- [ ] Labelled call: `<output>/Baselines/demo_<tenant>/` folder created
- [ ] `Get-Help Invoke-M365Assessment -Parameter SaveBaseline` shows the new switch + label syntax

Migration check:
- [ ] `Invoke-M365Assessment -SaveBaseline 'oldform'` should error clearly (PowerShell can't bind 'oldform' to a `[switch]`); the error message points at the migration path

## Out of scope

- v2.9.2 version bump (waits for live-test approval, then a separate PR)
- CHANGELOG entry (paired with the version bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)