### PR TITLE
feat(report): framework panel breakdown by native taxonomy — data-driven, 8 frameworks (closes #751)

### DIFF
--- a/src/M365-Assess/Common/Build-ReportData.ps1
+++ b/src/M365-Assess/Common/Build-ReportData.ps1
@@ -268,21 +268,16 @@ function Build-ReportDataJson {
     $caRows        = & $get 'ca'
     $adminRoleRows = & $get 'admin-roles'
 
-    # Issue #751: surface the framework's native taxonomy (groupBy + groups map)
-    # so the React FrameworkQuilt can render per-framework section/family rows
-    # instead of falling back to M365-Assess internal domains.
+    # Issue #751: surface the framework's native taxonomy (groupBy + groupLabel +
+    # groups map) so the React FrameworkQuilt can render per-framework
+    # section/family rows. Import-FrameworkDefinitions promotes these to
+    # top-level on the framework hashtable, including aliasing legacy field
+    # names (sections / controls / families / etc.) to 'groups'.
     $frameworkList = @($FrameworkDefs | ForEach-Object {
         $entry = @{ id = $_['frameworkId']; full = $_['label']; desc = $_['description']; url = $_['homepageUrl'] }
-        if ($_.ContainsKey('groupBy'))    { $entry['groupBy']    = $_['groupBy'] }
-        if ($_.ContainsKey('groupLabel')) { $entry['groupLabel'] = $_['groupLabel'] }
-        if ($_.ContainsKey('groups'))     { $entry['groups']     = $_['groups'] }
-        # Backward-compat: framework JSONs use various field names for the same
-        # concept -- alias them all to 'groups' so the consumer is uniform.
-        if (-not $entry.ContainsKey('groups')) {
-            foreach ($alias in 'sections', 'controls', 'families', 'requirements', 'clauses', 'functions') {
-                if ($_.ContainsKey($alias)) { $entry['groups'] = $_[$alias]; break }
-            }
-        }
+        if ($_.ContainsKey('groupBy')    -and $_['groupBy'])    { $entry['groupBy']    = $_['groupBy'] }
+        if ($_.ContainsKey('groupLabel') -and $_['groupLabel']) { $entry['groupLabel'] = $_['groupLabel'] }
+        if ($_.ContainsKey('groups')     -and $_['groups'])     { $entry['groups']     = $_['groups'] }
         $entry
     })
 

--- a/src/M365-Assess/Common/Build-ReportData.ps1
+++ b/src/M365-Assess/Common/Build-ReportData.ps1
@@ -268,7 +268,23 @@ function Build-ReportDataJson {
     $caRows        = & $get 'ca'
     $adminRoleRows = & $get 'admin-roles'
 
-    $frameworkList = @($FrameworkDefs | ForEach-Object { @{ id = $_['frameworkId']; full = $_['label']; desc = $_['description']; url = $_['homepageUrl'] } })
+    # Issue #751: surface the framework's native taxonomy (groupBy + groups map)
+    # so the React FrameworkQuilt can render per-framework section/family rows
+    # instead of falling back to M365-Assess internal domains.
+    $frameworkList = @($FrameworkDefs | ForEach-Object {
+        $entry = @{ id = $_['frameworkId']; full = $_['label']; desc = $_['description']; url = $_['homepageUrl'] }
+        if ($_.ContainsKey('groupBy'))    { $entry['groupBy']    = $_['groupBy'] }
+        if ($_.ContainsKey('groupLabel')) { $entry['groupLabel'] = $_['groupLabel'] }
+        if ($_.ContainsKey('groups'))     { $entry['groups']     = $_['groups'] }
+        # Backward-compat: framework JSONs use various field names for the same
+        # concept -- alias them all to 'groups' so the consumer is uniform.
+        if (-not $entry.ContainsKey('groups')) {
+            foreach ($alias in 'sections', 'controls', 'families', 'requirements', 'clauses', 'functions') {
+                if ($_.ContainsKey($alias)) { $entry['groups'] = $_[$alias]; break }
+            }
+        }
+        $entry
+    })
 
     # ------------------------------------------------------------------
     # Mailbox summary — pivot Metric/Count rows into a single object

--- a/src/M365-Assess/Common/Import-FrameworkDefinitions.ps1
+++ b/src/M365-Assess/Common/Import-FrameworkDefinitions.ps1
@@ -129,7 +129,11 @@ function Import-FrameworkDefinitions {
             }
         }
 
-        $frameworks.Add(@{
+        # Issue #751: promote groupBy / groupLabel / groups (with aliases sections,
+        # controls, families, requirements, clauses, functions) to top-level so
+        # Build-ReportData can surface them in REPORT_DATA.frameworks for the
+        # React FrameworkQuilt's native-taxonomy breakdown.
+        $entryHt = @{
             frameworkId   = $fwId
             label         = [string]$def.label
             description   = if ($def.description) { [string]$def.description } else { '' }
@@ -142,7 +146,25 @@ function Import-FrameworkDefinitions {
             filterFamily  = $filterFamily
             scoringData   = $scoringData
             extraData     = $extraData
-        })
+        }
+        if ($def.PSObject.Properties.Name -contains 'groupBy'    -and $def.groupBy)    { $entryHt['groupBy']    = [string]$def.groupBy }
+        if ($def.PSObject.Properties.Name -contains 'groupLabel' -and $def.groupLabel) { $entryHt['groupLabel'] = [string]$def.groupLabel }
+        # 'groups' is the canonical name; legacy field names alias to it. Whichever
+        # appears first wins (frameworks should pick one).
+        foreach ($alias in 'groups', 'sections', 'controls', 'families', 'requirements', 'clauses', 'functions') {
+            if ($def.PSObject.Properties.Name -contains $alias -and $def.$alias) {
+                $val = $def.$alias
+                if ($val -is [System.Management.Automation.PSCustomObject]) {
+                    $ht = [ordered]@{}
+                    foreach ($p in $val.PSObject.Properties) { $ht[$p.Name] = [string]$p.Value }
+                    $entryHt['groups'] = $ht
+                } else {
+                    $entryHt['groups'] = $val
+                }
+                break
+            }
+        }
+        $frameworks.Add($entryHt)
     }
 
     # Sort by displayOrder, then by frameworkId for stable ordering

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -2132,62 +2132,40 @@ const matchProfileToken = (profilesArr, token) => {
   return profilesArr.some(p => p.includes(token));
 };
 
-// Issue #751: per-framework family taxonomy used by the framework panel's
-// "Coverage by family" breakdown. v1 covers CIS M365 (sections 1-9) and
-// CMMC (11 standard families). Other frameworks fall back to the prior
-// "Coverage by domain" view. Migration to registry-driven mapping is
-// deferred -- hardcoded here for shipping speed per the issue's recommendation.
-const FRAMEWORK_FAMILIES = {
-  'cis-m365-v6': {
-    label: 'section',
-    // Extract the leading section number from a controlId like '5.2.2.5'
-    extract: cid => {
-      const m = String(cid).match(/^(\d+)/);
-      return m ? m[1] : null;
-    },
-    // Sort numerically by section number
-    compare: (a, b) => parseInt(a, 10) - parseInt(b, 10),
-    names: {
-      '1': 'Account / Authentication',
-      '2': 'Application Permissions',
-      '3': 'Data Management',
-      '4': 'Email Security',
-      '5': 'Auditing',
-      '6': 'Storage / OneDrive',
-      '7': 'SharePoint / Mobile',
-      '8': 'Microsoft Teams',
-      '9': 'Microsoft Defender'
-    }
+// Issue #751: extraction strategies that derive a "group key" (section number,
+// family code, function letter, etc.) from a framework's native controlId.
+// Each framework's JSON file declares its `groupBy` strategy + `groups` map
+// (key → display name); the strategies are enumerated here.
+const GROUP_EXTRACTORS = {
+  // CIS M365 v6, CIS Controls v8, PCI DSS v4: leading numeric section (e.g. '5.2.2.5' → '5')
+  'section-prefix': cid => {
+    const m = String(cid).match(/^(\d+)/);
+    return m ? m[1] : null;
   },
-  'cmmc': {
-    label: 'family',
-    // Extract the family code from a controlId like 'AC.L2-3.1.1' or 'IA.L1-B.1.V'
-    extract: cid => {
-      const m = String(cid).match(/^([A-Z]{2})\./);
-      return m ? m[1] : null;
-    },
-    // Alphabetical sort by family code
-    compare: (a, b) => a.localeCompare(b),
-    names: {
-      'AC': 'Access Control',
-      'AT': 'Awareness & Training',
-      'AU': 'Audit & Accountability',
-      'CA': 'Security Assessment',
-      'CM': 'Configuration Management',
-      'CP': 'Contingency Planning',
-      'IA': 'Identification & Authentication',
-      'IR': 'Incident Response',
-      'MA': 'Maintenance',
-      'MP': 'Media Protection',
-      'PE': 'Physical Protection',
-      'PS': 'Personnel Security',
-      'RA': 'Risk Assessment',
-      'SC': 'System & Communications Protection',
-      'SI': 'System & Information Integrity',
-      'SR': 'Supply Chain Risk Management'
-    }
+  // CMMC, NIST 800-53, FedRAMP: letter family before first non-letter (e.g. 'AC.L2-3.1.1' → 'AC', 'AC-1' → 'AC')
+  'family-letter-prefix': cid => {
+    const m = String(cid).match(/^([A-Z]{2,3})/);
+    return m ? m[1] : null;
+  },
+  // NIST CSF: function letters before the first dot (e.g. 'ID.AM-1' → 'ID', 'PR.AC-1' → 'PR')
+  'dot-prefix': cid => {
+    const m = String(cid).match(/^([A-Z]+)\./);
+    return m ? m[1] : null;
+  },
+  // ISO 27001:2022: 'A.5.1.1' → 'A.5'; ISO 27001:2013 also uses A.X.Y form
+  'iso-clause-prefix': cid => {
+    const m = String(cid).match(/^(A\.\d+)/);
+    return m ? m[1] : null;
   }
 };
+
+// Default: most groups sort alphanumerically; numeric-only keys sort numerically.
+function compareGroupKeys(a, b) {
+  const na = parseFloat(a);
+  const nb = parseFloat(b);
+  if (!isNaN(na) && !isNaN(nb)) return na - nb;
+  return String(a).localeCompare(String(b));
+}
 
 // ======================== Framework quilt ========================
 function FrameworkQuilt({
@@ -2281,14 +2259,16 @@ function FrameworkQuilt({
     return out;
   }, [expandedFw, activeProfiles]);
 
-  // Issue #751: family/section breakdown for frameworks with their own native
-  // taxonomy (CIS, CMMC). Each finding is counted ONCE per family it touches
-  // (a CMMC finding mapped to AC + IA + MA increments all three families'
-  // totals, but only once per family even if it has multiple AC.L2-* controlIds).
+  // Issue #751: native-taxonomy breakdown for frameworks that declare a `groupBy`
+  // strategy + `groups` map in their framework JSON (CIS, CMMC, NIST, ISO, ...).
+  // Each finding is counted ONCE per group it touches (a CMMC finding mapped to
+  // AC + IA + MA increments all three groups' totals, but multiple AC.L2-*
+  // controlIds within the same finding still count as one AC entry).
   const fwFamilyBreakdown = useMemo(() => {
     if (!expandedFw) return null;
-    const fam = FRAMEWORK_FAMILIES[expandedFw];
-    if (!fam) return null;
+    if (!expandedMeta || !expandedMeta.groupBy) return null;
+    const extract = GROUP_EXTRACTORS[expandedMeta.groupBy];
+    if (!extract) return null;
     const tokens = activeProfiles || [];
     const out = {};
     FINDINGS.forEach(f => {
@@ -2299,15 +2279,15 @@ function FrameworkQuilt({
       }
       const cidRaw = f.fwMeta?.[expandedFw]?.controlId;
       if (!cidRaw) return;
-      // controlId can be a single value or semi/comma-separated list
+      // controlId can be a single value or a semi/comma-separated list
       const cids = String(cidRaw).split(/[;,]/).map(s => s.trim()).filter(Boolean);
-      const families = new Set();
+      const groups = new Set();
       cids.forEach(cid => {
-        const code = fam.extract(cid);
-        if (code) families.add(code);
+        const code = extract(cid);
+        if (code) groups.add(code);
       });
-      if (families.size === 0) families.add('OTHER');
-      families.forEach(code => {
+      if (groups.size === 0) groups.add('OTHER');
+      groups.forEach(code => {
         if (!out[code]) out[code] = {
           pass: 0,
           warn: 0,
@@ -2322,7 +2302,7 @@ function FrameworkQuilt({
       });
     });
     return out;
-  }, [expandedFw, activeProfiles]);
+  }, [expandedFw, activeProfiles, expandedMeta]);
   const fwProfileStats = useMemo(() => {
     if (!expandedFw) return null;
     const l1 = new Set(),
@@ -2669,17 +2649,19 @@ function FrameworkQuilt({
       flex: expandedData.info
     }
   })), (() => {
-    // Issue #751: prefer the framework's own family/section taxonomy when
-    // available (CIS, CMMC); fall back to M365-Assess domain breakdown.
-    const famDef = FRAMEWORK_FAMILIES[expandedFw];
-    const useFamily = famDef && fwFamilyBreakdown && Object.keys(fwFamilyBreakdown).length > 0;
-    const headerLabel = useFamily ? `Coverage by ${famDef.label}` : 'Coverage by domain';
-    const rows = useFamily ? Object.entries(fwFamilyBreakdown).sort((a, b) => famDef.compare(a[0], b[0])) : Object.entries(fwDomainBreakdown).sort((a, b) => b[1].fail - a[1].fail || b[1].total - a[1].total);
+    // Issue #751: prefer the framework's own native taxonomy when available
+    // (declared via groupBy + groups in the framework JSON); fall back to
+    // M365-Assess domain breakdown for frameworks without that metadata.
+    const useFamily = fwFamilyBreakdown && Object.keys(fwFamilyBreakdown).length > 0;
+    const groupLabel = expandedMeta?.groupLabel || (useFamily ? 'family' : 'domain');
+    const headerLabel = useFamily ? `Coverage by ${groupLabel}` : 'Coverage by domain';
+    const groupNames = expandedMeta?.groups || {};
+    const rows = useFamily ? Object.entries(fwFamilyBreakdown).sort((a, b) => compareGroupKeys(a[0], b[0])) : Object.entries(fwDomainBreakdown).sort((a, b) => b[1].fail - a[1].fail || b[1].total - a[1].total);
     const labelFor = key => {
       if (!useFamily) return key;
       if (key === 'OTHER') return 'Other';
-      const name = famDef.names[key];
-      return name ? `${key} · ${name}` : key;
+      const name = groupNames[key];
+      return name ? `${key} · ${name}` : `${key} · (unmapped)`;
     };
     return /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement("div", {
       style: {

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -2234,6 +2234,11 @@ function FrameworkQuilt({
     }));
     return out;
   }, []);
+
+  // Issue #751: hoisted before fwFamilyBreakdown so the memo's dependency
+  // array can reference expandedMeta without hitting a TDZ ReferenceError
+  // (which unmounted the entire report on the prior commit on this branch).
+  const expandedMeta = expandedFw ? FRAMEWORKS.find(f => f.id === expandedFw) : null;
   const fwDomainBreakdown = useMemo(() => {
     if (!expandedFw) return {};
     const tokens = activeProfiles || [];
@@ -2334,7 +2339,8 @@ function FrameworkQuilt({
   const displayFws = FRAMEWORKS.filter(f => visibleFws.includes(f.id));
   const pickerLabel = visibleFws.length === 1 ? FRAMEWORKS.find(f => f.id === visibleFws[0])?.full || visibleFws[0] : `${visibleFws.length} frameworks`;
   const handleCardClick = fwId => setExpandedFw(e => e === fwId ? null : fwId);
-  const expandedMeta = expandedFw ? FRAMEWORKS.find(f => f.id === expandedFw) : null;
+
+  // expandedMeta is hoisted earlier (above fwFamilyBreakdown) — see comment there.
   const expandedData = expandedFw ? byFw[expandedFw] : null;
 
   // Count of findings within the expanded framework that match the active level-chip

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -2132,6 +2132,63 @@ const matchProfileToken = (profilesArr, token) => {
   return profilesArr.some(p => p.includes(token));
 };
 
+// Issue #751: per-framework family taxonomy used by the framework panel's
+// "Coverage by family" breakdown. v1 covers CIS M365 (sections 1-9) and
+// CMMC (11 standard families). Other frameworks fall back to the prior
+// "Coverage by domain" view. Migration to registry-driven mapping is
+// deferred -- hardcoded here for shipping speed per the issue's recommendation.
+const FRAMEWORK_FAMILIES = {
+  'cis-m365-v6': {
+    label: 'section',
+    // Extract the leading section number from a controlId like '5.2.2.5'
+    extract: cid => {
+      const m = String(cid).match(/^(\d+)/);
+      return m ? m[1] : null;
+    },
+    // Sort numerically by section number
+    compare: (a, b) => parseInt(a, 10) - parseInt(b, 10),
+    names: {
+      '1': 'Account / Authentication',
+      '2': 'Application Permissions',
+      '3': 'Data Management',
+      '4': 'Email Security',
+      '5': 'Auditing',
+      '6': 'Storage / OneDrive',
+      '7': 'SharePoint / Mobile',
+      '8': 'Microsoft Teams',
+      '9': 'Microsoft Defender'
+    }
+  },
+  'cmmc': {
+    label: 'family',
+    // Extract the family code from a controlId like 'AC.L2-3.1.1' or 'IA.L1-B.1.V'
+    extract: cid => {
+      const m = String(cid).match(/^([A-Z]{2})\./);
+      return m ? m[1] : null;
+    },
+    // Alphabetical sort by family code
+    compare: (a, b) => a.localeCompare(b),
+    names: {
+      'AC': 'Access Control',
+      'AT': 'Awareness & Training',
+      'AU': 'Audit & Accountability',
+      'CA': 'Security Assessment',
+      'CM': 'Configuration Management',
+      'CP': 'Contingency Planning',
+      'IA': 'Identification & Authentication',
+      'IR': 'Incident Response',
+      'MA': 'Maintenance',
+      'MP': 'Media Protection',
+      'PE': 'Physical Protection',
+      'PS': 'Personnel Security',
+      'RA': 'Risk Assessment',
+      'SC': 'System & Communications Protection',
+      'SI': 'System & Information Integrity',
+      'SR': 'Supply Chain Risk Management'
+    }
+  }
+};
+
 // ======================== Framework quilt ========================
 function FrameworkQuilt({
   onSelect,
@@ -2220,6 +2277,49 @@ function FrameworkQuilt({
       out[f.domain].total++;
       const k = STATUS_COLORS[f.status];
       if (k) out[f.domain][k]++;
+    });
+    return out;
+  }, [expandedFw, activeProfiles]);
+
+  // Issue #751: family/section breakdown for frameworks with their own native
+  // taxonomy (CIS, CMMC). Each finding is counted ONCE per family it touches
+  // (a CMMC finding mapped to AC + IA + MA increments all three families'
+  // totals, but only once per family even if it has multiple AC.L2-* controlIds).
+  const fwFamilyBreakdown = useMemo(() => {
+    if (!expandedFw) return null;
+    const fam = FRAMEWORK_FAMILIES[expandedFw];
+    if (!fam) return null;
+    const tokens = activeProfiles || [];
+    const out = {};
+    FINDINGS.forEach(f => {
+      if (!f.frameworks.includes(expandedFw)) return;
+      if (tokens.length > 0) {
+        const profs = [].concat(f.fwMeta?.[expandedFw]?.profiles || []);
+        if (!tokens.some(t => matchProfileToken(profs, t))) return;
+      }
+      const cidRaw = f.fwMeta?.[expandedFw]?.controlId;
+      if (!cidRaw) return;
+      // controlId can be a single value or semi/comma-separated list
+      const cids = String(cidRaw).split(/[;,]/).map(s => s.trim()).filter(Boolean);
+      const families = new Set();
+      cids.forEach(cid => {
+        const code = fam.extract(cid);
+        if (code) families.add(code);
+      });
+      if (families.size === 0) families.add('OTHER');
+      families.forEach(code => {
+        if (!out[code]) out[code] = {
+          pass: 0,
+          warn: 0,
+          fail: 0,
+          review: 0,
+          info: 0,
+          total: 0
+        };
+        out[code].total++;
+        const k = STATUS_COLORS[f.status];
+        if (k) out[code][k]++;
+      });
     });
     return out;
   }, [expandedFw, activeProfiles]);
@@ -2568,60 +2668,74 @@ function FrameworkQuilt({
     style: {
       flex: expandedData.info
     }
-  })), /*#__PURE__*/React.createElement("div", {
-    style: {
-      fontSize: 12,
-      fontWeight: 700,
-      textTransform: 'uppercase',
-      letterSpacing: '.1em',
-      color: 'var(--muted)',
-      marginBottom: 8
-    }
-  }, "Coverage by domain"), /*#__PURE__*/React.createElement("div", {
-    className: "fw-detail-domains"
-  }, Object.entries(fwDomainBreakdown).sort((a, b) => b[1].fail - a[1].fail || b[1].total - a[1].total).map(([domain, s]) => /*#__PURE__*/React.createElement("div", {
-    key: domain,
-    className: "fw-domain-row"
-  }, /*#__PURE__*/React.createElement("div", {
-    className: "fw-domain-name"
-  }, domain), /*#__PURE__*/React.createElement("div", {
-    className: "fw-domain-bar"
-  }, s.pass > 0 && /*#__PURE__*/React.createElement("div", {
-    className: "fw-seg pass",
-    style: {
-      flex: s.pass
-    }
-  }), s.warn > 0 && /*#__PURE__*/React.createElement("div", {
-    className: "fw-seg warn",
-    style: {
-      flex: s.warn
-    }
-  }), s.fail > 0 && /*#__PURE__*/React.createElement("div", {
-    className: "fw-seg fail",
-    style: {
-      flex: s.fail
-    }
-  }), s.review > 0 && /*#__PURE__*/React.createElement("div", {
-    className: "fw-seg review",
-    style: {
-      flex: s.review
-    }
-  }), s.info > 0 && /*#__PURE__*/React.createElement("div", {
-    className: "fw-seg info",
-    style: {
-      flex: s.info
-    }
-  })), /*#__PURE__*/React.createElement("div", {
-    className: "fw-domain-stat"
-  }, s.fail > 0 ? /*#__PURE__*/React.createElement("span", {
-    style: {
-      color: 'var(--danger-text)'
-    }
-  }, s.fail, " gap", s.fail !== 1 ? 's' : '') : /*#__PURE__*/React.createElement("span", {
-    style: {
-      color: 'var(--success-text)'
-    }
-  }, s.pass, " pass"))))), /*#__PURE__*/React.createElement("div", {
+  })), (() => {
+    // Issue #751: prefer the framework's own family/section taxonomy when
+    // available (CIS, CMMC); fall back to M365-Assess domain breakdown.
+    const famDef = FRAMEWORK_FAMILIES[expandedFw];
+    const useFamily = famDef && fwFamilyBreakdown && Object.keys(fwFamilyBreakdown).length > 0;
+    const headerLabel = useFamily ? `Coverage by ${famDef.label}` : 'Coverage by domain';
+    const rows = useFamily ? Object.entries(fwFamilyBreakdown).sort((a, b) => famDef.compare(a[0], b[0])) : Object.entries(fwDomainBreakdown).sort((a, b) => b[1].fail - a[1].fail || b[1].total - a[1].total);
+    const labelFor = key => {
+      if (!useFamily) return key;
+      if (key === 'OTHER') return 'Other';
+      const name = famDef.names[key];
+      return name ? `${key} · ${name}` : key;
+    };
+    return /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement("div", {
+      style: {
+        fontSize: 12,
+        fontWeight: 700,
+        textTransform: 'uppercase',
+        letterSpacing: '.1em',
+        color: 'var(--muted)',
+        marginBottom: 8
+      }
+    }, headerLabel), /*#__PURE__*/React.createElement("div", {
+      className: "fw-detail-domains"
+    }, rows.map(([key, s]) => /*#__PURE__*/React.createElement("div", {
+      key: key,
+      className: "fw-domain-row"
+    }, /*#__PURE__*/React.createElement("div", {
+      className: "fw-domain-name"
+    }, labelFor(key)), /*#__PURE__*/React.createElement("div", {
+      className: "fw-domain-bar"
+    }, s.pass > 0 && /*#__PURE__*/React.createElement("div", {
+      className: "fw-seg pass",
+      style: {
+        flex: s.pass
+      }
+    }), s.warn > 0 && /*#__PURE__*/React.createElement("div", {
+      className: "fw-seg warn",
+      style: {
+        flex: s.warn
+      }
+    }), s.fail > 0 && /*#__PURE__*/React.createElement("div", {
+      className: "fw-seg fail",
+      style: {
+        flex: s.fail
+      }
+    }), s.review > 0 && /*#__PURE__*/React.createElement("div", {
+      className: "fw-seg review",
+      style: {
+        flex: s.review
+      }
+    }), s.info > 0 && /*#__PURE__*/React.createElement("div", {
+      className: "fw-seg info",
+      style: {
+        flex: s.info
+      }
+    })), /*#__PURE__*/React.createElement("div", {
+      className: "fw-domain-stat"
+    }, s.fail > 0 ? /*#__PURE__*/React.createElement("span", {
+      style: {
+        color: 'var(--danger-text)'
+      }
+    }, s.fail, " gap", s.fail !== 1 ? 's' : '') : /*#__PURE__*/React.createElement("span", {
+      style: {
+        color: 'var(--success-text)'
+      }
+    }, s.pass, " pass"))))));
+  })(), /*#__PURE__*/React.createElement("div", {
     style: {
       marginTop: 14,
       paddingTop: 12,

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -1351,62 +1351,40 @@ const matchProfileToken = (profilesArr, token) => {
   return profilesArr.some(p => p.includes(token));
 };
 
-// Issue #751: per-framework family taxonomy used by the framework panel's
-// "Coverage by family" breakdown. v1 covers CIS M365 (sections 1-9) and
-// CMMC (11 standard families). Other frameworks fall back to the prior
-// "Coverage by domain" view. Migration to registry-driven mapping is
-// deferred -- hardcoded here for shipping speed per the issue's recommendation.
-const FRAMEWORK_FAMILIES = {
-  'cis-m365-v6': {
-    label: 'section',
-    // Extract the leading section number from a controlId like '5.2.2.5'
-    extract: (cid) => {
-      const m = String(cid).match(/^(\d+)/);
-      return m ? m[1] : null;
-    },
-    // Sort numerically by section number
-    compare: (a, b) => parseInt(a, 10) - parseInt(b, 10),
-    names: {
-      '1': 'Account / Authentication',
-      '2': 'Application Permissions',
-      '3': 'Data Management',
-      '4': 'Email Security',
-      '5': 'Auditing',
-      '6': 'Storage / OneDrive',
-      '7': 'SharePoint / Mobile',
-      '8': 'Microsoft Teams',
-      '9': 'Microsoft Defender',
-    },
+// Issue #751: extraction strategies that derive a "group key" (section number,
+// family code, function letter, etc.) from a framework's native controlId.
+// Each framework's JSON file declares its `groupBy` strategy + `groups` map
+// (key → display name); the strategies are enumerated here.
+const GROUP_EXTRACTORS = {
+  // CIS M365 v6, CIS Controls v8, PCI DSS v4: leading numeric section (e.g. '5.2.2.5' → '5')
+  'section-prefix': (cid) => {
+    const m = String(cid).match(/^(\d+)/);
+    return m ? m[1] : null;
   },
-  'cmmc': {
-    label: 'family',
-    // Extract the family code from a controlId like 'AC.L2-3.1.1' or 'IA.L1-B.1.V'
-    extract: (cid) => {
-      const m = String(cid).match(/^([A-Z]{2})\./);
-      return m ? m[1] : null;
-    },
-    // Alphabetical sort by family code
-    compare: (a, b) => a.localeCompare(b),
-    names: {
-      'AC': 'Access Control',
-      'AT': 'Awareness & Training',
-      'AU': 'Audit & Accountability',
-      'CA': 'Security Assessment',
-      'CM': 'Configuration Management',
-      'CP': 'Contingency Planning',
-      'IA': 'Identification & Authentication',
-      'IR': 'Incident Response',
-      'MA': 'Maintenance',
-      'MP': 'Media Protection',
-      'PE': 'Physical Protection',
-      'PS': 'Personnel Security',
-      'RA': 'Risk Assessment',
-      'SC': 'System & Communications Protection',
-      'SI': 'System & Information Integrity',
-      'SR': 'Supply Chain Risk Management',
-    },
+  // CMMC, NIST 800-53, FedRAMP: letter family before first non-letter (e.g. 'AC.L2-3.1.1' → 'AC', 'AC-1' → 'AC')
+  'family-letter-prefix': (cid) => {
+    const m = String(cid).match(/^([A-Z]{2,3})/);
+    return m ? m[1] : null;
+  },
+  // NIST CSF: function letters before the first dot (e.g. 'ID.AM-1' → 'ID', 'PR.AC-1' → 'PR')
+  'dot-prefix': (cid) => {
+    const m = String(cid).match(/^([A-Z]+)\./);
+    return m ? m[1] : null;
+  },
+  // ISO 27001:2022: 'A.5.1.1' → 'A.5'; ISO 27001:2013 also uses A.X.Y form
+  'iso-clause-prefix': (cid) => {
+    const m = String(cid).match(/^(A\.\d+)/);
+    return m ? m[1] : null;
   },
 };
+
+// Default: most groups sort alphanumerically; numeric-only keys sort numerically.
+function compareGroupKeys(a, b) {
+  const na = parseFloat(a);
+  const nb = parseFloat(b);
+  if (!isNaN(na) && !isNaN(nb)) return na - nb;
+  return String(a).localeCompare(String(b));
+}
 
 // ======================== Framework quilt ========================
 function FrameworkQuilt({ onSelect, selected, onProfileSelect, activeProfiles }) {
@@ -1478,14 +1456,16 @@ function FrameworkQuilt({ onSelect, selected, onProfileSelect, activeProfiles })
     return out;
   }, [expandedFw, activeProfiles]);
 
-  // Issue #751: family/section breakdown for frameworks with their own native
-  // taxonomy (CIS, CMMC). Each finding is counted ONCE per family it touches
-  // (a CMMC finding mapped to AC + IA + MA increments all three families'
-  // totals, but only once per family even if it has multiple AC.L2-* controlIds).
+  // Issue #751: native-taxonomy breakdown for frameworks that declare a `groupBy`
+  // strategy + `groups` map in their framework JSON (CIS, CMMC, NIST, ISO, ...).
+  // Each finding is counted ONCE per group it touches (a CMMC finding mapped to
+  // AC + IA + MA increments all three groups' totals, but multiple AC.L2-*
+  // controlIds within the same finding still count as one AC entry).
   const fwFamilyBreakdown = useMemo(() => {
     if (!expandedFw) return null;
-    const fam = FRAMEWORK_FAMILIES[expandedFw];
-    if (!fam) return null;
+    if (!expandedMeta || !expandedMeta.groupBy) return null;
+    const extract = GROUP_EXTRACTORS[expandedMeta.groupBy];
+    if (!extract) return null;
     const tokens = activeProfiles || [];
     const out = {};
     FINDINGS.forEach(f => {
@@ -1496,15 +1476,15 @@ function FrameworkQuilt({ onSelect, selected, onProfileSelect, activeProfiles })
       }
       const cidRaw = f.fwMeta?.[expandedFw]?.controlId;
       if (!cidRaw) return;
-      // controlId can be a single value or semi/comma-separated list
+      // controlId can be a single value or a semi/comma-separated list
       const cids = String(cidRaw).split(/[;,]/).map(s => s.trim()).filter(Boolean);
-      const families = new Set();
+      const groups = new Set();
       cids.forEach(cid => {
-        const code = fam.extract(cid);
-        if (code) families.add(code);
+        const code = extract(cid);
+        if (code) groups.add(code);
       });
-      if (families.size === 0) families.add('OTHER');
-      families.forEach(code => {
+      if (groups.size === 0) groups.add('OTHER');
+      groups.forEach(code => {
         if (!out[code]) out[code] = { pass:0, warn:0, fail:0, review:0, info:0, total:0 };
         out[code].total++;
         const k = STATUS_COLORS[f.status];
@@ -1512,7 +1492,7 @@ function FrameworkQuilt({ onSelect, selected, onProfileSelect, activeProfiles })
       });
     });
     return out;
-  }, [expandedFw, activeProfiles]);
+  }, [expandedFw, activeProfiles, expandedMeta]);
 
   const fwProfileStats = useMemo(() => {
     if (!expandedFw) return null;
@@ -1703,19 +1683,21 @@ function FrameworkQuilt({ onSelect, selected, onProfileSelect, activeProfiles })
             {expandedData.info>0   && <div className="fw-seg info"   style={{flex:expandedData.info}}/>}
           </div>
           {(() => {
-            // Issue #751: prefer the framework's own family/section taxonomy when
-            // available (CIS, CMMC); fall back to M365-Assess domain breakdown.
-            const famDef = FRAMEWORK_FAMILIES[expandedFw];
-            const useFamily = famDef && fwFamilyBreakdown && Object.keys(fwFamilyBreakdown).length > 0;
-            const headerLabel = useFamily ? `Coverage by ${famDef.label}` : 'Coverage by domain';
+            // Issue #751: prefer the framework's own native taxonomy when available
+            // (declared via groupBy + groups in the framework JSON); fall back to
+            // M365-Assess domain breakdown for frameworks without that metadata.
+            const useFamily = fwFamilyBreakdown && Object.keys(fwFamilyBreakdown).length > 0;
+            const groupLabel = expandedMeta?.groupLabel || (useFamily ? 'family' : 'domain');
+            const headerLabel = useFamily ? `Coverage by ${groupLabel}` : 'Coverage by domain';
+            const groupNames = expandedMeta?.groups || {};
             const rows = useFamily
-              ? Object.entries(fwFamilyBreakdown).sort((a, b) => famDef.compare(a[0], b[0]))
+              ? Object.entries(fwFamilyBreakdown).sort((a, b) => compareGroupKeys(a[0], b[0]))
               : Object.entries(fwDomainBreakdown).sort((a, b) => b[1].fail - a[1].fail || b[1].total - a[1].total);
             const labelFor = (key) => {
               if (!useFamily) return key;
               if (key === 'OTHER') return 'Other';
-              const name = famDef.names[key];
-              return name ? `${key} · ${name}` : key;
+              const name = groupNames[key];
+              return name ? `${key} · ${name}` : `${key} · (unmapped)`;
             };
             return (
               <>

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -1438,6 +1438,11 @@ function FrameworkQuilt({ onSelect, selected, onProfileSelect, activeProfiles })
     return out;
   }, []);
 
+  // Issue #751: hoisted before fwFamilyBreakdown so the memo's dependency
+  // array can reference expandedMeta without hitting a TDZ ReferenceError
+  // (which unmounted the entire report on the prior commit on this branch).
+  const expandedMeta = expandedFw ? FRAMEWORKS.find(f => f.id === expandedFw) : null;
+
   const fwDomainBreakdown = useMemo(() => {
     if (!expandedFw) return {};
     const tokens = activeProfiles || [];
@@ -1519,7 +1524,7 @@ function FrameworkQuilt({ onSelect, selected, onProfileSelect, activeProfiles })
 
   const handleCardClick = fwId => setExpandedFw(e => e === fwId ? null : fwId);
 
-  const expandedMeta = expandedFw ? FRAMEWORKS.find(f => f.id === expandedFw) : null;
+  // expandedMeta is hoisted earlier (above fwFamilyBreakdown) — see comment there.
   const expandedData = expandedFw ? byFw[expandedFw] : null;
 
   // Count of findings within the expanded framework that match the active level-chip

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -1351,6 +1351,63 @@ const matchProfileToken = (profilesArr, token) => {
   return profilesArr.some(p => p.includes(token));
 };
 
+// Issue #751: per-framework family taxonomy used by the framework panel's
+// "Coverage by family" breakdown. v1 covers CIS M365 (sections 1-9) and
+// CMMC (11 standard families). Other frameworks fall back to the prior
+// "Coverage by domain" view. Migration to registry-driven mapping is
+// deferred -- hardcoded here for shipping speed per the issue's recommendation.
+const FRAMEWORK_FAMILIES = {
+  'cis-m365-v6': {
+    label: 'section',
+    // Extract the leading section number from a controlId like '5.2.2.5'
+    extract: (cid) => {
+      const m = String(cid).match(/^(\d+)/);
+      return m ? m[1] : null;
+    },
+    // Sort numerically by section number
+    compare: (a, b) => parseInt(a, 10) - parseInt(b, 10),
+    names: {
+      '1': 'Account / Authentication',
+      '2': 'Application Permissions',
+      '3': 'Data Management',
+      '4': 'Email Security',
+      '5': 'Auditing',
+      '6': 'Storage / OneDrive',
+      '7': 'SharePoint / Mobile',
+      '8': 'Microsoft Teams',
+      '9': 'Microsoft Defender',
+    },
+  },
+  'cmmc': {
+    label: 'family',
+    // Extract the family code from a controlId like 'AC.L2-3.1.1' or 'IA.L1-B.1.V'
+    extract: (cid) => {
+      const m = String(cid).match(/^([A-Z]{2})\./);
+      return m ? m[1] : null;
+    },
+    // Alphabetical sort by family code
+    compare: (a, b) => a.localeCompare(b),
+    names: {
+      'AC': 'Access Control',
+      'AT': 'Awareness & Training',
+      'AU': 'Audit & Accountability',
+      'CA': 'Security Assessment',
+      'CM': 'Configuration Management',
+      'CP': 'Contingency Planning',
+      'IA': 'Identification & Authentication',
+      'IR': 'Incident Response',
+      'MA': 'Maintenance',
+      'MP': 'Media Protection',
+      'PE': 'Physical Protection',
+      'PS': 'Personnel Security',
+      'RA': 'Risk Assessment',
+      'SC': 'System & Communications Protection',
+      'SI': 'System & Information Integrity',
+      'SR': 'Supply Chain Risk Management',
+    },
+  },
+};
+
 // ======================== Framework quilt ========================
 function FrameworkQuilt({ onSelect, selected, onProfileSelect, activeProfiles }) {
   const { open, headProps } = useCollapsibleSection();
@@ -1417,6 +1474,42 @@ function FrameworkQuilt({ onSelect, selected, onProfileSelect, activeProfiles })
       out[f.domain].total++;
       const k = STATUS_COLORS[f.status];
       if (k) out[f.domain][k]++;
+    });
+    return out;
+  }, [expandedFw, activeProfiles]);
+
+  // Issue #751: family/section breakdown for frameworks with their own native
+  // taxonomy (CIS, CMMC). Each finding is counted ONCE per family it touches
+  // (a CMMC finding mapped to AC + IA + MA increments all three families'
+  // totals, but only once per family even if it has multiple AC.L2-* controlIds).
+  const fwFamilyBreakdown = useMemo(() => {
+    if (!expandedFw) return null;
+    const fam = FRAMEWORK_FAMILIES[expandedFw];
+    if (!fam) return null;
+    const tokens = activeProfiles || [];
+    const out = {};
+    FINDINGS.forEach(f => {
+      if (!f.frameworks.includes(expandedFw)) return;
+      if (tokens.length > 0) {
+        const profs = [].concat(f.fwMeta?.[expandedFw]?.profiles || []);
+        if (!tokens.some(t => matchProfileToken(profs, t))) return;
+      }
+      const cidRaw = f.fwMeta?.[expandedFw]?.controlId;
+      if (!cidRaw) return;
+      // controlId can be a single value or semi/comma-separated list
+      const cids = String(cidRaw).split(/[;,]/).map(s => s.trim()).filter(Boolean);
+      const families = new Set();
+      cids.forEach(cid => {
+        const code = fam.extract(cid);
+        if (code) families.add(code);
+      });
+      if (families.size === 0) families.add('OTHER');
+      families.forEach(code => {
+        if (!out[code]) out[code] = { pass:0, warn:0, fail:0, review:0, info:0, total:0 };
+        out[code].total++;
+        const k = STATUS_COLORS[f.status];
+        if (k) out[code][k]++;
+      });
     });
     return out;
   }, [expandedFw, activeProfiles]);
@@ -1609,30 +1702,48 @@ function FrameworkQuilt({ onSelect, selected, onProfileSelect, activeProfiles })
             {expandedData.review>0 && <div className="fw-seg review" style={{flex:expandedData.review}}/>}
             {expandedData.info>0   && <div className="fw-seg info"   style={{flex:expandedData.info}}/>}
           </div>
-          <div style={{fontSize:12, fontWeight:700, textTransform:'uppercase', letterSpacing:'.1em', color:'var(--muted)', marginBottom:8}}>
-            Coverage by domain
-          </div>
-          <div className="fw-detail-domains">
-            {Object.entries(fwDomainBreakdown)
-              .sort((a,b) => b[1].fail - a[1].fail || b[1].total - a[1].total)
-              .map(([domain, s]) => (
-                <div key={domain} className="fw-domain-row">
-                  <div className="fw-domain-name">{domain}</div>
-                  <div className="fw-domain-bar">
-                    {s.pass>0   && <div className="fw-seg pass"   style={{flex:s.pass}}/>}
-                    {s.warn>0   && <div className="fw-seg warn"   style={{flex:s.warn}}/>}
-                    {s.fail>0   && <div className="fw-seg fail"   style={{flex:s.fail}}/>}
-                    {s.review>0 && <div className="fw-seg review" style={{flex:s.review}}/>}
-                    {s.info>0   && <div className="fw-seg info"   style={{flex:s.info}}/>}
-                  </div>
-                  <div className="fw-domain-stat">
-                    {s.fail > 0
-                      ? <span style={{color:'var(--danger-text)'}}>{s.fail} gap{s.fail !== 1 ? 's' : ''}</span>
-                      : <span style={{color:'var(--success-text)'}}>{s.pass} pass</span>}
-                  </div>
+          {(() => {
+            // Issue #751: prefer the framework's own family/section taxonomy when
+            // available (CIS, CMMC); fall back to M365-Assess domain breakdown.
+            const famDef = FRAMEWORK_FAMILIES[expandedFw];
+            const useFamily = famDef && fwFamilyBreakdown && Object.keys(fwFamilyBreakdown).length > 0;
+            const headerLabel = useFamily ? `Coverage by ${famDef.label}` : 'Coverage by domain';
+            const rows = useFamily
+              ? Object.entries(fwFamilyBreakdown).sort((a, b) => famDef.compare(a[0], b[0]))
+              : Object.entries(fwDomainBreakdown).sort((a, b) => b[1].fail - a[1].fail || b[1].total - a[1].total);
+            const labelFor = (key) => {
+              if (!useFamily) return key;
+              if (key === 'OTHER') return 'Other';
+              const name = famDef.names[key];
+              return name ? `${key} · ${name}` : key;
+            };
+            return (
+              <>
+                <div style={{fontSize:12, fontWeight:700, textTransform:'uppercase', letterSpacing:'.1em', color:'var(--muted)', marginBottom:8}}>
+                  {headerLabel}
                 </div>
-              ))}
-          </div>
+                <div className="fw-detail-domains">
+                  {rows.map(([key, s]) => (
+                    <div key={key} className="fw-domain-row">
+                      <div className="fw-domain-name">{labelFor(key)}</div>
+                      <div className="fw-domain-bar">
+                        {s.pass>0   && <div className="fw-seg pass"   style={{flex:s.pass}}/>}
+                        {s.warn>0   && <div className="fw-seg warn"   style={{flex:s.warn}}/>}
+                        {s.fail>0   && <div className="fw-seg fail"   style={{flex:s.fail}}/>}
+                        {s.review>0 && <div className="fw-seg review" style={{flex:s.review}}/>}
+                        {s.info>0   && <div className="fw-seg info"   style={{flex:s.info}}/>}
+                      </div>
+                      <div className="fw-domain-stat">
+                        {s.fail > 0
+                          ? <span style={{color:'var(--danger-text)'}}>{s.fail} gap{s.fail !== 1 ? 's' : ''}</span>
+                          : <span style={{color:'var(--success-text)'}}>{s.pass} pass</span>}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </>
+            );
+          })()}
           <div style={{marginTop:14, paddingTop:12, borderTop:'1px solid var(--border)'}}>
             <button className="chip chip-more selected" onClick={() => {
               onSelect(expandedFw);

--- a/src/M365-Assess/controls/frameworks/cis-controls-v8.json
+++ b/src/M365-Assess/controls/frameworks/cis-controls-v8.json
@@ -42,6 +42,8 @@
       "color": "#60A5FA"
     }
   },
+  "groupBy": "section-prefix",
+  "groupLabel": "control",
   "controls": {
     "1": "Inventory and Control of Enterprise Assets",
     "2": "Inventory and Control of Software Assets",

--- a/src/M365-Assess/controls/frameworks/cis-m365-v6.json
+++ b/src/M365-Assess/controls/frameworks/cis-m365-v6.json
@@ -70,9 +70,11 @@
     "1": "Identity",
     "2": "Defender",
     "3": "Purview",
+    "4": "Microsoft Intune",
     "5": "Entra ID",
     "6": "Exchange Online",
     "7": "SharePoint & OneDrive",
-    "8": "Teams"
+    "8": "Teams",
+    "9": "Microsoft Fabric"
   }
 }

--- a/src/M365-Assess/controls/frameworks/cis-m365-v6.json
+++ b/src/M365-Assess/controls/frameworks/cis-m365-v6.json
@@ -65,6 +65,7 @@
     }
   },
   "groupBy": "section-prefix",
+  "groupLabel": "section",
   "sections": {
     "1": "Identity",
     "2": "Defender",

--- a/src/M365-Assess/controls/frameworks/cmmc.json
+++ b/src/M365-Assess/controls/frameworks/cmmc.json
@@ -38,5 +38,25 @@
       "background": "#134E4A",
       "color": "#5EEAD4"
     }
+  },
+  "groupBy": "family-letter-prefix",
+  "groupLabel": "family",
+  "groups": {
+    "AC": "Access Control",
+    "AT": "Awareness & Training",
+    "AU": "Audit & Accountability",
+    "CA": "Security Assessment",
+    "CM": "Configuration Management",
+    "CP": "Contingency Planning",
+    "IA": "Identification & Authentication",
+    "IR": "Incident Response",
+    "MA": "Maintenance",
+    "MP": "Media Protection",
+    "PE": "Physical Protection",
+    "PS": "Personnel Security",
+    "RA": "Risk Assessment",
+    "SC": "System & Communications Protection",
+    "SI": "System & Information Integrity",
+    "SR": "Supply Chain Risk Management"
   }
 }

--- a/src/M365-Assess/controls/frameworks/fedramp.json
+++ b/src/M365-Assess/controls/frameworks/fedramp.json
@@ -47,5 +47,29 @@
       "background": "#1E3A5F",
       "color": "#93C5FD"
     }
+  },
+  "groupBy": "family-letter-prefix",
+  "groupLabel": "family",
+  "groups": {
+    "AC": "Access Control",
+    "AT": "Awareness & Training",
+    "AU": "Audit & Accountability",
+    "CA": "Assessment, Authorization & Monitoring",
+    "CM": "Configuration Management",
+    "CP": "Contingency Planning",
+    "IA": "Identification & Authentication",
+    "IR": "Incident Response",
+    "MA": "Maintenance",
+    "MP": "Media Protection",
+    "PE": "Physical & Environmental Protection",
+    "PL": "Planning",
+    "PM": "Program Management",
+    "PS": "Personnel Security",
+    "PT": "PII Processing & Transparency",
+    "RA": "Risk Assessment",
+    "SA": "System & Services Acquisition",
+    "SC": "System & Communications Protection",
+    "SI": "System & Information Integrity",
+    "SR": "Supply Chain Risk Management"
   }
 }

--- a/src/M365-Assess/controls/frameworks/iso-27001.json
+++ b/src/M365-Assess/controls/frameworks/iso-27001.json
@@ -39,5 +39,16 @@
       "background": "#064E3B",
       "color": "#6EE7B7"
     }
+  },
+  "groupBy": "section-prefix",
+  "groupLabel": "clause",
+  "groups": {
+    "4": "Context of the Organization",
+    "5": "Organizational Controls (A.5)",
+    "6": "People Controls (A.6)",
+    "7": "Physical Controls (A.7)",
+    "8": "Technological Controls (A.8)",
+    "9": "Performance Evaluation",
+    "10": "Improvement"
   }
 }

--- a/src/M365-Assess/controls/frameworks/nist-800-53-r5.json
+++ b/src/M365-Assess/controls/frameworks/nist-800-53-r5.json
@@ -67,5 +67,29 @@
       "background": "#1E3A5F",
       "color": "#93C5FD"
     }
+  },
+  "groupBy": "family-letter-prefix",
+  "groupLabel": "family",
+  "groups": {
+    "AC": "Access Control",
+    "AT": "Awareness & Training",
+    "AU": "Audit & Accountability",
+    "CA": "Assessment, Authorization & Monitoring",
+    "CM": "Configuration Management",
+    "CP": "Contingency Planning",
+    "IA": "Identification & Authentication",
+    "IR": "Incident Response",
+    "MA": "Maintenance",
+    "MP": "Media Protection",
+    "PE": "Physical & Environmental Protection",
+    "PL": "Planning",
+    "PM": "Program Management",
+    "PS": "Personnel Security",
+    "PT": "PII Processing & Transparency",
+    "RA": "Risk Assessment",
+    "SA": "System & Services Acquisition",
+    "SC": "System & Communications Protection",
+    "SI": "System & Information Integrity",
+    "SR": "Supply Chain Risk Management"
   }
 }

--- a/src/M365-Assess/controls/frameworks/nist-csf.json
+++ b/src/M365-Assess/controls/frameworks/nist-csf.json
@@ -47,5 +47,15 @@
       "background": "#78350F",
       "color": "#FCD34D"
     }
+  },
+  "groupBy": "dot-prefix",
+  "groupLabel": "function",
+  "groups": {
+    "GV": "Govern",
+    "ID": "Identify",
+    "PR": "Protect",
+    "DE": "Detect",
+    "RS": "Respond",
+    "RC": "Recover"
   }
 }

--- a/src/M365-Assess/controls/frameworks/pci-dss-v4.json
+++ b/src/M365-Assess/controls/frameworks/pci-dss-v4.json
@@ -59,5 +59,21 @@
       "background": "#7F1D1D",
       "color": "#FCA5A5"
     }
+  },
+  "groupBy": "section-prefix",
+  "groupLabel": "requirement",
+  "groups": {
+    "1": "Network Security Controls",
+    "2": "Secure Configurations",
+    "3": "Protect Stored Account Data",
+    "4": "Protect Cardholder Data in Transit",
+    "5": "Protect Against Malicious Software",
+    "6": "Develop & Maintain Secure Systems",
+    "7": "Restrict Access by Need-to-Know",
+    "8": "Identify Users & Authenticate Access",
+    "9": "Restrict Physical Access",
+    "10": "Log & Monitor All Access",
+    "11": "Test Security Regularly",
+    "12": "Information Security Policy"
   }
 }


### PR DESCRIPTION
## Summary

Closes #751. Live-test on the first commit caught two issues that this PR now addresses:

1. The hardcoded CIS section names in JSX were wrong — `cis-m365-v6.json` already has a `sections` map (Identity / Defender / Purview / Entra ID / Exchange Online / SharePoint & OneDrive / Teams) that we should be reading instead of inventing.
2. User wants every framework on its own native taxonomy, not just CIS + CMMC.

So this PR refactors the family taxonomy out of JSX and into each framework's own JSON file — single source of truth — and covers 8 frameworks instead of 2.

## Architecture (data-driven)

Each framework's JSON declares:

```json
{
  "groupBy": "section-prefix" | "family-letter-prefix" | "dot-prefix" | "iso-clause-prefix",
  "groupLabel": "section" | "family" | "function" | "clause" | "requirement" | "control",
  "groups": { "<code>": "<display name>", ... }
}
```

Build-ReportData.ps1 surfaces this metadata via `REPORT_DATA.frameworks`. The React `FrameworkQuilt` switches on `groupBy` to extract a group code from each finding's `controlId`, looks up the display name, renders rows. Hardcoded `FRAMEWORK_FAMILIES` const is gone — replaced by a `GROUP_EXTRACTORS` strategy table.

Backward-compat aliasing: framework JSONs use various legacy field names for the same concept (`sections`, `controls`, `families`, `requirements`, `clauses`, `functions`) — Build-ReportData aliases them all to `groups` so the React side is uniform.

## Frameworks now using their native taxonomy (8)

| Framework | Strategy | Groups |
|---|---|---|
| CIS M365 v6 | section-prefix | 7 sections (existing JSON, plumbed through) |
| CMMC 2.0 | family-letter-prefix | 16 NIST 800-171 families |
| CIS Controls v8 | section-prefix | 18 controls (existing `controls` map, added groupBy) |
| NIST 800-53 r5 | family-letter-prefix | 20 control families |
| NIST CSF 2.0 | dot-prefix | 6 functions (GV / ID / PR / DE / RS / RC) |
| ISO 27001:2022 | section-prefix | 7 clauses (Organizational / People / Physical / Technological + management) |
| PCI DSS v4 | section-prefix | 12 requirements |
| FedRAMP r5 | family-letter-prefix | 20 control families (same as NIST 800-53) |

## Frameworks NOT yet covered (fall back to "Coverage by domain")

HIPAA, SOC2 TSC, Essential Eight, MITRE ATT&CK, CISA SCUBA, STIG. These have more complex or less-standardized taxonomies. Follow-up issue can address them once the architecture proves out in production.

## Counting semantics (unchanged from prior commit)

Each finding is counted ONCE per group it touches:
- A CMMC finding mapped to `AC.L2-3.1.1; IA.L2-3.5.1; MA.L2-3.7.5` increments all three groups
- Multiple controlIds within the same group still count as one entry (Set deduplication)
- Unmapped controlIds → `Other` row (NOT hidden)
- Respects FilterBar level chip state (L1/L2/L3/E3/E5only)

## Files

- `src/M365-Assess/Common/Build-ReportData.ps1` — surface `groupBy` / `groupLabel` / `groups` (with alias logic for legacy field names) in the framework list
- `src/M365-Assess/assets/report-app.jsx` — `GROUP_EXTRACTORS` strategy table, `compareGroupKeys`, data-driven `fwFamilyBreakdown` memo, render switch
- `src/M365-Assess/assets/report-app.js` — regenerated via `npm run build`
- `src/M365-Assess/controls/frameworks/{cis-m365-v6,cmmc,cis-controls-v8,nist-800-53-r5,nist-csf,iso-27001,pci-dss-v4,fedramp}.json` — added taxonomy metadata

## Test plan

Local checks (passed):
- [x] `npm run build` clean, `node --check` clean
- [x] All 14 framework JSONs parse cleanly
- [x] Pester `tests/Common` + `tests/Behavior` 700/700 pass

**Live tenant verification** (per `.claude/rules/releases.md`):

```powershell
Invoke-M365Assessment -ProfileName <your-profile> -AutoBaseline
```

For each of the 8 covered frameworks, click into the framework card:
- [x] CIS M365 v6 → "Coverage by section" → rows like `1 · Identity`, `2 · Defender`, `3 · Purview`, `5 · Entra ID`, `6 · Exchange Online`, `7 · SharePoint & OneDrive`, `8 · Teams`
- [x] CMMC → "Coverage by family" → rows like `AC · Access Control`, `AU · Audit & Accountability`, `IA · Identification & Authentication`, etc.
- [x] CIS Controls v8 → "Coverage by control" → rows like `5 · Account Management`, `6 · Access Control Management`, etc.
- [x] NIST 800-53 r5 → "Coverage by family" → rows like `AC · Access Control`, `AU · Audit & Accountability`, etc.
- [x] NIST CSF 2.0 → "Coverage by function" → rows like `ID · Identify`, `PR · Protect`, `DE · Detect`, `RS · Respond`, `RC · Recover`, `GV · Govern`
- [x] ISO 27001:2022 → "Coverage by clause" → rows like `5 · Organizational Controls (A.5)`, `8 · Technological Controls (A.8)`, etc.
- [x] PCI DSS v4 → "Coverage by requirement" → rows like `1 · Network Security Controls`, `8 · Identify Users & Authenticate Access`, etc.
- [x] FedRAMP → "Coverage by family" → same family codes as NIST 800-53

For each of the 6 uncovered frameworks (HIPAA, SOC2, Essential Eight, MITRE ATT&CK, SCUBA, STIG):
- [x] Falls back to "Coverage by domain" with M365-Assess domain names — unchanged from current main

Cross-cutting:
- [x] Toggle L1/L2 level chips on the CIS panel — row counts update
- [x] Unmapped codes land in `Other` row (sorted appropriately)
- [x] All 4 themes render cleanly

## Out of scope

- The 6 frameworks not yet covered — separate follow-up issue
- Level chip count/inheritance bug — filed as #844 (independent concern; user asked for full audit, not patch)
- Version bump — waits for PR 2 + PR 3 to ship as part of v2.7.0 closeout sprint

🤖 Generated with [Claude Code](https://claude.com/claude-code)