### PR TITLE
chore(release): bump to v2.9.3 (Polish + framework redesign)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to M365 Assess are documented here. This project uses [Conve
 
 ## [Unreleased]
 
+## [2.9.3] - 2026-04-28
+
+Big patch release covering the v2.7.0 — Deep UX milestone closeout plus the v2.10.0 — Polish & Audits UX work to date. Despite "patch" in the version label, this release ships a substantial new framework-coverage UX (per a Claude Design handoff) and several new capabilities — but no breaking API changes. The 3 remaining audit-flavored items (CIS mapping integrity, ISO 27001/27002, per-control narrative content) ship in v2.10.0 proper.
+
+### Added
+- **FrameworkQuilt redesign — adaptive single/multi layout (#751, #855)** — One unified component branches on framework count: 0 → empty state, 1 → single-framework focus surface (donut score + family chart + primary CTA), 2+ → sortable comparison table + coverage chart + drill-down. Implements the Direction-Merged design from `docs/design/framework-redesign/`. New components: `ScoreDonut` (animated SVG ring), `FwManageButton` (real form-control dropdown replacing the chip-shaped picker), `CompareTableM` (sortable), `CoverageChart` (sorted bar with position markers), `FamilyChartM` (clickable family rows), `FilterBanner` (action feedback with single Clear-all), `ProfileChipsM` (level chips promoted out of the buried expanded panel), `GapsCTA` (real primary action button)
+- **HideableBlock for any card or section (#712)** — extends edit-mode finding-row hide to ANY card/section. New generic `<HideableBlock hideKey>` wrapper with hover ✕ overlay and ↩ Restore. Persists into REPORT_OVERRIDES on Finalize. v1 wraps 15 elements (Score card, 4 KPIs, 3 roadmap lanes, 7 appendix sub-cards)
+- **Native taxonomy for 4 more frameworks (#845 partial)** — HIPAA (6 safeguards via 164.X), SOC 2 TSC (5 criteria), Essential Eight (8 strategies), CISA SCUBA (6 services). Brings native-taxonomy coverage to 12 of 14 supported frameworks. MITRE ATT&CK + STIG documented as deliberate domain fallback
+- **Findings table columns resizable + sortable (#846)** — drag handle on the right edge of every header (8px hot zone, 60px min-width, fr columns snap to px on first drag). Click sortable headers (Status / Finding / Domain / CheckID / Severity) to cycle none → asc → desc → none. Status sorts by enum order so Fail comes first. Both persist per-tenant in localStorage
+- **`-BaselineLabel` parameter** — already present from v2.9.2, no change here
+- **Design handoff package (#856)** — `docs/design/framework-redesign/` committed as the source of truth for the redesign spec
+- **`docs/LEVELS.md` (#844)** — semantic reference for level/profile chips. Locks down the per-check trust-the-registry model and rejects synthetic inheritance in code
+
+### Changed
+- **FilterBar consolidation (#847)** — collapsed from 5 stacked rows to a single flowing row with vertical dividers between groups (STATUS / SEVERITY / FRAMEWORK / DOMAIN / LEVEL). Groups break as units when the viewport is narrower; chips inside a group never break across a separator. Density-aware compact mode (existing `[data-density="compact"]` selector) halves vertical padding. FilterBar height drops from ~250px to ≤120px on a 1440px viewport
+- **CIS M365 v6 sections complete** — added the missing `4: Microsoft Intune` and `9: Microsoft Fabric` to the framework JSON so the family breakdown no longer shows `(unmapped)` rows for those sections
+- **Topbar text-size control split into A− / A+ (#852)** — replaced the single A/A+/A++ cycling button with two adjacent buttons that step one position each direction and disable at the boundaries. Tooltips show direction + current size. Persistence (`m365-text-scale` localStorage key) unchanged
+
+### Fixed
+- **Appendix Email-authentication card SPF/DKIM predicates (#860)** — the appendix used `r.SPF === 'Pass'` and `r.DKIMStatus === 'Pass'` to count passing domains, but the data fields contain raw SPF records and `OK`/`Not configured` for DKIMStatus. The card always reported `0/N passing` even when the top-of-report DNS panel showed correct counts. Aligned predicates with `DnsAuthPanel`
+- **Finding-detail Current value outline now reflects status (refs #674)** — was always red regardless of status, so a Pass finding's Current value visually read as failing. Now color-coded per tier: Pass green / Fail red / Warning amber / Review accent / Info muted. Recommended outline unchanged (always green — it's the target state)
+- **Level chip text "L2 ⊇ L3" was backwards (#844)** — already removed in #855's framework redesign; audit confirms no remaining text states it. `docs/LEVELS.md` enshrines the corrected semantic
+
 ## [2.9.2] - 2026-04-27
 
 Polish release: HTML report layout cleanup, XLSX matrix readability, and a `-SaveBaseline` UX papercut. One **breaking change** to a parameter type (see Changed).

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [![Coverage](https://img.shields.io/badge/coverage-check%20CI-informational)](https://github.com/Galvnyz/M365-Assess/actions/workflows/ci.yml)
 [![PowerShell 7.x](https://img.shields.io/badge/PowerShell-7.x-blue?logo=powershell&logoColor=white)](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows)
 [![Read-Only](https://img.shields.io/badge/Operations-Read--Only-brightgreen)](.)
-[![Version](https://img.shields.io/badge/version-2.9.2-blue)](.)
+[![Version](https://img.shields.io/badge/version-2.9.3-blue)](.)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 </div>

--- a/src/M365-Assess/M365-Assess.psd1
+++ b/src/M365-Assess/M365-Assess.psd1
@@ -3,7 +3,7 @@
     # Generated: 2026-03-08
 
     RootModule        = 'M365-Assess.psm1'
-    ModuleVersion     = '2.9.2'
+    ModuleVersion     = '2.9.3'
     GUID              = 'f7e3b2a1-4c5d-6e8f-9a0b-1c2d3e4f5a6b'
     Author            = 'Galvnyz'
     CompanyName       = 'Community'
@@ -242,7 +242,7 @@
             IconUri      = 'https://raw.githubusercontent.com/Galvnyz/M365-Assess/main/src/M365-Assess/assets/m365-assess-logo.png'
             LicenseUri   = 'https://github.com/Galvnyz/M365-Assess/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/Galvnyz/M365-Assess'
-            ReleaseNotes = 'v2.9.2 - Polish release. HTML report layout cleanup: ScoringViews gained a section header + tier-coloured % number (#835); Permissions panel relocated from top-of-report into Appendix (#834); sidebar Domains demoted from top-level group to a collapsible sub-tree under Findings & Action (#836). XLSX Compliance Matrix: Horizon column renamed to Sequence; Pass rows now show Done with green color-coding (#840). Fixed: FilterBar position:sticky no longer follows the user past the findings section (#838). BREAKING: -SaveBaseline is now a [switch]; combine with new -BaselineLabel parameter for custom labels. Old -SaveBaseline ''mylabel'' form must migrate to -SaveBaseline -BaselineLabel ''mylabel'' (#809). v2.9.1: hotfix for AutoBaseline + PermissionsPanel render bugs. v2.9.0: Trust Hardening release.'
+            ReleaseNotes = 'v2.9.3 - Big patch covering v2.7.0 closeout + v2.10.0 polish to date. ADDED: FrameworkQuilt redesign (#751/#855) -- adaptive single/multi layout with animated donut score, sortable comparison table, coverage chart, family chart, primary CTA. HideableBlock wrapper for cards/sections in edit mode (#712). Native taxonomy for HIPAA / SOC2 / Essential Eight / SCUBA -- 12 of 14 frameworks now covered (#845 partial). Findings-table column resize + sort with localStorage persist (#846). Design handoff package committed at docs/design/framework-redesign/ (#856). docs/LEVELS.md semantic reference (#844). CHANGED: FilterBar consolidated to single flowing row, density-aware compact mode (#847) -- height drops ~250px to <=120px. CIS M365 v6 sections 4 and 9 added (Microsoft Intune, Microsoft Fabric). Topbar text-size split into A- / A+ controls (#852). FIXED: Appendix Email-auth card always reported 0/N passing for SPF/DKIM (#860). Finding-detail Current value outline now reflects status (refs #674). v2.9.2: Sequence column rename + breaking SaveBaseline switch.'
         }
     }
 }


### PR DESCRIPTION
## Summary

Big patch release covering the v2.7.0 — Deep UX milestone closeout plus the v2.10.0 — Polish & Audits UX work to date. Despite "patch" in the version label, this release ships a substantial new framework-coverage UX (per a Claude Design handoff) and several new capabilities — but **no breaking API changes**, so it stays in the v2.9.x line.

The 3 remaining audit-flavored items (CIS mapping integrity, ISO 27001/27002, per-control narrative content) ship in **v2.10.0** proper, after audit work completes.

## What's in v2.9.3

10 PRs merged since v2.9.2:

| PR | Closes | Notes |
|---|---|---|
| #843 | #751 | Framework families (data-driven taxonomy, 8 frameworks) |
| #850 | #845 partial | Native taxonomy for HIPAA / SOC2 / Essential Eight / SCUBA (12 of 14 covered) |
| #851 | #712 | HideableBlock for any card or section |
| #856 | refs #855 | Design handoff package committed at `docs/design/framework-redesign/` |
| #857 | #855 | **FrameworkQuilt redesign** — adaptive single/multi layout |
| #859 | refs #674 | Current value outline reflects status |
| #861 | #860, #852 | SPF/DKIM appendix predicates + text-size A−/A+ split |
| #862 | #847 | FilterBar consolidation — single-flow + density-aware compact |
| #864 | #844 | Level filter audit (docs/LEVELS.md + structural Pester regression) |
| #865 | #846 | Findings-table column resize + sort |

Plus `docs/LEVELS.md` (new) defining the trust-the-registry semantic for level chips.

See `CHANGELOG.md` v2.9.3 entry for full Added / Changed / Fixed sections.

## Files

- `src/M365-Assess/M365-Assess.psd1` — `ModuleVersion` 2.9.2 → 2.9.3 + new `ReleaseNotes`
- `README.md` — version badge bump
- `CHANGELOG.md` — new `## [2.9.3] - 2026-04-28` section grouped Added / Changed / Fixed

## Verification

Local checks (passed):
- [x] `(Import-PowerShellDataFile -Path './src/M365-Assess/M365-Assess.psd1').ModuleVersion` → `2.9.3`
- [x] `Invoke-Pester -Path './tests/Smoke/PSGallery-Readiness.Tests.ps1','./tests/Consistency'` — 34/34 pass

**Live tenant verification:** each merged PR in this release was individually live-tested by the user against a real tenant before merge. Per `.claude/rules/releases.md` the version-bump PR also gets a final pass before tagging — please confirm with one more end-to-end run before approving the merge.

## Merge → tag → publish flow

Per `.claude/rules/releases.md`:

1. Merge this PR
2. I'll create the GitHub release tag `v2.9.3` after explicit approval
3. The tag triggers `release.yml`, which publishes to PSGallery

🤖 Generated with [Claude Code](https://claude.com/claude-code)