### PR TITLE
feat(report): edit-mode generic HideableBlock for any card or section (closes #712)

### DIFF
--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -20,6 +20,7 @@ const LS = key => `${key}-${TENANT.TenantId || 'anon'}`;
 const RO = window.REPORT_OVERRIDES || null;
 function finalizeReport({
   hiddenFindings,
+  hiddenElements,
   roadmapOverrides
 }) {
   const overridesEl = document.getElementById('report-overrides');
@@ -29,6 +30,7 @@ function finalizeReport({
   }
   const overrides = {
     hiddenFindings: [...(hiddenFindings || [])],
+    hiddenElements: [...(hiddenElements || [])],
     roadmapOverrides: roadmapOverrides || {}
   };
   const clone = document.documentElement.cloneNode(true);
@@ -43,6 +45,45 @@ function finalizeReport({
   a.download = (TENANT.OrgDisplayName || 'Assessment').replace(/[^a-z0-9 ]/gi, '').trim().replace(/\s+/g, '-') + '-M365-Report.html';
   a.click();
   URL.revokeObjectURL(url);
+}
+
+// Issue #712: edit-mode generic hide capability for any card or section.
+// Context lets HideableBlock read editMode + hiddenElements without prop
+// drilling through every parent component (App > Posture > KPI cards, etc.).
+const EditModeContext = React.createContext({
+  editMode: false,
+  hiddenElements: new Set(),
+  toggleHideElement: () => {}
+});
+
+// HideableBlock wraps any element to make it hideable in edit mode.
+//  - In production view (editMode=false) and the key is hidden → renders nothing
+//  - In production view and not hidden → renders children with a transparent wrapper (display:contents)
+//  - In edit mode → renders a positioning wrapper with a ✕ overlay (or ↩ Restore when hidden)
+function HideableBlock({
+  hideKey,
+  children,
+  label
+}) {
+  const {
+    editMode,
+    hiddenElements,
+    toggleHideElement
+  } = React.useContext(EditModeContext);
+  const isHidden = hiddenElements?.has(hideKey);
+  if (!editMode && isHidden) return null;
+  if (!editMode) return /*#__PURE__*/React.createElement(React.Fragment, null, children);
+  return /*#__PURE__*/React.createElement("div", {
+    className: 'hideable-block' + (isHidden ? ' hideable-block-hidden' : ''),
+    "data-hide-key": hideKey
+  }, children, /*#__PURE__*/React.createElement("button", {
+    className: 'hideable-btn' + (isHidden ? ' restore' : ''),
+    title: isHidden ? `Restore ${label || 'this section'}` : `Hide ${label || 'this section'}`,
+    onClick: e => {
+      e.stopPropagation();
+      toggleHideElement(hideKey);
+    }
+  }, isHidden ? '↩' : '✕'));
 }
 
 // Issue #715: roadmap lane counts now read from t.lane (precomputed by
@@ -995,6 +1036,9 @@ function Posture() {
     id: "posture"
   }, /*#__PURE__*/React.createElement("div", {
     className: "posture-grid"
+  }, /*#__PURE__*/React.createElement(HideableBlock, {
+    hideKey: "posture-score-card",
+    label: "Microsoft Secure Score card"
   }, /*#__PURE__*/React.createElement("div", {
     className: "score-card"
   }, /*#__PURE__*/React.createElement("div", {
@@ -1040,11 +1084,14 @@ function Posture() {
     className: "score-split-label"
   }, "Customer-earned"), /*#__PURE__*/React.createElement("div", {
     className: "score-split-value"
-  }, fmt(SCORE.CustomerScore), " pts")))), /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("div", {
+  }, fmt(SCORE.CustomerScore), " pts"))))), /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("div", {
     className: "kpi-strip",
     style: {
       marginBottom: 10
     }
+  }, /*#__PURE__*/React.createElement(HideableBlock, {
+    hideKey: "kpi-critical",
+    label: "Critical findings KPI"
   }, /*#__PURE__*/React.createElement("div", {
     className: 'kpi ' + (critical ? 'bad' : 'good')
   }, /*#__PURE__*/React.createElement("div", {
@@ -1062,7 +1109,10 @@ function Posture() {
       width: Math.min(100, critical * 15) + '%',
       background: 'var(--danger)'
     }
-  }))), /*#__PURE__*/React.createElement("div", {
+  })))), /*#__PURE__*/React.createElement(HideableBlock, {
+    hideKey: "kpi-fails",
+    label: "Fails KPI"
+  }, /*#__PURE__*/React.createElement("div", {
     className: "kpi bad"
   }, /*#__PURE__*/React.createElement("div", {
     className: "kpi-label"
@@ -1077,7 +1127,10 @@ function Posture() {
       width: pct(fail, scoreDenom(FINDINGS)) + '%',
       background: 'var(--danger)'
     }
-  }))), /*#__PURE__*/React.createElement("div", {
+  })))), /*#__PURE__*/React.createElement(HideableBlock, {
+    hideKey: "kpi-warnings",
+    label: "Warnings KPI"
+  }, /*#__PURE__*/React.createElement("div", {
     className: "kpi warn"
   }, /*#__PURE__*/React.createElement("div", {
     className: "kpi-label"
@@ -1092,7 +1145,10 @@ function Posture() {
       width: pct(warn, scoreDenom(FINDINGS)) + '%',
       background: 'var(--warn)'
     }
-  }))), /*#__PURE__*/React.createElement("div", {
+  })))), /*#__PURE__*/React.createElement(HideableBlock, {
+    hideKey: "kpi-passing",
+    label: "Passing KPI"
+  }, /*#__PURE__*/React.createElement("div", {
     className: "kpi good"
   }, /*#__PURE__*/React.createElement("div", {
     className: "kpi-label"
@@ -1107,7 +1163,7 @@ function Posture() {
       width: pct(pass, scoreDenom(FINDINGS)) + '%',
       background: 'var(--success)'
     }
-  })))), /*#__PURE__*/React.createElement(MFABreakdown, null))), /*#__PURE__*/React.createElement(ExecSummaryRow, null), critical > 0 && /*#__PURE__*/React.createElement("div", {
+  }))))), /*#__PURE__*/React.createElement(MFABreakdown, null))), /*#__PURE__*/React.createElement(ExecSummaryRow, null), critical > 0 && /*#__PURE__*/React.createElement("div", {
     className: "banner"
   }, /*#__PURE__*/React.createElement("div", {
     className: "banner-icon"
@@ -3906,6 +3962,9 @@ function Roadmap({
     }
   }, "Click any task to expand it, or use the move buttons on each card to reprioritize. Use Finalize (\u270E) to bake lane changes into the report."))), /*#__PURE__*/React.createElement("div", {
     className: "roadmap"
+  }, /*#__PURE__*/React.createElement(HideableBlock, {
+    hideKey: "roadmap-lane-now",
+    label: "Now lane"
   }, /*#__PURE__*/React.createElement("div", {
     className: "lane"
   }, /*#__PURE__*/React.createElement("div", {
@@ -3930,7 +3989,10 @@ function Roadmap({
     laneItems: now
   }), /*#__PURE__*/React.createElement("div", {
     className: "lane-eta"
-  }, "< 1 week"))), now.map(t => renderTask(t, 'now'))), /*#__PURE__*/React.createElement("div", {
+  }, "< 1 week"))), now.map(t => renderTask(t, 'now')))), /*#__PURE__*/React.createElement(HideableBlock, {
+    hideKey: "roadmap-lane-next",
+    label: "Next lane"
+  }, /*#__PURE__*/React.createElement("div", {
     className: "lane"
   }, /*#__PURE__*/React.createElement("div", {
     className: "lane-head"
@@ -3954,7 +4016,10 @@ function Roadmap({
     laneItems: soon
   }), /*#__PURE__*/React.createElement("div", {
     className: "lane-eta"
-  }, "1 \u2013 4 weeks"))), soon.map(t => renderTask(t, 'soon'))), /*#__PURE__*/React.createElement("div", {
+  }, "1 \u2013 4 weeks"))), soon.map(t => renderTask(t, 'soon')))), /*#__PURE__*/React.createElement(HideableBlock, {
+    hideKey: "roadmap-lane-later",
+    label: "Later lane"
+  }, /*#__PURE__*/React.createElement("div", {
     className: "lane"
   }, /*#__PURE__*/React.createElement("div", {
     className: "lane-head"
@@ -3978,7 +4043,7 @@ function Roadmap({
     laneItems: later
   }), /*#__PURE__*/React.createElement("div", {
     className: "lane-eta"
-  }, "1 \u2013 3 months"))), later.map(t => renderTask(t, 'later'))))));
+  }, "1 \u2013 3 months"))), later.map(t => renderTask(t, 'later')))))));
 }
 
 // ======================== Critical Exposure section ========================
@@ -4182,7 +4247,10 @@ function Appendix() {
     "aria-hidden": "true"
   }, open ? '▾' : '▸'), /*#__PURE__*/React.createElement("div", {
     className: "hr"
-  })), open && /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement("div", {
+  })), open && /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement(HideableBlock, {
+    hideKey: "appendix-tenant",
+    label: "Tenant info"
+  }, /*#__PURE__*/React.createElement("div", {
     className: "card",
     style: {
       marginBottom: 14
@@ -4220,12 +4288,15 @@ function Appendix() {
     style: {
       color: 'var(--muted)'
     }
-  }, "created"), " ", /*#__PURE__*/React.createElement("b", null, TENANT.CreatedDateTime.slice(0, 10))))), /*#__PURE__*/React.createElement("div", {
+  }, "created"), " ", /*#__PURE__*/React.createElement("b", null, TENANT.CreatedDateTime.slice(0, 10)))))), /*#__PURE__*/React.createElement("div", {
     style: {
       display: 'grid',
       gridTemplateColumns: '1fr 1fr',
       gap: 14
     }
+  }, /*#__PURE__*/React.createElement(HideableBlock, {
+    hideKey: "appendix-licenses",
+    label: "Licenses card"
   }, /*#__PURE__*/React.createElement("div", {
     className: "card"
   }, /*#__PURE__*/React.createElement("div", {
@@ -4269,7 +4340,10 @@ function Appendix() {
       ...monoRight,
       color: 'var(--muted)'
     }
-  }, l.Total)))))), /*#__PURE__*/React.createElement("div", {
+  }, l.Total))))))), /*#__PURE__*/React.createElement(HideableBlock, {
+    hideKey: "appendix-mfa-coverage",
+    label: "MFA coverage card"
+  }, /*#__PURE__*/React.createElement("div", {
     className: "card"
   }, /*#__PURE__*/React.createElement("div", {
     style: labelStyle
@@ -4356,7 +4430,10 @@ function Appendix() {
     }
   }, fmt(MFA_STATS.adminsWithoutMfa)), /*#__PURE__*/React.createElement("td", {
     style: cellStyle
-  }))))), /*#__PURE__*/React.createElement("div", {
+  })))))), /*#__PURE__*/React.createElement(HideableBlock, {
+    hideKey: "appendix-ca-policies",
+    label: "Conditional Access policies card"
+  }, /*#__PURE__*/React.createElement("div", {
     className: "card"
   }, /*#__PURE__*/React.createElement("div", {
     style: labelStyle
@@ -4385,7 +4462,10 @@ function Appendix() {
       textAlign: 'right',
       color: 'var(--muted)'
     }
-  }, r.State)))))), /*#__PURE__*/React.createElement("div", {
+  }, r.State))))))), /*#__PURE__*/React.createElement(HideableBlock, {
+    hideKey: "appendix-privileged-roles",
+    label: "Privileged roles card"
+  }, /*#__PURE__*/React.createElement("div", {
     className: "card"
   }, /*#__PURE__*/React.createElement("div", {
     style: labelStyle
@@ -4406,7 +4486,10 @@ function Appendix() {
       ...monoRight,
       color: 'var(--muted)'
     }
-  }, count)))))), dnsTotal > 0 && /*#__PURE__*/React.createElement("div", {
+  }, count))))))), dnsTotal > 0 && /*#__PURE__*/React.createElement(HideableBlock, {
+    hideKey: "appendix-email-auth",
+    label: "Email authentication card"
+  }, /*#__PURE__*/React.createElement("div", {
     className: "card"
   }, /*#__PURE__*/React.createElement("div", {
     style: labelStyle
@@ -4446,7 +4529,10 @@ function Appendix() {
       ...monoRight,
       color: dmarcEnf === dnsTotal ? 'var(--success-text)' : dmarcEnf > 0 ? 'var(--warn-text)' : 'var(--danger-text)'
     }
-  }, dmarcEnf, "/", dnsTotal))))), ad && /*#__PURE__*/React.createElement("div", {
+  }, dmarcEnf, "/", dnsTotal)))))), ad && /*#__PURE__*/React.createElement(HideableBlock, {
+    hideKey: "appendix-hybrid-sync",
+    label: "Hybrid sync card"
+  }, /*#__PURE__*/React.createElement("div", {
     className: "card"
   }, /*#__PURE__*/React.createElement("div", {
     style: labelStyle
@@ -4486,7 +4572,7 @@ function Appendix() {
       textAlign: 'right',
       fontFamily: 'var(--font-mono)'
     }
-  }, String(ad.lastSync).slice(0, 19).replace('T', ' '))))))), /*#__PURE__*/React.createElement(PermissionsPanel, null)));
+  }, String(ad.lastSync).slice(0, 19).replace('T', ' ')))))))), /*#__PURE__*/React.createElement(PermissionsPanel, null)));
 }
 function StatusDot({
   ok,
@@ -4661,21 +4747,34 @@ function App() {
   }, [matchIdx, searchMatches]);
   const [editMode, setEditMode] = useState(false);
   const [hiddenFindings, setHiddenFindings] = useState(() => new Set(RO?.hiddenFindings || []));
+  const [hiddenElements, setHiddenElements] = useState(() => new Set(RO?.hiddenElements || []));
   const [roadmapOverrides, setRoadmapOverrides] = useState(() => RO?.roadmapOverrides || {});
   const toggleHideFinding = id => setHiddenFindings(prev => {
     const s = new Set(prev);
     s.has(id) ? s.delete(id) : s.add(id);
     return s;
   });
+  const toggleHideElement = key => setHiddenElements(prev => {
+    const s = new Set(prev);
+    s.has(key) ? s.delete(key) : s.add(key);
+    return s;
+  });
   const restoreAllFindings = () => setHiddenFindings(new Set());
   const handleFinalize = () => finalizeReport({
     hiddenFindings: [...hiddenFindings],
+    hiddenElements: [...hiddenElements],
     roadmapOverrides
   });
   const handleResetAll = () => {
     setHiddenFindings(new Set());
+    setHiddenElements(new Set());
     setRoadmapOverrides({});
   };
+  const editModeCtx = useMemo(() => ({
+    editMode,
+    hiddenElements,
+    toggleHideElement
+  }), [editMode, hiddenElements]);
   useEffect(() => {
     document.documentElement.dataset.theme = theme;
     document.documentElement.dataset.mode = mode;
@@ -4820,7 +4919,9 @@ function App() {
       block: 'start'
     });
   }, []);
-  return /*#__PURE__*/React.createElement("div", {
+  return /*#__PURE__*/React.createElement(EditModeContext.Provider, {
+    value: editModeCtx
+  }, /*#__PURE__*/React.createElement("div", {
     className: "app"
   }, /*#__PURE__*/React.createElement(Sidebar, {
     active: active,
@@ -4854,7 +4955,7 @@ function App() {
     onEditToggle: () => setEditMode(e => !e),
     onFinalize: handleFinalize,
     onReset: handleResetAll,
-    hiddenCount: hiddenFindings.size
+    hiddenCount: hiddenFindings.size + hiddenElements.size
   }), /*#__PURE__*/React.createElement(Overview, null), /*#__PURE__*/React.createElement(Posture, null), /*#__PURE__*/React.createElement(ScoringViews, null), /*#__PURE__*/React.createElement(TrendChart, null), /*#__PURE__*/React.createElement(FrameworkQuilt, {
     onSelect: onFrameworkSelect,
     selected: filters.framework[0],
@@ -4935,7 +5036,7 @@ function App() {
     setMode: setMode,
     density: density,
     setDensity: setDensity
-  }));
+  })));
 }
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(/*#__PURE__*/React.createElement(App, null));

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -14,7 +14,7 @@ const DOMAIN_STATS = D.domainStats;
 const LS = key => `${key}-${TENANT.TenantId || 'anon'}`;
 const RO = window.REPORT_OVERRIDES || null;
 
-function finalizeReport({ hiddenFindings, roadmapOverrides }) {
+function finalizeReport({ hiddenFindings, hiddenElements, roadmapOverrides }) {
   const overridesEl = document.getElementById('report-overrides');
   if (!overridesEl) {
     alert('This report is missing the overrides injection point. Regenerate it with the latest template.');
@@ -22,6 +22,7 @@ function finalizeReport({ hiddenFindings, roadmapOverrides }) {
   }
   const overrides = {
     hiddenFindings:   [...(hiddenFindings || [])],
+    hiddenElements:   [...(hiddenElements || [])],
     roadmapOverrides: roadmapOverrides || {},
   };
   const clone = document.documentElement.cloneNode(true);
@@ -34,6 +35,33 @@ function finalizeReport({ hiddenFindings, roadmapOverrides }) {
   a.download = (TENANT.OrgDisplayName || 'Assessment').replace(/[^a-z0-9 ]/gi, '').trim().replace(/\s+/g, '-') + '-M365-Report.html';
   a.click();
   URL.revokeObjectURL(url);
+}
+
+// Issue #712: edit-mode generic hide capability for any card or section.
+// Context lets HideableBlock read editMode + hiddenElements without prop
+// drilling through every parent component (App > Posture > KPI cards, etc.).
+const EditModeContext = React.createContext({ editMode: false, hiddenElements: new Set(), toggleHideElement: () => {} });
+
+// HideableBlock wraps any element to make it hideable in edit mode.
+//  - In production view (editMode=false) and the key is hidden → renders nothing
+//  - In production view and not hidden → renders children with a transparent wrapper (display:contents)
+//  - In edit mode → renders a positioning wrapper with a ✕ overlay (or ↩ Restore when hidden)
+function HideableBlock({ hideKey, children, label }) {
+  const { editMode, hiddenElements, toggleHideElement } = React.useContext(EditModeContext);
+  const isHidden = hiddenElements?.has(hideKey);
+  if (!editMode && isHidden) return null;
+  if (!editMode) return <>{children}</>;
+  return (
+    <div className={'hideable-block' + (isHidden ? ' hideable-block-hidden' : '')} data-hide-key={hideKey}>
+      {children}
+      <button
+        className={'hideable-btn' + (isHidden ? ' restore' : '')}
+        title={isHidden ? `Restore ${label || 'this section'}` : `Hide ${label || 'this section'}`}
+        onClick={e => { e.stopPropagation(); toggleHideElement(hideKey); }}>
+        {isHidden ? '↩' : '✕'}
+      </button>
+    </div>
+  );
 }
 
 // Issue #715: roadmap lane counts now read from t.lane (precomputed by
@@ -607,6 +635,7 @@ function Posture() {
   return (
     <section className="block" id="posture">
       <div className="posture-grid">
+        <HideableBlock hideKey="posture-score-card" label="Microsoft Secure Score card">
         <div className="score-card">
           <div className="score-eyebrow">Microsoft Secure Score</div>
           <div className="score-headline">
@@ -643,33 +672,42 @@ function Posture() {
             </div>
           )}
         </div>
+        </HideableBlock>
 
         <div>
           <div className="kpi-strip" style={{marginBottom:10}}>
+            <HideableBlock hideKey="kpi-critical" label="Critical findings KPI">
             <div className={'kpi ' + (critical?'bad':'good')}>
               <div className="kpi-label">Critical findings</div>
               <div className="kpi-value">{critical}<span className="kpi-suffix">open</span></div>
               <div className="kpi-hint">Admin, PIM & break-glass exposure</div>
               <div className="tiny-bar"><span style={{width: Math.min(100, critical*15)+'%', background:'var(--danger)'}}/></div>
             </div>
+            </HideableBlock>
+            <HideableBlock hideKey="kpi-fails" label="Fails KPI">
             <div className="kpi bad">
               <div className="kpi-label">Fails</div>
               <div className="kpi-value">{fail}</div>
               <div className="kpi-hint">of {FINDINGS.length} checks</div>
               <div className="tiny-bar"><span style={{width: pct(fail, scoreDenom(FINDINGS))+'%', background:'var(--danger)'}}/></div>
             </div>
+            </HideableBlock>
+            <HideableBlock hideKey="kpi-warnings" label="Warnings KPI">
             <div className="kpi warn">
               <div className="kpi-label">Warnings</div>
               <div className="kpi-value">{warn}</div>
               <div className="kpi-hint">Review & harden</div>
               <div className="tiny-bar"><span style={{width: pct(warn, scoreDenom(FINDINGS))+'%', background:'var(--warn)'}}/></div>
             </div>
+            </HideableBlock>
+            <HideableBlock hideKey="kpi-passing" label="Passing KPI">
             <div className="kpi good">
               <div className="kpi-label">Passing</div>
               <div className="kpi-value">{pass}</div>
               <div className="kpi-hint">Controls validated</div>
               <div className="tiny-bar"><span style={{width: pct(pass, scoreDenom(FINDINGS))+'%', background:'var(--success)'}}/></div>
             </div>
+            </HideableBlock>
           </div>
           <MFABreakdown />
         </div>
@@ -2585,6 +2623,7 @@ function Roadmap({ onViewFinding, editMode, hiddenFindings, roadmapOverrides, on
         </div>
       </div>
       <div className="roadmap">
+        <HideableBlock hideKey="roadmap-lane-now" label="Now lane">
         <div className="lane">
           <div className="lane-head">
             <div className="lane-title" id="roadmap-now"><span className="lane-dot crit"/>Now <span style={{color:'var(--muted)', fontWeight:400}}>· {now.length}</span></div>
@@ -2595,6 +2634,8 @@ function Roadmap({ onViewFinding, editMode, hiddenFindings, roadmapOverrides, on
           </div>
           {now.map(t => renderTask(t, 'now'))}
         </div>
+        </HideableBlock>
+        <HideableBlock hideKey="roadmap-lane-next" label="Next lane">
         <div className="lane">
           <div className="lane-head">
             <div className="lane-title" id="roadmap-next"><span className="lane-dot soon"/>Next <span style={{color:'var(--muted)', fontWeight:400}}>· {soon.length}</span></div>
@@ -2605,6 +2646,8 @@ function Roadmap({ onViewFinding, editMode, hiddenFindings, roadmapOverrides, on
           </div>
           {soon.map(t => renderTask(t, 'soon'))}
         </div>
+        </HideableBlock>
+        <HideableBlock hideKey="roadmap-lane-later" label="Later lane">
         <div className="lane">
           <div className="lane-head">
             <div className="lane-title" id="roadmap-later"><span className="lane-dot later"/>Later <span style={{color:'var(--muted)', fontWeight:400}}>· {later.length}</span></div>
@@ -2615,6 +2658,7 @@ function Roadmap({ onViewFinding, editMode, hiddenFindings, roadmapOverrides, on
           </div>
           {later.map(t => renderTask(t, 'later'))}
         </div>
+        </HideableBlock>
       </div></>}
     </section>
   );
@@ -2739,7 +2783,9 @@ function Appendix() {
         <div className="hr"/>
       </div>
 
-      {open && <><div className="card" style={{marginBottom:14}}>
+      {open && <>
+      <HideableBlock hideKey="appendix-tenant" label="Tenant info">
+      <div className="card" style={{marginBottom:14}}>
         <div style={labelStyle}>Tenant</div>
         <div style={{display:'flex',flexWrap:'wrap',gap:'6px 24px',fontSize:12}}>
           <span><span style={{color:'var(--muted)'}}>org</span> <b>{TENANT.OrgDisplayName}</b></span>
@@ -2753,8 +2799,10 @@ function Appendix() {
           )}
         </div>
       </div>
+      </HideableBlock>
 
       <div style={{display:'grid',gridTemplateColumns:'1fr 1fr',gap:14}}>
+        <HideableBlock hideKey="appendix-licenses" label="Licenses card">
         <div className="card">
           <div style={labelStyle}>Licenses</div>
           <table style={{width:'100%',fontSize:12,borderCollapse:'collapse'}}>
@@ -2770,7 +2818,9 @@ function Appendix() {
             </tbody>
           </table>
         </div>
+        </HideableBlock>
 
+        <HideableBlock hideKey="appendix-mfa-coverage" label="MFA coverage card">
         <div className="card">
           <div style={labelStyle}>MFA coverage ({fmt(mfaTotal)} users)</div>
           <table style={{width:'100%',fontSize:12,borderCollapse:'collapse'}}>
@@ -2811,7 +2861,9 @@ function Appendix() {
             </tbody>
           </table>
         </div>
+        </HideableBlock>
 
+        <HideableBlock hideKey="appendix-ca-policies" label="Conditional Access policies card">
         <div className="card">
           <div style={labelStyle}>Conditional Access policies ({ca.length})</div>
           <table style={{width:'100%',fontSize:12,borderCollapse:'collapse'}}>
@@ -2826,7 +2878,9 @@ function Appendix() {
             </tbody>
           </table>
         </div>
+        </HideableBlock>
 
+        <HideableBlock hideKey="appendix-privileged-roles" label="Privileged roles card">
         <div className="card">
           <div style={labelStyle}>Privileged roles ({allRoles.length} assignments)</div>
           <table style={{width:'100%',fontSize:12,borderCollapse:'collapse'}}>
@@ -2840,8 +2894,10 @@ function Appendix() {
             </tbody>
           </table>
         </div>
+        </HideableBlock>
 
         {dnsTotal > 0 && (
+          <HideableBlock hideKey="appendix-email-auth" label="Email authentication card">
           <div className="card">
             <div style={labelStyle}>Email authentication ({dnsTotal} domain{dnsTotal!==1?'s':''})</div>
             <table style={{width:'100%',fontSize:12,borderCollapse:'collapse'}}>
@@ -2861,9 +2917,11 @@ function Appendix() {
               </tbody>
             </table>
           </div>
+          </HideableBlock>
         )}
 
         {ad && (
+          <HideableBlock hideKey="appendix-hybrid-sync" label="Hybrid sync card">
           <div className="card">
             <div style={labelStyle}>Hybrid sync</div>
             <table style={{width:'100%',fontSize:12,borderCollapse:'collapse'}}>
@@ -2885,6 +2943,7 @@ function Appendix() {
               </tbody>
             </table>
           </div>
+          </HideableBlock>
         )}
       </div>
       <PermissionsPanel/>
@@ -2993,22 +3052,33 @@ function App() {
   }, [matchIdx, searchMatches]);
   const [editMode, setEditMode] = useState(false);
   const [hiddenFindings, setHiddenFindings] = useState(() => new Set(RO?.hiddenFindings || []));
+  const [hiddenElements, setHiddenElements] = useState(() => new Set(RO?.hiddenElements || []));
   const [roadmapOverrides, setRoadmapOverrides] = useState(() => RO?.roadmapOverrides || {});
 
   const toggleHideFinding = id => setHiddenFindings(prev => {
     const s = new Set(prev); s.has(id) ? s.delete(id) : s.add(id); return s;
   });
+  const toggleHideElement = key => setHiddenElements(prev => {
+    const s = new Set(prev); s.has(key) ? s.delete(key) : s.add(key); return s;
+  });
   const restoreAllFindings = () => setHiddenFindings(new Set());
 
   const handleFinalize = () => finalizeReport({
     hiddenFindings: [...hiddenFindings],
+    hiddenElements: [...hiddenElements],
     roadmapOverrides,
   });
 
   const handleResetAll = () => {
     setHiddenFindings(new Set());
+    setHiddenElements(new Set());
     setRoadmapOverrides({});
   };
+
+  const editModeCtx = useMemo(
+    () => ({ editMode, hiddenElements, toggleHideElement }),
+    [editMode, hiddenElements]
+  );
 
   useEffect(() => {
     document.documentElement.dataset.theme = theme;
@@ -3117,6 +3187,7 @@ function App() {
   }, []);
 
   return (
+    <EditModeContext.Provider value={editModeCtx}>
     <div className="app">
       <Sidebar active={active} activeSubsection={activeSubsection} counts={navCounts} domainCounts={domainCounts} activeDomain={filters.domain.length===1 ? filters.domain[0] : null} onDomainJump={onDomainJump} onOverviewClick={onOverviewClick} navOpen={navOpen} onClose={()=>setNavOpen(false)}/>
       <main className="main">
@@ -3134,7 +3205,7 @@ function App() {
           onEditToggle={()=>setEditMode(e=>!e)}
           onFinalize={handleFinalize}
           onReset={handleResetAll}
-          hiddenCount={hiddenFindings.size}
+          hiddenCount={hiddenFindings.size + hiddenElements.size}
         />
         <Overview/>
         <Posture/>
@@ -3161,6 +3232,7 @@ function App() {
       </main>
       {showTweaks && <TweaksPanel onClose={()=>setShowTweaks(false)} theme={theme} setTheme={setTheme} mode={mode} setMode={setMode} density={density} setDensity={setDensity}/>}
     </div>
+    </EditModeContext.Provider>
   );
 }
 

--- a/src/M365-Assess/assets/report-shell.css
+++ b/src/M365-Assess/assets/report-shell.css
@@ -1921,6 +1921,37 @@ mark.search-hl {
 .hide-finding-btn.restore { border-color: var(--accent); color: var(--accent); }
 .hide-finding-btn.restore:hover { background: color-mix(in srgb, var(--accent) 15%, transparent); }
 .finding-hidden { opacity: .45; }
+
+/* Issue #712: HideableBlock wrapper. Active only in edit mode (the JSX bypasses
+   the wrapper entirely when edit mode is off). The wrapper preserves the host
+   element's natural sizing -- display: contents would drop the box but breaks
+   the absolutely-positioned ✕ button, so we use position: relative with no
+   layout impact other than introducing a stacking context. */
+.hideable-block { position: relative; }
+.hideable-block-hidden > *:not(.hideable-btn) { opacity: .35; pointer-events: none; }
+.hideable-btn {
+  position: absolute; top: 6px; right: 6px;
+  width: 22px; height: 22px;
+  font-size: 12px; line-height: 1;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--muted);
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  opacity: 0; transition: opacity .15s, background .15s, border-color .15s, color .15s;
+  z-index: 5;
+}
+.hideable-block:hover > .hideable-btn,
+.hideable-block-hidden > .hideable-btn { opacity: 1; }
+.hideable-btn:hover { background: color-mix(in srgb, var(--danger) 15%, transparent); border-color: var(--danger); color: var(--danger); }
+.hideable-btn.restore { border-color: var(--accent); color: var(--accent); opacity: 1; }
+.hideable-btn.restore:hover { background: color-mix(in srgb, var(--accent) 15%, transparent); }
+@media print {
+  /* Hidden elements stay hidden in print; ✕ overlays never print. */
+  .hideable-block-hidden { display: none; }
+  .hideable-btn { display: none !important; }
+}
 .restore-all-btn { font-size: 12px; padding: 4px 10px; border-radius: 5px; border: 1px solid var(--accent); background: transparent; color: var(--accent); cursor: pointer; margin-left: auto; }
 .restore-all-btn:hover { background: color-mix(in srgb, var(--accent) 10%, transparent); }
 .edit-toolbar-reset { font-size: 12px; padding: 5px 12px; border-radius: 6px; border: 1px solid var(--border); background: transparent; color: var(--muted); cursor: pointer; }


### PR DESCRIPTION
## Summary

Closes #712. Extends the existing edit-mode finding-row hide mechanic to **any card or section** in the report. Adds a generic `<HideableBlock hideKey="...">` wrapper that, in edit mode, overlays a hover ✕ button (or ↩ Restore when hidden) on its child. Hidden state persists into `REPORT_OVERRIDES` on Finalize so regenerated reports re-apply the hides.

## Architecture

- **New `EditModeContext`** exposes `editMode` + `hiddenElements` + `toggleHideElement` so HideableBlock can read them without prop-drilling through every parent (Posture → KPI cards → ...). Avoids threading 3 props through 5 layers per wrapped element.
- **Sibling `hiddenElements` state** (Set, persisted as `REPORT_OVERRIDES.hiddenElements`) — kept separate from the existing `hiddenFindings` store to avoid backward-compat breakage of the existing serialization shape (per the sprint plan's "keep both, defer the merge to a future cleanup PR" decision).
- **Finalize** writes both sets; **Reset All** clears both.
- **Topbar hidden-count badge** shows the combined size of `hiddenFindings` + `hiddenElements`.

## Wrapped elements (v1 scope, 15 total)

| Group | Hide keys |
|---|---|
| Score | `posture-score-card` |
| KPIs | `kpi-critical`, `kpi-fails`, `kpi-warnings`, `kpi-passing` |
| Roadmap lanes | `roadmap-lane-now`, `roadmap-lane-next`, `roadmap-lane-later` |
| Appendix | `appendix-tenant`, `appendix-licenses`, `appendix-mfa-coverage`, `appendix-ca-policies`, `appendix-privileged-roles`, `appendix-email-auth`, `appendix-hybrid-sync` |

The pattern is **one line per wrapped element** — adding more (ExecSummaryRow tiles, MFA breakdown tiles, framework quilt cells, domain posture cards/sub-panels) is incremental and trivial. Left as follow-up to keep this PR's review surface manageable.

## Render contract

- `editMode off + key in hiddenElements` → renders **nothing** (production view)
- `editMode off + key NOT hidden` → renders children with **no wrapper** at all
- `editMode on` → renders `<div className="hideable-block">` wrapper + ✕/↩ button overlay

In edit mode the wrapper carries `position: relative;` to host the absolutely-positioned button. In production view the wrapper is bypassed entirely (returns `<>{children}</>`), so the unhidden output is **byte-identical** to the prior render. No layout impact when not in edit mode.

Print media query forces hidden elements to `display: none` and hides ✕ buttons.

## Files

- `src/M365-Assess/assets/report-app.jsx`:
  - New `EditModeContext` + `HideableBlock` component (next to `finalizeReport`)
  - New `hiddenElements` state in App + `toggleHideElement` modifier
  - `finalizeReport` accepts and serializes `hiddenElements`
  - `handleFinalize` and `handleResetAll` updated
  - Topbar badge counts both sets
  - Provider wraps the App's main render
  - 15 elements wrapped with `<HideableBlock>`
- `src/M365-Assess/assets/report-shell.css`:
  - `.hideable-block` (relative positioning)
  - `.hideable-block-hidden > *:not(.hideable-btn)` (opacity 0.35 + pointer-events: none)
  - `.hideable-btn` (top-right ✕ overlay, hover-reveal in edit mode)
  - `.hideable-btn.restore` (accent-colored, always visible when hidden)
  - `@media print` — hide both the wrapper-when-hidden and the buttons
- `src/M365-Assess/assets/report-app.js` — regenerated via `npm run build`

## Test plan

Local checks (passed):
- [x] `npm run build` clean, `node --check` clean
- [x] Pester `Get-ReportTemplate.Tests.ps1` 31/31 pass

**Live tenant verification** (per `.claude/rules/releases.md`):

```powershell
Invoke-M365Assessment -ProfileName <your-profile> -AutoBaseline
```

In browser:
- [x] Toggle edit mode (✎ in topbar) → hover any wrapped element → ✕ appears in top-right
- [x] Click ✕ on the Score card → it fades to 0.35 opacity, ↩ Restore button appears
- [x] Click ↩ Restore → element fully visible again
- [x] Click ✕ on a KPI card → same behavior, hidden in production
- [x] Click ✕ on a roadmap lane (Now/Next/Later) → same
- [x] Click ✕ on multiple appendix sub-cards (Licenses, MFA coverage, CA policies, etc.) → same
- [x] Topbar shows the combined hidden count (findings + elements)
- [x] Reset All button clears all hides
- [x] Click Finalize → downloaded HTML, reopen → hidden elements stay hidden, ↩ buttons absent (because edit mode is off in the new file)
- [x] Reopen the finalized HTML, toggle edit mode on → hidden elements show at 0.35 opacity with ↩ Restore visible
- [x] Print preview (Ctrl+P) → hidden elements absent, ✕/↩ buttons absent

## Out of scope

- ExecSummaryRow tiles / MFA breakdown tiles / framework quilt cells / domain posture cards (incremental — pattern is one line per element)
- Migrating `hiddenFindings` into `hiddenElements` (would break REPORT_OVERRIDES backward compat; sprint plan defers to a future cleanup PR)
- Version bump (waits for PR 3 + your hold directive on framework coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)