### PR TITLE
feat(taxonomy): document MITRE / STIG fallback + regression-guard taxonomy decisions (closes #845)

### DIFF
--- a/docs/SCORING.md
+++ b/docs/SCORING.md
@@ -89,6 +89,34 @@ A single composite would force these conversations to reverse-engineer the weigh
 
 ---
 
+## Framework taxonomy strategies (#751, #845)
+
+Each supported framework's expanded panel groups checks by the framework's own native control families/sections — CIS sections, CMMC families, NIST CSF functions, ISO clauses, etc. — rather than by M365-Assess internal domains. Every framework JSON in `src/M365-Assess/controls/frameworks/*.json` either declares a `groupBy` strategy + `groups` map, OR declares `taxonomyDecision: "domain-fallback"` with a documented reason.
+
+The strategy mapping is enumerated in `GROUP_EXTRACTORS` (`src/M365-Assess/assets/report-app.jsx`):
+
+| Strategy | Frameworks using it | controlId shape | Group key |
+|---|---|---|---|
+| `section-prefix` | CIS M365 v6, CIS Controls v8, PCI DSS v4 | `5.2.2.5` | leading numeric section (`5`) |
+| `family-letter-prefix` | CMMC, NIST 800-53 r5, FedRAMP r5 | `AC.L2-3.1.1`, `AC-1` | letter family (`AC`) |
+| `dot-prefix` | NIST CSF 2.0 | `ID.AM-1`, `PR.AC-1` | function letters before first dot (`ID`) |
+| `iso-clause-prefix` | ISO 27001, ISO 27002 | `A.5.1.1` | leading clause (`A.5`) |
+| `hipaa-section` | HIPAA Security Rule | `164.308(a)(1)(ii)(A)` | subsection number (`308`) |
+| `soc2-tsc-prefix` | SOC 2 Trust Services Criteria | `CC1.1`, `PI1.2-POF1` | TSC category — longest-match wins (`CC`/`PI` before `P`) |
+| `essential-eight-practice` | ASD Essential Eight | `ML1-P3` | practice number (`3`) — maturity level intentionally NOT the grouping |
+| `scuba-service` | CISA SCUBA | `MS.AAD.1.1v1` | service prefix (`MS.AAD`) |
+
+### Deliberate fallbacks (no native taxonomy)
+
+| Framework | Reason |
+|---|---|
+| **MITRE ATT&CK** | Technique IDs (`T1078.004`) don't encode tactics. M365-Assess checks map to 100+ techniques each (semicolon-separated controlIds), and a single technique can serve multiple tactics — any per-check tactic grouping is ambiguous. To enable: ship a technique → tactic lookup table + decide how to handle multi-tactic techniques. |
+| **DISA STIG** | Rule IDs (`V-NNNNNN`) are opaque — no product, category, or severity encoded. CAT-I/II/III severity exists in the published XCCDF XML but is not carried per-check in the registry's framework mapping. To enable: extend the registry to carry per-check STIG severity, or maintain a rule-ID → category lookup. |
+
+Both are flagged in their JSON via `taxonomyDecision: "domain-fallback"` + `taxonomyReason`. The Pester regression in `tests/Behavior/Framework-Taxonomy.Tests.ps1` enforces that every framework declares either `groupBy` or `taxonomyDecision: "domain-fallback"` so a future maintainer can't silently drop a taxonomy without an explicit decision.
+
+---
+
 ## Where the math lives
 
 - `src/M365-Assess/assets/report-app.jsx` -- the `SCORING_VIEWS` array near the top defines each view; helpers `computeSecurityRiskScore`, `computeComplianceReadinessScore`, `computeLicenseAdjustedScore`, `getQuickWins`, `getRequiresLicensing`, `getManualValidation` are pure functions of `FINDINGS`.

--- a/src/M365-Assess/controls/frameworks/mitre-attack.json
+++ b/src/M365-Assess/controls/frameworks/mitre-attack.json
@@ -67,5 +67,7 @@
     }
   },
   "controlIdFormat": "T{number}[.{sub}]",
-  "note": "totalControls reflects techniques referenced in CheckID mappings, not the full ATT&CK matrix (356+ techniques)."
+  "note": "totalControls reflects techniques referenced in CheckID mappings, not the full ATT&CK matrix (356+ techniques).",
+  "taxonomyDecision": "domain-fallback",
+  "taxonomyReason": "ATT&CK technique IDs (e.g. T1078.004) do not encode tactics. Many M365-Assess checks map to 100+ techniques each (semicolon-separated), and a single technique can serve multiple tactics — making any per-check tactic grouping ambiguous. Native taxonomy intentionally not provided; report falls back to M365-Assess domain breakdown. To enable: ship a technique → tactic lookup table and decide how to handle multi-tactic techniques. See issue #845 + docs/SCORING.md."
 }

--- a/src/M365-Assess/controls/frameworks/stig.json
+++ b/src/M365-Assess/controls/frameworks/stig.json
@@ -36,5 +36,7 @@
       "color": "#C4B5FD"
     }
   },
-  "controlIdFormat": "V-{number}"
+  "controlIdFormat": "V-{number}",
+  "taxonomyDecision": "domain-fallback",
+  "taxonomyReason": "STIG rule IDs (V-NNNNNN) are opaque — they don't encode product, category, or severity. CAT-I/II/III severity is published in the STIG XCCDF XML but not carried per-check in the registry's framework mapping. Native taxonomy intentionally not provided; report falls back to M365-Assess domain breakdown. To enable: extend the registry to carry per-check STIG severity, or maintain a rule-ID → category lookup. See issue #845 + docs/SCORING.md."
 }

--- a/tests/Behavior/Framework-Taxonomy.Tests.ps1
+++ b/tests/Behavior/Framework-Taxonomy.Tests.ps1
@@ -1,0 +1,69 @@
+# Issue #845: every framework JSON in controls/frameworks/ must declare either
+# a native taxonomy (groupBy + groups) OR an explicit fallback decision
+# (taxonomyDecision: "domain-fallback" + taxonomyReason). This regression
+# guards against a maintainer silently dropping a taxonomy without an
+# explicit decision — the React FrameworkQuilt panel falls back to a domain
+# breakdown when groupBy is missing, but that fallback should be deliberate
+# and documented, not accidental.
+
+BeforeAll {
+    $script:frameworksDir = "$PSScriptRoot/../../src/M365-Assess/controls/frameworks"
+    # Aliases for the "groups" map — kept in sync with Import-FrameworkDefinitions.ps1
+    # (issue #751: frameworks express their group taxonomy under a domain-natural
+    # key like 'sections' for CIS, 'controls' for CIS Controls v8, 'families' for
+    # CMMC, 'requirements' for PCI-DSS, etc. — all alias to 'groups' at load time).
+    $script:groupsAliases = @('groups', 'sections', 'controls', 'families', 'requirements', 'clauses', 'functions')
+    $script:frameworks = @()
+    foreach ($f in Get-ChildItem -Path $script:frameworksDir -Filter '*.json') {
+        $j = Get-Content -Raw -Path $f.FullName | ConvertFrom-Json
+        $hasGroupsMap = $false
+        foreach ($alias in $script:groupsAliases) {
+            if ($j.PSObject.Properties[$alias]) { $hasGroupsMap = $true; break }
+        }
+        $script:frameworks += [pscustomobject]@{
+            File             = $f.Name
+            FrameworkId      = $j.frameworkId
+            HasGroupBy       = [bool]$j.PSObject.Properties['groupBy']
+            HasGroups        = $hasGroupsMap
+            HasFallbackFlag  = ($j.PSObject.Properties['taxonomyDecision'] -and $j.taxonomyDecision -eq 'domain-fallback')
+            HasFallbackReason = ($j.PSObject.Properties['taxonomyReason'] -and -not [string]::IsNullOrWhiteSpace($j.taxonomyReason))
+        }
+    }
+}
+
+Describe 'Framework taxonomy declarations (#845)' {
+    It 'every framework declares either native taxonomy OR an explicit fallback' {
+        foreach ($fw in $script:frameworks) {
+            $hasNative   = $fw.HasGroupBy -and $fw.HasGroups
+            $hasFallback = $fw.HasFallbackFlag -and $fw.HasFallbackReason
+            ($hasNative -or $hasFallback) |
+                Should -BeTrue -Because "$($fw.File) ($($fw.FrameworkId)) must declare either groupBy + groups OR taxonomyDecision: 'domain-fallback' + taxonomyReason — see docs/SCORING.md"
+        }
+    }
+
+    It 'fallback frameworks include a non-empty taxonomyReason' {
+        $fallbacks = $script:frameworks | Where-Object { $_.HasFallbackFlag }
+        foreach ($fw in $fallbacks) {
+            $fw.HasFallbackReason |
+                Should -BeTrue -Because "$($fw.File) declares taxonomyDecision: 'domain-fallback' but is missing taxonomyReason — explain WHY native taxonomy was rejected"
+        }
+    }
+
+    It 'frameworks with groupBy include a non-empty groups map' {
+        $native = $script:frameworks | Where-Object { $_.HasGroupBy }
+        foreach ($fw in $native) {
+            $fw.HasGroups |
+                Should -BeTrue -Because "$($fw.File) declares groupBy but no groups (or sections) map — the React panel renders empty rows"
+        }
+    }
+
+    It 'reports current taxonomy coverage (informational)' {
+        $total    = $script:frameworks.Count
+        $native   = ($script:frameworks | Where-Object { $_.HasGroupBy -and $_.HasGroups }).Count
+        $fallback = ($script:frameworks | Where-Object { $_.HasFallbackFlag }).Count
+        Write-Host ("    [INFO] Total frameworks:   $total")
+        Write-Host ("    [INFO] Native taxonomy:    $native")
+        Write-Host ("    [INFO] Domain fallback:    $fallback")
+        ($native + $fallback) | Should -Be $total
+    }
+}


### PR DESCRIPTION
## Summary

Closes out #845 by formalising the **deliberate** fallback decision for the two frameworks that can't get native taxonomy without significant new infrastructure (MITRE ATT&CK + DISA STIG), and adds a regression so future maintainers can't silently drop a taxonomy.

## State after this PR

| Frameworks (15 total) | Native taxonomy | Domain fallback |
|---|---|---|
| count | 13 | 2 |
| list | CIS M365 v6, CIS Controls v8, CMMC, NIST 800-53 r5, NIST CSF 2.0, ISO 27001, ISO 27002, PCI DSS v4, FedRAMP r5, HIPAA, SOC 2 TSC, Essential Eight, CISA SCUBA | MITRE ATT&CK, DISA STIG |

## Why MITRE + STIG are deliberate fallbacks (not oversights)

- **MITRE ATT&CK** — technique IDs (`T1078.004`) don't encode tactics. M365-Assess checks map to 100+ techniques each (semicolon-separated controlIds), and a single technique can serve multiple tactics — any per-check tactic grouping is ambiguous. To enable: ship a technique → tactic lookup + decide how to handle multi-tactic techniques.
- **DISA STIG** — rule IDs (`V-NNNNNN`) are opaque. CAT-I/II/III severity exists in the XCCDF XML but isn't carried per-check in the registry. To enable: extend registry with per-check severity, or maintain a rule-ID lookup.

Both flagged via `taxonomyDecision: "domain-fallback"` + `taxonomyReason` so the deliberate decision is visible to maintainers.

## Files

- `src/M365-Assess/controls/frameworks/mitre-attack.json` — adds `taxonomyDecision` + `taxonomyReason`
- `src/M365-Assess/controls/frameworks/stig.json` — adds `taxonomyDecision` + `taxonomyReason`
- `docs/SCORING.md` — new "Framework taxonomy strategies" section with the full strategy table (8 strategies + 2 fallbacks documented)
- `tests/Behavior/Framework-Taxonomy.Tests.ps1` — Pester regression asserting every framework declares one or the other, plus always-runs informational counts

## Test plan

- [x] `Invoke-Pester ./tests/Behavior/Framework-Taxonomy.Tests.ps1` — 4 passed
- [x] Full Pester suite — 2299 passed / 0 failed / 3 expected skips
- [x] CI green
- [x] Live-tenant verification — MITRE + STIG framework panels still render (domain fallback is unchanged behaviour)

## What this PR does NOT do

- No registry mapping changes
- No code changes in `report-app.jsx` (the React side already falls back to domain breakdown when groupBy is missing — this PR just documents that decision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)