### PR TITLE
chore(release): bump to v2.10.1 (collector data-quality patch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to M365 Assess are documented here. This project uses [Conve
 
 ## [Unreleased]
 
+## [2.10.1] - 2026-04-30
+
+Patch release. Four collector data-quality bugs surfaced during v2.10.0 live-test, plus the #845 taxonomy closeout. No breaking API changes. Sets the stage for v2.11.0 — Data Quality & Accuracy milestone, which covers the broader collector audit work surfaced this sprint (#878 SSPR semantic mismatch, #879 remediation-path rot, #886 PIM logic bug, #888 break-glass duplication, #884 Review/Unknown/Skipped audit).
+
+### Fixed
+- **ENTRA-ENTAPP-020 false-positives Microsoft Graph PowerShell SDK (#880)** — the Microsoft first-party allowlist filtered SPs by a single owner-tenant GUID; Microsoft actually publishes first-party apps from at least 4 tenants. Empirical observation surfaced both Microsoft Corp (`72f988bf...`) and the dedicated Graph Command Line Tools tenant (`cdc5aeea-15c5-4db6-b079-fcadd2505dc2`) as sources missing from the allowlist. Now covers all 4 known owner tenants. Long-term hardening (AppId-based allowlist) tracked in #887
+- **ENTRA-PIM-* false-negatives on E5 Developer + other E5 variants (#881)** — license detection matched against a hardcoded list of 4 SkuIds, missing Developer Pack, education tiers, government tiers, and partner SKUs. Switched to detection by `AAD_PREMIUM_P2` service plan ID (`eec0eb4f-6444-4f95-aba0-50c24d67f998`), which all P2-bundling SKUs resolve to. Same pattern `Get-TeamsSecurityConfig.ps1` already uses for Teams licensing
+- **ENTRA-ADMIN-003 break-glass detail hides matched UPNs in Review state (#882)** — listed account names in the Pass branch but dropped them in the Review branch, the more important branch for the user. Both branches now list matched UPNs + `[DISABLED]` tag, with displayName fallback when UPN is null
+- **SPO-AUTH-001 always returned "Not available via API" Review (#883)** — `Get-SharePointSecurityConfig.ps1` read `$spoSettings['legacyAuthProtocolsEnabled']` but Graph v1.0 `sharepointSettings` exposes the property as `isLegacyAuthProtocolsEnabled` (boolean properties on this resource use the `is-` prefix). Wrong key returned `$null` in every tenant; the check now correctly reports Pass/Fail
+- **MITRE / STIG taxonomy decision documented + regression-guarded (#845, shipped via #877)** — every framework JSON in `controls/frameworks/` now declares either native taxonomy (`groupBy` + groups map) OR an explicit fallback decision (`taxonomyDecision: "domain-fallback"` + `taxonomyReason`). New Pester regression in `tests/Behavior/Framework-Taxonomy.Tests.ps1` enforces it. 13 frameworks have native taxonomy; MITRE ATT&CK + STIG declared deliberate domain-fallback (technique IDs / opaque rule IDs don't carry tactic / category metadata)
+
 ## [2.10.0] - 2026-04-29
 
 The **Polish & Audits** milestone — 10 of 10 issues closed. Three audit-flavored research artifacts (ISO 27001/27002, CIS M365 v6.0.1, per-control narrative content) plus the long-standing SharePoint prefix-bug in the report's "Why It Matters" renderer. No breaking API changes.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [![Coverage](https://img.shields.io/badge/coverage-check%20CI-informational)](https://github.com/Galvnyz/M365-Assess/actions/workflows/ci.yml)
 [![PowerShell 7.x](https://img.shields.io/badge/PowerShell-7.x-blue?logo=powershell&logoColor=white)](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows)
 [![Read-Only](https://img.shields.io/badge/Operations-Read--Only-brightgreen)](.)
-[![Version](https://img.shields.io/badge/version-2.10.0-blue)](.)
+[![Version](https://img.shields.io/badge/version-2.10.1-blue)](.)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 </div>

--- a/src/M365-Assess/M365-Assess.psd1
+++ b/src/M365-Assess/M365-Assess.psd1
@@ -3,7 +3,7 @@
     # Generated: 2026-03-08
 
     RootModule        = 'M365-Assess.psm1'
-    ModuleVersion     = '2.10.0'
+    ModuleVersion     = '2.10.1'
     GUID              = 'f7e3b2a1-4c5d-6e8f-9a0b-1c2d3e4f5a6b'
     Author            = 'Galvnyz'
     CompanyName       = 'Community'
@@ -242,7 +242,7 @@
             IconUri      = 'https://raw.githubusercontent.com/Galvnyz/M365-Assess/main/src/M365-Assess/assets/m365-assess-logo.png'
             LicenseUri   = 'https://github.com/Galvnyz/M365-Assess/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/Galvnyz/M365-Assess'
-            ReleaseNotes = 'v2.10.0 - Polish & Audits milestone (10 of 10 issues closed). ADDED: Per-prefix narrative content for the report finding-detail "Why It Matters" callout (#854) -- expanded coverage from ~22 to ~70 prefix families across SPO/EXO/DNS/DEFENDER/ENTRA/CA/INTUNE/COMPLIANCE/TEAMS/POWERBI/PBI/FORMS, fixing a long-standing prefix-bug where every SharePoint finding fell through to the generic fallback. New docs/research/narrative-content-sources.md captures source-authority by family (Microsoft Learn, CIS M365 v6.0.1, NIST 800-63B/800-53 r5, CISA, M3AAWG). ISO 27001 vs 27002 mapping audit (#858) -- new docs/research/iso-27001-vs-27002-audit.md plus iso-27002.json framework definition; identifies the upstream SCF conflation (1020/1020 identical mappings) and recommends the upstream-fix path. New tests/Behavior/Iso-27001-27002-Mapping-Audit.Tests.ps1 with skip-until-upstream divergence assertion + always-runs informational stats. CIS M365 v6.0.1 mapping audit (#848) -- new docs/research/cis-m365-v6-audit.md catalogs section-9 POWERBI-/PBI- merge-artifact duplicates (11/11 clusters) + section-4 EXO-* labeling anomaly; recommends upstream SCF fixes. New tests/Behavior/Cis-M365-v6-Mapping-Audit.Tests.ps1 with skip-until-upstream regressions + informational stats. Follow-up tracker #871 monitors when upstream lands. CHANGED: None (audit-flavored milestone). FIXED: SPO-/SHAREPOINT- prefix matching bug in whyItMatters() (#854) -- chain checked SHAREPOINT- but registry uses SPO-; every SharePoint finding hit the generic fallback. Now matches correctly with sub-prefix specificity (SHARING/B2B, SITE, SCRIPT/SWAY, SYNC/OD, etc.).'
+            ReleaseNotes = 'v2.10.1 - Patch release: four collector data-quality bugs surfaced during v2.10.0 live test. FIXED: ENTRA-ENTAPP-020 (#880) extended Microsoft first-party allowlist from 1 to 4 known owner-tenant GUIDs (Services + Corp + ea8a4392 + Graph CLI Tools cdc5aeea); Connect-MgGraph SP no longer false-positives as impersonator. ENTRA-PIM-* license detection (#881) now uses AAD_PREMIUM_P2 service plan ID instead of hardcoded SkuIds; catches every E5 variant including Developer Pack, education, government, partner SKUs. ENTRA-ADMIN-003 break-glass detail (#882) now lists matched UPNs + [DISABLED] tag in BOTH Pass and Review branches (was only in Pass), with displayName fallback when UPN is null. SPO-AUTH-001 Legacy Auth Protocols (#883) typo fix: now reads isLegacyAuthProtocolsEnabled (Graph v1.0 property uses is- prefix); previously falsely reported "Not available via API" Review in every tenant. PLUS: also includes #845 closeout (MITRE/STIG taxonomy decision documented + regression test) shipped via #877. Sets the stage for v2.11.0 -- Data Quality & Accuracy milestone covering broader collector audit work surfaced this sprint.'
         }
     }
 }


### PR DESCRIPTION
## Summary

Patch release covering 4 collector data-quality bugs surfaced during v2.10.0 live-test, plus the #845 taxonomy closeout. **No breaking API changes.**

### Fixed
- **#880** — ENTRA-ENTAPP-020 first-party allowlist extended (4 owner-tenant GUIDs). Connect-MgGraph SP no longer false-positives as impersonator
- **#881** — ENTRA-PIM-* license detection now uses AAD_PREMIUM_P2 service plan ID (catches E5 Developer Pack, education, government, partner SKUs)
- **#882** — ENTRA-ADMIN-003 break-glass detail lists matched UPNs + `[DISABLED]` tag in both branches, with displayName fallback when UPN is null
- **#883** — SPO-AUTH-001 typo fix: `isLegacyAuthProtocolsEnabled` (Graph v1.0 `is-` prefix); was falsely reporting "Not available via API" in every tenant
- **#845** (shipped via #877) — Every framework JSON declares either native taxonomy or explicit `domain-fallback`; Pester regression enforces it

## What's NEXT (not in this release)

The v2.10.1 fixes are the easy hotfix-class bugs. The harder data-quality work goes into **v2.11.0 — Data Quality & Accuracy** milestone:
- #878 SSPR semantic mismatch
- #879 remediation-path rot (systemic UI-path drift across all collectors)
- #886 PIM logic bug (only sees PIM-scheduled assignments, blind to direct GAs)
- #887 first-party AppId-based allowlist hardening
- #888 break-glass detection duplication + threshold
- #884 Review / Unknown / Skipped audit
- #863 finding-detail panel redesign
- #871 ISO 27001/27002 un-skip when upstream lands

## Version locations updated

- `src/M365-Assess/M365-Assess.psd1` (ModuleVersion `2.10.0` → `2.10.1` + ReleaseNotes)
- `README.md` (badge)
- `CHANGELOG.md` (new `[2.10.1]` section)

## Hard precondition before merge

Per `.claude/rules/releases.md`, **a human MUST run an end-to-end live tenant assessment** and validate the output before this PR merges. CI green is necessary but not sufficient. Specifically:

- [x] `Invoke-M365Assessment -ProfileName <your-profile> -AutoBaseline` runs to completion
- [x] HTML report opens cleanly
- [x] Spot-check the 4 fixes in the new report:
  - [ ] ENTRA-ENTAPP-020 → No foreign apps impersonate (Pass)
  - [ ] ENTRA-PIM-* → no longer "Not licensed" Review on E5 Developer
  - [ ] ENTRA-ADMIN-003 → break-glass row lists matched UPN(s)
  - [ ] SPO-AUTH-001 → real Pass/Fail (not "Not available via API")
- [ ] XLSX matrix Title row shows `M365-Assess v2.10.1`
- [ ] `_Assessment-Provenance.json` shows `toolVersion: "2.10.1"`

After live test: merge → tag `v2.10.1` → `release.yml` publishes to PSGallery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)