### PR TITLE
feat(report): native taxonomy for HIPAA, SOC2, Essential Eight, SCUBA (#845 partial)

### DIFF
--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -2132,10 +2132,10 @@ const matchProfileToken = (profilesArr, token) => {
   return profilesArr.some(p => p.includes(token));
 };
 
-// Issue #751: extraction strategies that derive a "group key" (section number,
-// family code, function letter, etc.) from a framework's native controlId.
-// Each framework's JSON file declares its `groupBy` strategy + `groups` map
-// (key → display name); the strategies are enumerated here.
+// Issue #751 / #845: extraction strategies that derive a "group key" (section
+// number, family code, function letter, service prefix, etc.) from a framework's
+// native controlId. Each framework's JSON file declares its `groupBy` strategy
+// + `groups` map (key → display name); the strategies are enumerated here.
 const GROUP_EXTRACTORS = {
   // CIS M365 v6, CIS Controls v8, PCI DSS v4: leading numeric section (e.g. '5.2.2.5' → '5')
   'section-prefix': cid => {
@@ -2155,6 +2155,31 @@ const GROUP_EXTRACTORS = {
   // ISO 27001:2022: 'A.5.1.1' → 'A.5'; ISO 27001:2013 also uses A.X.Y form
   'iso-clause-prefix': cid => {
     const m = String(cid).match(/^(A\.\d+)/);
+    return m ? m[1] : null;
+  },
+  // HIPAA Security Rule: '164.308(a)(1)(ii)(A)' → '308'
+  'hipaa-section': cid => {
+    const m = String(cid).match(/^164\.(\d+)/);
+    return m ? m[1] : null;
+  },
+  // SOC 2 Trust Services Criteria: 'CC1.1' → 'CC', 'PI1.2-POF1' → 'PI', 'A1.2' → 'A'
+  // PI must be tested before P (longest-match). C is single-letter and ambiguous
+  // with CC prefix; check CC first then C.
+  'soc2-tsc-prefix': cid => {
+    const s = String(cid);
+    if (s.startsWith('CC')) return 'CC';
+    if (s.startsWith('PI')) return 'PI';
+    const m = s.match(/^([ACP])\d/);
+    return m ? m[1] : null;
+  },
+  // Essential Eight: 'ML1-P3' → '3' (group by practice number, not maturity level)
+  'essential-eight-practice': cid => {
+    const m = String(cid).match(/-P(\d+)/);
+    return m ? m[1] : null;
+  },
+  // CISA SCUBA: 'MS.AAD.1.1v1' → 'MS.AAD'
+  'scuba-service': cid => {
+    const m = String(cid).match(/^(MS\.[A-Z]+)/);
     return m ? m[1] : null;
   }
 };

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -1351,10 +1351,10 @@ const matchProfileToken = (profilesArr, token) => {
   return profilesArr.some(p => p.includes(token));
 };
 
-// Issue #751: extraction strategies that derive a "group key" (section number,
-// family code, function letter, etc.) from a framework's native controlId.
-// Each framework's JSON file declares its `groupBy` strategy + `groups` map
-// (key → display name); the strategies are enumerated here.
+// Issue #751 / #845: extraction strategies that derive a "group key" (section
+// number, family code, function letter, service prefix, etc.) from a framework's
+// native controlId. Each framework's JSON file declares its `groupBy` strategy
+// + `groups` map (key → display name); the strategies are enumerated here.
 const GROUP_EXTRACTORS = {
   // CIS M365 v6, CIS Controls v8, PCI DSS v4: leading numeric section (e.g. '5.2.2.5' → '5')
   'section-prefix': (cid) => {
@@ -1374,6 +1374,31 @@ const GROUP_EXTRACTORS = {
   // ISO 27001:2022: 'A.5.1.1' → 'A.5'; ISO 27001:2013 also uses A.X.Y form
   'iso-clause-prefix': (cid) => {
     const m = String(cid).match(/^(A\.\d+)/);
+    return m ? m[1] : null;
+  },
+  // HIPAA Security Rule: '164.308(a)(1)(ii)(A)' → '308'
+  'hipaa-section': (cid) => {
+    const m = String(cid).match(/^164\.(\d+)/);
+    return m ? m[1] : null;
+  },
+  // SOC 2 Trust Services Criteria: 'CC1.1' → 'CC', 'PI1.2-POF1' → 'PI', 'A1.2' → 'A'
+  // PI must be tested before P (longest-match). C is single-letter and ambiguous
+  // with CC prefix; check CC first then C.
+  'soc2-tsc-prefix': (cid) => {
+    const s = String(cid);
+    if (s.startsWith('CC')) return 'CC';
+    if (s.startsWith('PI')) return 'PI';
+    const m = s.match(/^([ACP])\d/);
+    return m ? m[1] : null;
+  },
+  // Essential Eight: 'ML1-P3' → '3' (group by practice number, not maturity level)
+  'essential-eight-practice': (cid) => {
+    const m = String(cid).match(/-P(\d+)/);
+    return m ? m[1] : null;
+  },
+  // CISA SCUBA: 'MS.AAD.1.1v1' → 'MS.AAD'
+  'scuba-service': (cid) => {
+    const m = String(cid).match(/^(MS\.[A-Z]+)/);
     return m ? m[1] : null;
   },
 };

--- a/src/M365-Assess/controls/frameworks/cisa-scuba.json
+++ b/src/M365-Assess/controls/frameworks/cisa-scuba.json
@@ -42,5 +42,15 @@
       "color": "#FDBA74"
     }
   },
-  "controlIdFormat": "MS.{product}.{number}v{version}"
+  "controlIdFormat": "MS.{product}.{number}v{version}",
+  "groupBy": "scuba-service",
+  "groupLabel": "service",
+  "groups": {
+    "MS.AAD":           "Azure AD / Entra ID",
+    "MS.EXO":           "Exchange Online",
+    "MS.DEFENDER":      "Microsoft Defender",
+    "MS.POWERPLATFORM": "Power Platform",
+    "MS.SHAREPOINT":    "SharePoint",
+    "MS.TEAMS":         "Teams"
+  }
 }

--- a/src/M365-Assess/controls/frameworks/essential-eight.json
+++ b/src/M365-Assess/controls/frameworks/essential-eight.json
@@ -85,5 +85,17 @@
       "background": "#713F12",
       "color": "#FDE047"
     }
+  },
+  "groupBy": "essential-eight-practice",
+  "groupLabel": "strategy",
+  "groups": {
+    "1": "Application Control",
+    "2": "Patch Applications",
+    "3": "Configure MS Office Macros",
+    "4": "User Application Hardening",
+    "5": "Restrict Administrative Privileges",
+    "6": "Patch Operating Systems",
+    "7": "Multi-Factor Authentication",
+    "8": "Regular Backups"
   }
 }

--- a/src/M365-Assess/controls/frameworks/hipaa.json
+++ b/src/M365-Assess/controls/frameworks/hipaa.json
@@ -43,5 +43,15 @@
       "background": "#831843",
       "color": "#F9A8D4"
     }
+  },
+  "groupBy": "hipaa-section",
+  "groupLabel": "safeguard",
+  "groups": {
+    "306": "General Rules",
+    "308": "Administrative Safeguards",
+    "310": "Physical Safeguards",
+    "312": "Technical Safeguards",
+    "314": "Organizational Requirements",
+    "316": "Policies, Procedures & Documentation"
   }
 }

--- a/src/M365-Assess/controls/frameworks/soc2-tsc.json
+++ b/src/M365-Assess/controls/frameworks/soc2-tsc.json
@@ -103,5 +103,14 @@
       "background": "#1E3A5F",
       "color": "#60A5FA"
     }
+  },
+  "groupBy": "soc2-tsc-prefix",
+  "groupLabel": "criteria",
+  "groups": {
+    "CC": "Common Criteria (Security)",
+    "A":  "Availability",
+    "C":  "Confidentiality",
+    "P":  "Privacy",
+    "PI": "Processing Integrity"
   }
 }


### PR DESCRIPTION
## Summary

Extends the data-driven framework taxonomy from #751 / PR #843 to cover 4 more of the 6 remaining frameworks. After this merges, **12 of 14 supported frameworks render with their own native taxonomy** in the framework panel.

Only MITRE ATT&CK and STIG still fall back to "Coverage by domain" — both require external lookup tables (technique → tactic, rule → STIG-category) that are out of scope per #845's analysis.

Partial close on #845 — leaves the MITRE/STIG question as the remaining decision.

## Frameworks added

| Framework | Strategy | Groups |
|---|---|---|
| HIPAA | `hipaa-section` | 6 safeguards (164.306 / 308 / 310 / 312 / 314 / 316) |
| SOC 2 TSC | `soc2-tsc-prefix` | 5 criteria (CC, A, C, P, PI) |
| Essential Eight | `essential-eight-practice` | 8 strategies (1 Application Control … 8 Regular Backups) |
| CISA SCUBA | `scuba-service` | 6 services (MS.AAD / MS.EXO / MS.DEFENDER / MS.POWERPLATFORM / MS.SHAREPOINT / MS.TEAMS) |

## 4 new `GROUP_EXTRACTORS` strategies

```js
'hipaa-section':            '164.308(a)(1)(ii)(A)' -> '308'
'soc2-tsc-prefix':          'CC1.1' -> 'CC', 'PI1.2-POF1' -> 'PI'   (longest-match-wins for PI/CC vs P/C)
'essential-eight-practice': 'ML2-P3' -> '3'                          (group by practice, not maturity level)
'scuba-service':            'MS.AAD.1.1v1' -> 'MS.AAD'
```

Essential Eight rationale: maturity levels (ML1/ML2/ML3) are inheritance levels, not categories. Practice number is the actual strategy axis — Practice 3 (Configure MS Office Macros) is the same strategy whether at ML1 or ML3.

## Files

- `src/M365-Assess/assets/report-app.jsx` — extended `GROUP_EXTRACTORS` with the 4 new strategies
- `src/M365-Assess/assets/report-app.js` — regenerated via `npm run build`
- `src/M365-Assess/controls/frameworks/{hipaa,soc2-tsc,essential-eight,cisa-scuba}.json` — added taxonomy metadata

## Test plan

Local checks (passed):
- [x] `npm run build` clean, `node --check` clean
- [x] All 4 framework JSONs validated by `Import-FrameworkDefinitions` — `groupBy` / `groupLabel` / `groups` all surface at top level
- [x] Pester `Get-ReportTemplate.Tests.ps1` 31/31 pass

**Live tenant verification** (per `.claude/rules/releases.md`):

```powershell
Invoke-M365Assessment -ProfileName <your-profile> -AutoBaseline
```

For each of the 4 new frameworks, click into the framework card:
- [ ] HIPAA → "Coverage by safeguard" → rows like `308 · Administrative Safeguards`, `312 · Technical Safeguards`, etc.
- [ ] SOC 2 → "Coverage by criteria" → rows like `CC · Common Criteria (Security)`, `PI · Processing Integrity`, etc.
- [ ] Essential Eight → "Coverage by strategy" → rows like `1 · Application Control`, `7 · Multi-Factor Authentication`, etc.
- [ ] CISA SCUBA → "Coverage by service" → rows like `MS.AAD · Azure AD / Entra ID`, `MS.EXO · Exchange Online`, etc.

For the 2 still-uncovered frameworks (MITRE ATT&CK, STIG):
- [ ] Falls back to "Coverage by domain" — unchanged from current main

For the 8 frameworks already covered by #843:
- [ ] Unchanged behavior — still show their native taxonomy

## Out of scope

- MITRE ATT&CK technique → tactic mapping (#845 documented this needs a 700+ entry lookup table; defer or doc as fallback)
- STIG rule → category mapping (same — opaque V-NNNNNN IDs need external lookup)
- Version bump (waits for PR 2 + PR 3 of the v2.7.0 closeout sprint per the user's hold directive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)