### PR TITLE
fix(report): finding-detail Current value outline reflects status (refs #674)

### DIFF
--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -4098,7 +4098,7 @@ function FindingsTable({
     }, whyItMatters(f))), /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("div", {
       className: "block-title"
     }, "Current value"), /*#__PURE__*/React.createElement("div", {
-      className: "value-box current"
+      className: 'value-box current finding-current-' + statusTier(f.status)
     }, f.current || '—')), /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("div", {
       className: "block-title"
     }, "Recommended value"), /*#__PURE__*/React.createElement("div", {
@@ -4216,6 +4216,19 @@ function renderRemediation(text) {
   }, /*#__PURE__*/React.createElement("span", {
     className: "remediation-label"
   }, "Portal"), /*#__PURE__*/React.createElement("p", null, b.text))));
+}
+
+// Issue #674 (partial cherry-pick from PR #853): map a finding's status to a
+// CSS-class tier so the Current value card's left-border color reflects
+// pass/fail/warn/etc. — was always red, which incorrectly visually flagged
+// passing values as failing.
+function statusTier(status) {
+  if (status === 'Pass') return 'pass';
+  if (status === 'Fail') return 'fail';
+  if (status === 'Warning') return 'warn';
+  if (status === 'Review') return 'review';
+  if (status === 'Info') return 'info';
+  return 'neutral';
 }
 function whyItMatters(f) {
   const id = f.checkId;

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -2516,7 +2516,7 @@ function FindingsTable({ filters, search, focusFinding, onFocusClear, onMatchesC
                   </div>
                   <div>
                     <div className="block-title">Current value</div>
-                    <div className="value-box current">{f.current || '—'}</div>
+                    <div className={'value-box current finding-current-' + statusTier(f.status)}>{f.current || '—'}</div>
                   </div>
                   <div>
                     <div className="block-title">Recommended value</div>
@@ -2636,6 +2636,19 @@ function renderRemediation(text) {
       )}
     </div>
   );
+}
+
+// Issue #674 (partial cherry-pick from PR #853): map a finding's status to a
+// CSS-class tier so the Current value card's left-border color reflects
+// pass/fail/warn/etc. — was always red, which incorrectly visually flagged
+// passing values as failing.
+function statusTier(status) {
+  if (status === 'Pass') return 'pass';
+  if (status === 'Fail') return 'fail';
+  if (status === 'Warning') return 'warn';
+  if (status === 'Review') return 'review';
+  if (status === 'Info') return 'info';
+  return 'neutral';
 }
 
 function whyItMatters(f) {

--- a/src/M365-Assess/assets/report-shell.css
+++ b/src/M365-Assess/assets/report-shell.css
@@ -879,6 +879,15 @@ mark.search-hl {
 }
 .finding-detail .value-box.current { border-left: 3px solid var(--danger); }
 .finding-detail .value-box.recommended { border-left: 3px solid var(--success); }
+/* Issue #674 (partial): tier-based outline so a passing value doesn't read as
+   failing. The .current rule above sets the default red; these per-tier rules
+   override based on the finding's status. */
+.finding-detail .value-box.finding-current-pass    { border-left-color: var(--success); }
+.finding-detail .value-box.finding-current-fail    { border-left-color: var(--danger); }
+.finding-detail .value-box.finding-current-warn    { border-left-color: var(--warn); }
+.finding-detail .value-box.finding-current-review  { border-left-color: var(--accent); }
+.finding-detail .value-box.finding-current-info,
+.finding-detail .value-box.finding-current-neutral { border-left-color: var(--border); }
 .finding-detail .why {
   grid-column: 1 / -1;
   padding: 10px 14px;


### PR DESCRIPTION
## Summary

Cherry-pick from PR #853. The full finding-detail redesign in #853 felt too busy for the value it added (will close #853 separately), but the **Current value outline color** was a real bug worth keeping on its own:

> Currently, the Current value box's left-border is always red regardless of the finding's status. So a Pass finding's Current value visually reads as failing in the detail panel — misleading.

This PR takes JUST that fix and leaves the rest of #853 behind.

## What changed

- New `statusTier(status)` helper near \`whyItMatters\` (~10 lines) — maps Pass/Fail/Warning/Review/Info/etc. to a CSS-class tier name
- Current value box className now includes \`finding-current-<tier>\`
- 5 new CSS rules in \`report-shell.css\` override the default red border based on the tier:
  - Pass → green
  - Fail → red (unchanged)
  - Warning → amber
  - Review → accent
  - Info / neutral → muted border

Recommended value's always-green outline is unchanged (it's the target state — always green is correct).

## What's NOT in this PR (deliberately left in #853)

- Status header bar at top — duplicated row header info
- Why It Matters callout boost — exposed thin generic content (#854 tracks the content audit)
- Mapped-to-frameworks chips section — verbose; controlId already in row column
- Reordering of detail panel blocks — subjective change

## Files

- \`src/M365-Assess/assets/report-app.jsx\` — \`statusTier\` helper + 1-line className change
- \`src/M365-Assess/assets/report-app.js\` — regenerated via \`npm run build\`
- \`src/M365-Assess/assets/report-shell.css\` — 5 new override rules

Total: +37 / -2 lines.

## Test plan

Local checks (passed):
- [x] \`npm run build\` clean, \`node --check\` clean
- [x] Pester \`Get-ReportTemplate.Tests.ps1\` 31/31 pass

**Live tenant verification** (per \`.claude/rules/releases.md\`):

\`\`\`powershell
Invoke-M365Assessment -ProfileName <your-profile> -AutoBaseline
\`\`\`

In browser:
- [ ] Click any **Pass** finding → expanded panel's Current value box has GREEN left border (was red)
- [ ] Click any **Fail** finding → red left border (unchanged)
- [ ] Click any **Warning** finding → amber left border (was red)
- [ ] Click any **Review** finding → accent (purple/blue per theme) left border (was red)
- [ ] Recommended value box still has green left border in all cases

## Out of scope

- Per-control narrative content audit — tracked in #854
- Other elements of the #853 redesign — explicitly left behind

## Related

- #853 — full redesign PR, will be closed separately with a note pointing here
- #674 — original issue, partially addressed by this cherry-pick

🤖 Generated with [Claude Code](https://claude.com/claude-code)