### PR TITLE
fix(report): SPF/DKIM appendix predicates + text-size A−/A+ split (closes #860, #852)

### DIFF
--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -708,14 +708,27 @@ function Topbar({
   onReset,
   hiddenCount
 }) {
+  // Issue #852: split the single cycling A/A+/A++ button into separate
+  // A− (decrement) and A+ (increment) controls. Each disables at the
+  // boundary (normal/xlarge) instead of wrapping around.
   const SCALE_CYCLE = ['normal', 'large', 'xlarge'];
-  const cycleScale = () => setTextScale(s => SCALE_CYCLE[(SCALE_CYCLE.indexOf(s) + 1) % SCALE_CYCLE.length] || 'normal');
-  const scaleLabel = {
-    normal: 'A',
-    large: 'A+',
-    xlarge: 'A++'
-  }[textScale] || 'A';
-  const scaleTitle = `Text size: ${textScale} (click to cycle)`;
+  const scaleIdx = SCALE_CYCLE.indexOf(textScale);
+  const safeIdx = scaleIdx === -1 ? 0 : scaleIdx;
+  const canIncrement = safeIdx < SCALE_CYCLE.length - 1;
+  const canDecrement = safeIdx > 0;
+  const incScale = () => {
+    if (canIncrement) setTextScale(SCALE_CYCLE[safeIdx + 1]);
+  };
+  const decScale = () => {
+    if (canDecrement) setTextScale(SCALE_CYCLE[safeIdx - 1]);
+  };
+  const scaleNames = {
+    normal: 'normal',
+    large: 'large',
+    xlarge: 'extra large'
+  };
+  const incTitle = canIncrement ? `Increase text size (currently ${scaleNames[textScale] || textScale})` : 'Already at max text size';
+  const decTitle = canDecrement ? `Decrease text size (currently ${scaleNames[textScale] || textScale})` : 'Already at default text size';
   return /*#__PURE__*/React.createElement(React.Fragment, null, editMode && /*#__PURE__*/React.createElement("div", {
     className: "edit-toolbar"
   }, /*#__PURE__*/React.createElement("span", {
@@ -775,17 +788,33 @@ function Topbar({
     onClick: () => setTheme('high-contrast')
   }, "High Contrast")), /*#__PURE__*/React.createElement("div", {
     className: "icon-btn-group"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "text-scale-group",
+    role: "group",
+    "aria-label": "Text size"
   }, /*#__PURE__*/React.createElement("button", {
-    className: 'icon-btn text-scale-btn scale-' + textScale,
-    title: scaleTitle,
-    onClick: cycleScale
+    className: 'icon-btn text-scale-step text-scale-step-dec' + (!canDecrement ? ' disabled' : ''),
+    title: decTitle,
+    "aria-disabled": !canDecrement,
+    onClick: decScale
   }, /*#__PURE__*/React.createElement("span", {
     style: {
       fontWeight: 600,
       fontSize: 13,
       letterSpacing: '-0.02em'
     }
-  }, scaleLabel)), /*#__PURE__*/React.createElement("button", {
+  }, "A\u2212")), /*#__PURE__*/React.createElement("button", {
+    className: 'icon-btn text-scale-step text-scale-step-inc' + (!canIncrement ? ' disabled' : ''),
+    title: incTitle,
+    "aria-disabled": !canIncrement,
+    onClick: incScale
+  }, /*#__PURE__*/React.createElement("span", {
+    style: {
+      fontWeight: 600,
+      fontSize: 13,
+      letterSpacing: '-0.02em'
+    }
+  }, "A+"))), /*#__PURE__*/React.createElement("button", {
     className: "icon-btn",
     title: mode === 'dark' ? 'Light mode' : 'Dark mode',
     onClick: () => setMode(mode === 'dark' ? 'light' : 'dark')

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -4794,8 +4794,11 @@ function Appendix() {
   const licenses = D.licenses || [];
   const dns = D.dns || [];
   const dnsTotal = dns.length;
-  const spfPass = dns.filter(r => r.SPF === 'Pass').length;
-  const dkimPass = dns.filter(r => r.DKIMStatus === 'Pass' || r.DKIM === 'Pass').length;
+  // Issue #860: predicates aligned with DnsAuthPanel (line 986). The previous
+  // === 'Pass' checks always counted 0 because the data fields contain raw
+  // SPF records and 'OK' for DKIMStatus, never the literal 'Pass'.
+  const spfPass = dns.filter(r => r.SPF && !r.SPF.includes('Not')).length;
+  const dkimPass = dns.filter(r => r.DKIMStatus === 'OK').length;
   const dmarcEnf = dns.filter(r => r.DMARCPolicy === 'reject' || r.DMARCPolicy === 'quarantine').length;
   const allRoles = D['admin-roles'] || [];
   const roleCounts = allRoles.reduce((acc, r) => {

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -379,10 +379,19 @@ function useCollapsibleSection(defaultOpen = true) {
 
 // ======================== Topbar ========================
 function Topbar({ search, setSearch, searchMatches, matchIdx, onAdvanceMatch, onRetreatMatch, mode, setMode, theme, setTheme, textScale, setTextScale, onPrint, onTweaks, onHamburger, editMode, onEditToggle, onFinalize, onReset, hiddenCount }) {
+  // Issue #852: split the single cycling A/A+/A++ button into separate
+  // A− (decrement) and A+ (increment) controls. Each disables at the
+  // boundary (normal/xlarge) instead of wrapping around.
   const SCALE_CYCLE = ['normal', 'large', 'xlarge'];
-  const cycleScale = () => setTextScale(s => SCALE_CYCLE[(SCALE_CYCLE.indexOf(s) + 1) % SCALE_CYCLE.length] || 'normal');
-  const scaleLabel = { normal: 'A', large: 'A+', xlarge: 'A++' }[textScale] || 'A';
-  const scaleTitle = `Text size: ${textScale} (click to cycle)`;
+  const scaleIdx = SCALE_CYCLE.indexOf(textScale);
+  const safeIdx = scaleIdx === -1 ? 0 : scaleIdx;
+  const canIncrement = safeIdx < SCALE_CYCLE.length - 1;
+  const canDecrement = safeIdx > 0;
+  const incScale = () => { if (canIncrement) setTextScale(SCALE_CYCLE[safeIdx + 1]); };
+  const decScale = () => { if (canDecrement) setTextScale(SCALE_CYCLE[safeIdx - 1]); };
+  const scaleNames = { normal: 'normal', large: 'large', xlarge: 'extra large' };
+  const incTitle = canIncrement ? `Increase text size (currently ${scaleNames[textScale] || textScale})` : 'Already at max text size';
+  const decTitle = canDecrement ? `Decrease text size (currently ${scaleNames[textScale] || textScale})` : 'Already at default text size';
   return (
     <>
       {editMode && (
@@ -430,9 +439,16 @@ function Topbar({ search, setSearch, searchMatches, matchIdx, onAdvanceMatch, on
           <button className={theme==='high-contrast'?'active':''} onClick={()=>setTheme('high-contrast')}>High Contrast</button>
         </div>
         <div className="icon-btn-group">
-          <button className={'icon-btn text-scale-btn scale-' + textScale} title={scaleTitle} onClick={cycleScale}>
-            <span style={{fontWeight:600,fontSize:13,letterSpacing:'-0.02em'}}>{scaleLabel}</span>
-          </button>
+          <div className="text-scale-group" role="group" aria-label="Text size">
+            <button className={'icon-btn text-scale-step text-scale-step-dec' + (!canDecrement ? ' disabled' : '')}
+              title={decTitle} aria-disabled={!canDecrement} onClick={decScale}>
+              <span style={{fontWeight:600,fontSize:13,letterSpacing:'-0.02em'}}>A−</span>
+            </button>
+            <button className={'icon-btn text-scale-step text-scale-step-inc' + (!canIncrement ? ' disabled' : '')}
+              title={incTitle} aria-disabled={!canIncrement} onClick={incScale}>
+              <span style={{fontWeight:600,fontSize:13,letterSpacing:'-0.02em'}}>A+</span>
+            </button>
+          </div>
           <button className="icon-btn" title={mode==='dark'?'Light mode':'Dark mode'} onClick={()=>setMode(mode==='dark'?'light':'dark')}>
             {mode==='dark' ? <Icon.sun/> : <Icon.moon/>}
           </button>

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -2998,8 +2998,11 @@ function Appendix() {
   const licenses = D.licenses || [];
   const dns = D.dns || [];
   const dnsTotal = dns.length;
-  const spfPass  = dns.filter(r => r.SPF === 'Pass').length;
-  const dkimPass = dns.filter(r => r.DKIMStatus === 'Pass' || r.DKIM === 'Pass').length;
+  // Issue #860: predicates aligned with DnsAuthPanel (line 986). The previous
+  // === 'Pass' checks always counted 0 because the data fields contain raw
+  // SPF records and 'OK' for DKIMStatus, never the literal 'Pass'.
+  const spfPass  = dns.filter(r => r.SPF && !r.SPF.includes('Not')).length;
+  const dkimPass = dns.filter(r => r.DKIMStatus === 'OK').length;
   const dmarcEnf = dns.filter(r => r.DMARCPolicy === 'reject' || r.DMARCPolicy === 'quarantine').length;
 
   const allRoles = D['admin-roles'] || [];

--- a/src/M365-Assess/assets/report-shell.css
+++ b/src/M365-Assess/assets/report-shell.css
@@ -1834,6 +1834,30 @@ mark.search-hl {
 .text-scale-btn.scale-large span  { color: var(--accent-text, var(--accent)); }
 .text-scale-btn.scale-xlarge span { color: var(--accent-text, var(--accent)); font-size: 15px !important; }
 
+/* Issue #852: split A−/A+ controls. Buttons sit adjacent in a single rounded
+   pill, with a subtle divider between them. Disabled state for boundary. */
+.text-scale-group {
+  display: inline-flex;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+.text-scale-group .icon-btn.text-scale-step {
+  border: none;
+  border-radius: 0;
+  padding: 0 10px;
+  height: 28px;
+  min-width: 32px;
+}
+.text-scale-group .text-scale-step-dec { border-right: 1px solid var(--border); }
+.text-scale-group .icon-btn.text-scale-step.disabled {
+  opacity: .35;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+[data-text-scale="large"]  .text-scale-step-inc span,
+[data-text-scale="xlarge"] .text-scale-step-inc span { color: var(--accent-text, var(--accent)); }
+
 /* =========================================================
    DENSITY — base CSS is the neutral midpoint.
    Compact reduces padding; Comfort increases it significantly.


### PR DESCRIPTION
## Summary

First v2.10.0 — Polish & Audits sprint PR. Two small bug/UX fixes bundled for one live-test cycle:

| Commit | Closes | Type |
|---|---|---|
| `4326f20` | #860 | Bug fix — Appendix Email auth card always reported 0/N for SPF + DKIM |
| `b51df83` | #852 | UX — split single cycling A/A+/A++ button into A−/A+ controls |

Both target the v2.10.0 — Polish & Audits milestone.

## #860 — SPF/DKIM predicate alignment

3-line bug fix at `report-app.jsx:3001-3002`. The Appendix Email auth card used `r.SPF === 'Pass'` and `r.DKIMStatus === 'Pass'` to count passing domains, but the data fields contain raw SPF records and `OK`/`Not configured` for DKIMStatus — never the literal `Pass`. Result: even tenants with fully-passing email auth saw `0/N passing` in the appendix while the top-of-report DNS panel showed the correct counts.

Aligned with `DnsAuthPanel`'s correct predicates (line 986). DMARC was already correct.

## #852 — A−/A+ split

The single cycling A/A+/A++ button in the topbar made stepping back tedious (you had to forward-cycle twice from xlarge to large). Replaced with two adjacent buttons:

- `A−` decrements scale: xlarge → large → normal. Disabled at `normal`.
- `A+` increments scale: normal → large → xlarge. Disabled at `xlarge`.
- Tooltip per button: "Increase text size (currently large)" etc.
- Accent color on the `A+` button when scaled up, so the user sees current state at a glance.
- localStorage key (`m365-text-scale`) and applied scale unchanged — purely topbar UX swap. No behavior change for already-saved settings.

CSS: two buttons share a single rounded pill via a `.text-scale-group` wrapper with a thin internal divider; matches the visual weight of the original single button.

## Files

- `src/M365-Assess/assets/report-app.jsx` — Appendix predicate alignment + Topbar buttons + state helpers
- `src/M365-Assess/assets/report-shell.css` — `.text-scale-group` + adjacent-button styling + boundary disabled state
- `src/M365-Assess/assets/report-app.js` — regenerated via `npm run build`

## Test plan

Local checks (passed):
- [x] `npm run build` clean, `node --check` clean
- [x] Pester `Get-ReportTemplate.Tests.ps1` 31/31 pass

**Live tenant verification** (per `.claude/rules/releases.md`):

```powershell
Invoke-M365Assessment -ProfileName <your-profile> -AutoBaseline
```

For #860:
- [ ] Open the HTML report. Top-of-report DNS / Email Security panel still shows correct SPF/DKIM/DMARC counts (unchanged).
- [ ] Open Appendix → Email authentication card. SPF + DKIM passing counts now MATCH the top-of-report panel (was always `0/N`).
- [ ] DMARC enforced count unchanged in both places.

For #852:
- [ ] Topbar shows two adjacent buttons `A−` / `A+` (was a single `A` button).
- [ ] Click `A+` at default — text scales to large, button label gets accent color.
- [ ] Click `A+` again — scales to xlarge.
- [ ] Click `A+` at xlarge — nothing happens, button shows muted/disabled state, tooltip says "Already at max text size".
- [ ] Click `A−` at xlarge — steps back to large.
- [ ] Click `A−` at normal — disabled, tooltip says "Already at default text size".
- [ ] Reload page — last-set scale persists (existing localStorage mechanism unchanged).
- [ ] All 4 themes render the new buttons cleanly.

## Out of scope

- #844 (level-chip inversion) — explicitly NOT bundled; the issue body asks for a full audit, not a patch
- Other v2.10.0 items — separate PRs to come

🤖 Generated with [Claude Code](https://claude.com/claude-code)