### PR TITLE
chore(release): bump to v2.9.2 (Polish + breaking SaveBaseline)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to M365 Assess are documented here. This project uses [Conve
 
 ## [Unreleased]
 
+## [2.9.2] - 2026-04-27
+
+Polish release: HTML report layout cleanup, XLSX matrix readability, and a `-SaveBaseline` UX papercut. One **breaking change** to a parameter type (see Changed).
+
+### Added
+- **ScoringViews section header (#835)** — the scoring-tabs panel now has a proper `01c · Scoring` eyebrow + `Posture views by audience` h2 above it (was a "naked" tab strip with no section context). Big % number is color-coded by tier: ≥80 green, 60–79 amber, <60 red, using the theme-safe `--success-text` / `--warn-text` / `--danger-text` palette across all 4 themes. New `<section id="scoring">` anchor enables sidebar deep-linking
+- **`-BaselineLabel` parameter on `Invoke-M365Assessment` (#809)** — optional custom label paired with the new switch-form `-SaveBaseline`. Pre-existing `auto-<timestamp>` naming via `-AutoBaseline` is unchanged
+
+### Changed
+- **`-SaveBaseline` is now a `[switch]` (BREAKING, #809)** — `-SaveBaseline 'mylabel'` no longer works; migrate to `-SaveBaseline -BaselineLabel 'mylabel'`. The bare `-SaveBaseline` form now auto-labels as `manual-<timestamp>`. Why the breaking shape: PowerShell parameter binding does not allow a single non-switch parameter to accept BOTH the bare flag form AND a string-value form; the two-parameter shape is the only PowerShell-legal way to honor the bare-`-SaveBaseline` request
+- **Compliance Matrix XLSX `Horizon` column renamed to `Sequence` (#840)** — Pass-status rows now show `Done` (was empty) with green color-coding matching the Pass status cell. Source data unchanged so the Remediation Roadmap sheet still excludes Pass rows correctly
+- **Permissions panel moved from top-of-report to Appendix (#834)** — was wedged between the Domain rollup and findings table; now renders as a card alongside Tenant / MFA / CA in `Appendix · tenant`. The `id="permissions"` deep-link anchor is preserved
+- **Sidebar Domains demoted from top-level group to collapsible sub-tree under Findings & Action (#836)** — the per-domain entries are filter shortcuts into the findings table, not separate destinations, so they read more truthfully nested under FINDINGS & ACTION. `Domain posture` link under EXECUTIVE (separate destination) is preserved
+
+### Fixed
+- **FilterBar sticky pin no longer follows the user past the findings section (#838)** — `.filter-bar-active`'s `position: sticky` was scoped to the App's main scroll container and stayed pinned through Roadmap, the Permissions card, and Tenant Appendix. Now gates the sticky class on the App's existing scrollspy signal (`active === 'findings'`) so the bar releases when the user scrolls past the table. Reuses the IntersectionObserver already driving sidebar highlighting; no new event listeners
+
 ## [2.9.1] - 2026-04-26
 
 Hotfix to v2.9.0. Caught by live-tenant validation post-tag — the underlying lesson is also addressed by a new `.claude/rules/releases.md` rule requiring live verification before any future tag/publish.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [![Coverage](https://img.shields.io/badge/coverage-check%20CI-informational)](https://github.com/Galvnyz/M365-Assess/actions/workflows/ci.yml)
 [![PowerShell 7.x](https://img.shields.io/badge/PowerShell-7.x-blue?logo=powershell&logoColor=white)](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows)
 [![Read-Only](https://img.shields.io/badge/Operations-Read--Only-brightgreen)](.)
-[![Version](https://img.shields.io/badge/version-2.9.1-blue)](.)
+[![Version](https://img.shields.io/badge/version-2.9.2-blue)](.)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 </div>

--- a/src/M365-Assess/M365-Assess.psd1
+++ b/src/M365-Assess/M365-Assess.psd1
@@ -3,7 +3,7 @@
     # Generated: 2026-03-08
 
     RootModule        = 'M365-Assess.psm1'
-    ModuleVersion     = '2.9.1'
+    ModuleVersion     = '2.9.2'
     GUID              = 'f7e3b2a1-4c5d-6e8f-9a0b-1c2d3e4f5a6b'
     Author            = 'Galvnyz'
     CompanyName       = 'Community'
@@ -242,7 +242,7 @@
             IconUri      = 'https://raw.githubusercontent.com/Galvnyz/M365-Assess/main/src/M365-Assess/assets/m365-assess-logo.png'
             LicenseUri   = 'https://github.com/Galvnyz/M365-Assess/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/Galvnyz/M365-Assess'
-            ReleaseNotes = 'v2.9.1 - Hotfix. PowerShell parser ambiguity in Get-BaselineTrend caused HTML report generation to fail silently when -AutoBaseline was supplied: New-Object -TypeName System.Collections.Generic.Dictionary[string, System.IO.DirectoryInfo] was parsed as an array literal, yielding "Cannot convert Object[] to System.String required by parameter TypeName" inside Build-ReportData -- and the catch block in Invoke-M365Assessment swallowed the failure to a WARN log line. Switched to ::new() which parses unambiguously, made the report-generation catch block also Write-Warning to console so silent failures stop happening, added regression test coverage for Get-BaselineTrend (no prior tests). v2.9.0: Trust Hardening release with evidence schema, sanitized evidence package, license-adjusted scoring views, remediation export formats, HTML Permissions panel, wrapper deprecation, cross-platform smoke lane, behavioral tests.'
+            ReleaseNotes = 'v2.9.2 - Polish release. HTML report layout cleanup: ScoringViews gained a section header + tier-coloured % number (#835); Permissions panel relocated from top-of-report into Appendix (#834); sidebar Domains demoted from top-level group to a collapsible sub-tree under Findings & Action (#836). XLSX Compliance Matrix: Horizon column renamed to Sequence; Pass rows now show Done with green color-coding (#840). Fixed: FilterBar position:sticky no longer follows the user past the findings section (#838). BREAKING: -SaveBaseline is now a [switch]; combine with new -BaselineLabel parameter for custom labels. Old -SaveBaseline ''mylabel'' form must migrate to -SaveBaseline -BaselineLabel ''mylabel'' (#809). v2.9.1: hotfix for AutoBaseline + PermissionsPanel render bugs. v2.9.0: Trust Hardening release.'
         }
     }
 }


### PR DESCRIPTION
## Summary

Bumps version to v2.9.2 covering four merged PRs:

| PR | Closes | Surface |
|---|---|---|
| #837 | #834, #835, #836 | HTML report (UI bundle) |
| #839 | #838 | HTML report (FilterBar sticky scope) |
| #841 | #840, #809 | XLSX matrix + Invoke-M365Assessment param shape |

## Headline call-out: BREAKING CHANGE in #809

`-SaveBaseline` is now a `[switch]` (was `[string]`).

- `-SaveBaseline 'mylabel'` → migrate to `-SaveBaseline -BaselineLabel 'mylabel'`
- Bare `-SaveBaseline` (new) → auto-labels as `manual-<timestamp>`
- `-AutoBaseline` (existing) is unchanged

The breaking shape is the only PowerShell-legal way to honor the bare-flag form the original issue requested. Documented in CHANGELOG, `psd1` ReleaseNotes, README, `docs/cmdlet-reference.md`, and `docs/RUN.md`.

This is a PATCH bump (per `.claude/rules/releases.md` semver table), not MINOR — the `2.9.x` train is the polish series; the next MINOR (2.10.0 — Cohort Comparison) will theme around #717-#719.

## Files

- `src/M365-Assess/M365-Assess.psd1` — `ModuleVersion` + `ReleaseNotes`
- `README.md` — version badge
- `CHANGELOG.md` — new `## [2.9.2] - 2026-04-27` section grouped Added / Changed / Fixed

## Verification

Local checks (passed):
- [x] `Invoke-Pester -Path './tests/Smoke/PSGallery-Readiness.Tests.ps1','./tests/Consistency'` → 34/34 pass
- [x] `(Import-PowerShellDataFile -Path './src/M365-Assess/M365-Assess.psd1').ModuleVersion` → `2.9.2`

**Live tenant verification:** confirmed by user 2026-04-27 against merged main (assessment run completed cleanly, all output formats present, no React errors, both `-SaveBaseline` shapes verified, Sequence column with `Done` cells visible in XLSX).

## Merge → Tag → Publish flow

Per `.claude/rules/releases.md`:

1. Merge this PR
2. `release.yml` workflow auto-tags `v2.9.2` and publishes to PSGallery
3. GH release notes pull from the CHANGELOG section above

🤖 Generated with [Claude Code](https://claude.com/claude-code)