### PR TITLE
test+audit: Stryker break-glass coverage + Review/Unknown/Skipped lock-down (closes #884 #891)

### DIFF
--- a/docs/research/review-status-audit.md
+++ b/docs/research/review-status-audit.md
@@ -1,0 +1,101 @@
+# Audit: Review / Unknown / Skipped status emissions
+
+Surfaced by issue #884. After PR #885 (#883 SPO-AUTH-001) discovered a check that ALWAYS returned `Review` due to a single-character property-name typo, the question became: **how many other checks return `Review` / `Unknown` / `Skipped` for reasons that look like "we couldn't measure" but are actually "the collector has a bug"?**
+
+## Empirical scan
+
+Snapshot taken 2026-04-30 from `src/M365-Assess/**/*.ps1`:
+
+```powershell
+Get-ChildItem -Path 'src/M365-Assess' -Recurse -Filter '*.ps1' |
+    Select-String -Pattern "Status\s*=\s*'(Review|Unknown|Skipped)'"
+```
+
+| Status | Emissions | What it should mean |
+|---|---|---|
+| `Review` | 68 | Data was collected but a human needs to interpret the result. |
+| `Skipped` | 28 | The check did not run (license-gated, permission-gated, or env-not-applicable). |
+| `Unknown` | 1 | Data could not be collected; this is different from "Skipped". |
+| **Total** | **97** | |
+
+Per-collector breakdown:
+
+| Collector | Review | Skipped | Unknown |
+|---|---|---|---|
+| `Entra/EntraUserGroupChecks.ps1` | 0 | 22 | 0 |
+| `Entra/EntraPasswordAuthChecks.ps1` | 7 | 0 | 0 |
+| `Entra/EntraAdminRoleChecks.ps1` | 5 | 0 | 1 |
+| `Collaboration/Get-SharePointSecurityConfig.ps1` | 4 | 0 | 0 |
+| `Exchange-Online/Get-DnsSecurityConfig.ps1` | 4 | 0 | 0 |
+| `Exchange-Online/Get-ExoSecurityConfig.ps1` | 5 | 0 | 0 |
+| `Collaboration/Get-TeamsSecurityConfig.ps1` | 2 | 0 | 0 |
+| `Entra/Get-CASecurityConfig.ps1` | 2 | 0 | 0 |
+| various Intune, Compliance, Defender collectors | ~30 | ~6 | 0 |
+
+(Full per-site table available via `Get-ChildItem -Path 'src/M365-Assess' -Recurse -Filter '*.ps1' | Select-String -Pattern "Status\s*=\s*'(Review|Unknown|Skipped)'"`. Snapshot is intentionally not committed — it would rot quickly.)
+
+## Triage classification
+
+For each emission site, the question is one of three things:
+
+| Class | Meaning | Action |
+|---|---|---|
+| **Genuine limitation** | The data truly isn't measurable via API (paper-trail process, manual attestation, license-gated and we correctly detected the gap). | Leave as-is. Surface clearly to user via CurrentValue. May feed into the attestation flow (#875). |
+| **Collector bug** | API exposes the data but the collector queries the wrong field, the wrong endpoint, or doesn't handle the response correctly. | File as bug, fix in collector. |
+| **Triage pending** | Need to investigate the specific check before classifying. | Schedule into ongoing v2.11.0 work. |
+
+## Known examples
+
+### Confirmed bugs (since fixed)
+
+- **SPO-AUTH-001** (#883) — collector queried `legacyAuthProtocolsEnabled` when the v1.0 Graph property is `isLegacyAuthProtocolsEnabled`. Always returned Review with "Not available via API". Fixed in v2.10.1.
+- **ENTRA-PIM-001** (#886) — collector queried only PIM-managed schedule instances, blind to direct GA assignments. Tenants without PIM onboarded passed incorrectly. Fixed via PR #890.
+
+### Confirmed genuine limitations
+
+- **`EntraUserGroupChecks.ps1` Skipped emissions (22 sites)** — most are conditional on Graph permissions or specific service-plan licensing. Skipped is the correct status for those scenarios.
+- **EXO checks that depend on Connect-ExchangeOnline** — when EXO module isn't connected, checks Skip. Correct.
+
+### Triage pending (representative — not exhaustive)
+
+- `EntraPasswordAuthChecks.ps1` — 7 Review emissions; some may be the same shape as ENTRA-SSPR-001 (semantic mismatch with upstream registry name) — see #878.
+- `Exchange-Online/Get-DnsSecurityConfig.ps1` — 4 Review emissions; verify whether they're genuinely manual-validation or if a Graph endpoint would resolve them.
+- `Get-CASecurityConfig.ps1` — 2 Review emissions; given the CA admin-center reorg + #879 path rot, worth confirming the collector's data path.
+
+## Lock-down regression
+
+`tests/Behavior/Status-Emission-Audit.Tests.ps1` asserts the count of Review / Unknown / Skipped emissions stays at or below the current ceiling (68 / 28 / 1 = 97 total). When a new emission is added the test fails, forcing the contributor to:
+
+1. Justify the new emission (genuine limitation? collector bug?)
+2. Update this doc to add the new site to the audit catalogue
+3. Bump the ceiling in the test
+
+Without this guardrail, "I couldn't measure it, returning Review" silently accumulates in the codebase. The lock-down doesn't fix existing emissions — those are the ongoing audit work. It prevents the surface from growing unaudited.
+
+## Workflow for individual audits
+
+When a contributor (or a reader of customer reports) flags a specific Review/Unknown/Skipped emission:
+
+1. **Reproduce**: identify the CheckId, the collector file/line, and the Graph endpoint being queried.
+2. **Investigate**: does Graph (v1.0 or beta) expose the data? Run the query manually against a test tenant.
+3. **Classify**:
+   - If the property exists and the collector queries it incorrectly → **Collector bug**, file as bug issue, fix.
+   - If the property exists but only with a different scope/license that we don't currently require → consider whether to add the scope/license guard, treat as Skipped.
+   - If no Graph endpoint exists → **Genuine limitation**, document clearly.
+4. **Update this doc**: add the audited check to the "Confirmed bugs" or "Confirmed genuine limitations" section.
+5. **If the emission count drops** (a Review converted to Pass/Fail): update the lock-down ceiling in the regression test.
+
+## Out of scope
+
+Per-check exhaustive triage of all 97 emissions is multi-day content work. This PR delivers:
+- The audit catalogue + classification framework (this doc)
+- The lock-down Pester regression
+- A handful of representative known-bug + known-limitation examples
+
+Per-check triage of the remaining ~85 emissions is ongoing v2.11.0 (or follow-up milestone) work, filed as bug issues as they're triaged.
+
+## Sources
+
+- `src/M365-Assess/**/*.ps1` — empirical scan
+- `docs/CHECK-STATUS-MODEL.md` — canonical status-value semantics (defines what each status MEANS)
+- Issue #884 (this audit) + #875 (interactive attestation, downstream consumer of the "genuine limitation" subset)

--- a/tests/Behavior/Status-Emission-Audit.Tests.ps1
+++ b/tests/Behavior/Status-Emission-Audit.Tests.ps1
@@ -1,0 +1,71 @@
+# Issue #884: lock-down regression preventing silent growth in Review /
+# Unknown / Skipped status emissions across collectors. The full audit
+# catalogue + classification framework lives at
+# docs/research/review-status-audit.md.
+#
+# When a contributor adds a new emission site, this test fails, forcing
+# them to:
+#   1. Justify the new emission in the PR description (genuine limitation
+#      vs. collector bug?)
+#   2. Add the new site to the audit catalogue in
+#      docs/research/review-status-audit.md
+#   3. Raise the ceiling in this test
+#
+# Without this guardrail, "I couldn't measure it, returning Review"
+# silently accumulates and erodes the report's credibility.
+#
+# Ceiling values are the snapshot taken 2026-04-30. Adjust ONLY when
+# the audit doc has been updated to reflect the new state.
+
+BeforeAll {
+    $script:srcRoot = "$PSScriptRoot/../../src/M365-Assess"
+    $script:emissionPattern = "Status\s*=\s*'(Review|Unknown|Skipped)'"
+
+    $script:emissions = Get-ChildItem -Path $script:srcRoot -Recurse -Filter '*.ps1' |
+        Select-String -Pattern $script:emissionPattern |
+        ForEach-Object {
+            if ($_.Line -match "'(Review|Unknown|Skipped)'") {
+                [pscustomobject]@{
+                    File   = $_.Path
+                    Line   = $_.LineNumber
+                    Status = $Matches[1]
+                }
+            }
+        }
+
+    $script:counts = @{
+        Review  = ($script:emissions | Where-Object Status -EQ 'Review').Count
+        Skipped = ($script:emissions | Where-Object Status -EQ 'Skipped').Count
+        Unknown = ($script:emissions | Where-Object Status -EQ 'Unknown').Count
+    }
+}
+
+Describe 'Review/Unknown/Skipped emission count lock-down (#884)' {
+    # Ceiling values capture the audited state as of 2026-04-30. Raising
+    # these requires a corresponding entry in docs/research/review-status-
+    # audit.md classifying the new emission as genuine-limitation vs.
+    # collector-bug.
+
+    It "Review emissions stay at or below the audited ceiling (68)" {
+        $script:counts.Review |
+            Should -BeLessOrEqual 68 -Because 'a new Review emission was added without updating docs/research/review-status-audit.md — see issue #884'
+    }
+
+    It "Skipped emissions stay at or below the audited ceiling (28)" {
+        $script:counts.Skipped |
+            Should -BeLessOrEqual 28 -Because 'a new Skipped emission was added without updating docs/research/review-status-audit.md — see issue #884'
+    }
+
+    It "Unknown emissions stay at or below the audited ceiling (1)" {
+        $script:counts.Unknown |
+            Should -BeLessOrEqual 1 -Because 'a new Unknown emission was added without updating docs/research/review-status-audit.md — see issue #884'
+    }
+
+    It 'reports current emission counts for visibility (informational)' {
+        Write-Host ("    [INFO] Review:  $($script:counts.Review) / 68")
+        Write-Host ("    [INFO] Skipped: $($script:counts.Skipped) / 28")
+        Write-Host ("    [INFO] Unknown: $($script:counts.Unknown) / 1")
+        Write-Host ("    [INFO] Total:   $($script:emissions.Count)")
+        $script:emissions.Count | Should -BeGreaterThan 0
+    }
+}

--- a/tests/Security/Get-StrykerIncidentReadiness.Tests.ps1
+++ b/tests/Security/Get-StrykerIncidentReadiness.Tests.ps1
@@ -8,6 +8,13 @@ Describe 'Get-StrykerIncidentReadiness' {
 
         function Get-MgContext { return @{ TenantId = 'test-tenant-id'; AuthType = 'Delegated' } }
         function global:Update-CheckProgress { param($CheckId, $Setting, $Status) }
+        # Stub Mg cmdlets so Pester's Mock can find them even when
+        # Microsoft.Graph isn't imported (local runs); CI has them anyway.
+        function Get-MgDirectoryRole { param($Filter) }
+        function Get-MgDirectoryRoleMemberAsUser { param($DirectoryRoleId, [switch]$All) }
+        function Get-MgIdentityConditionalAccessPolicy { param([switch]$All) }
+        function Get-MgServicePrincipal { param($Filter, [switch]$All) }
+        function Invoke-MgGraphRequest { param($Method, $Uri, $Body, $ErrorAction) }
 
         Mock Import-Module { }
 
@@ -82,4 +89,183 @@ Describe 'Get-StrykerIncidentReadiness' {
     AfterAll {
         Remove-Item Function:\Update-CheckProgress -ErrorAction SilentlyContinue
     }
+}
+
+# Issue #891: dedicated tests for ENTRA-BREAKGLASS-001 threshold logic.
+# After #888 consolidation, the threshold became:
+#   0 detected            -> Fail
+#   1 detected            -> Warning (single point of failure)
+#   2+ high confidence    -> Pass (name match)
+#   2+ medium confidence  -> Warning (CA-exclusion-only)
+# Each scenario re-mocks Get-MgDirectoryRoleMemberAsUser + (sometimes) the
+# CA policy excludes, then dot-sources the collector and inspects the
+# emitted ENTRA-BREAKGLASS-001 setting.
+
+Describe 'ENTRA-BREAKGLASS-001 threshold (0 break-glass)' {
+    BeforeAll {
+        . "$PSScriptRoot/../../src/M365-Assess/Orchestrator/AssessmentHelpers.ps1"
+        function Get-MgContext { return @{ TenantId = 'test-tenant-id'; AuthType = 'Delegated' } }
+        function global:Update-CheckProgress { param($CheckId, $Setting, $Status) }
+        # Stub Mg cmdlets so Pester's Mock can find them even when
+        # Microsoft.Graph isn't imported (local runs); CI has them anyway.
+        function Get-MgDirectoryRole { param($Filter) }
+        function Get-MgDirectoryRoleMemberAsUser { param($DirectoryRoleId, [switch]$All) }
+        function Get-MgIdentityConditionalAccessPolicy { param([switch]$All) }
+        function Get-MgServicePrincipal { param($Filter, [switch]$All) }
+        function Invoke-MgGraphRequest { param($Method, $Uri, $Body, $ErrorAction) }
+        Mock Import-Module { }
+        Mock Get-MgDirectoryRole {
+            @([PSCustomObject]@{ Id = 'ga-role-id'; DisplayName = 'Global Administrator'; RoleTemplateId = '62e90394-69f5-4237-9190-012177145e10' })
+        }
+        Mock Get-MgDirectoryRoleMemberAsUser {
+            @(
+                [PSCustomObject]@{ Id = 'user-1'; DisplayName = 'Daren Maranya';   UserPrincipalName = 'daren@contoso.com'; SignInActivity = @{ LastSignInDateTime = (Get-Date).AddDays(-1); LastNonInteractiveSignInDateTime = (Get-Date).AddDays(-1) }; OnPremisesSyncEnabled = $false }
+                [PSCustomObject]@{ Id = 'user-2'; DisplayName = 'Admin Account';    UserPrincipalName = 'admin@contoso.com'; SignInActivity = @{ LastSignInDateTime = (Get-Date).AddDays(-1); LastNonInteractiveSignInDateTime = (Get-Date).AddDays(-1) }; OnPremisesSyncEnabled = $false }
+            )
+        }
+        Mock Get-MgIdentityConditionalAccessPolicy { @() }
+        Mock Invoke-MgGraphRequest { @{ value = @() } }
+        Mock Get-MgServicePrincipal { @() }
+        . "$PSScriptRoot/../../src/M365-Assess/Security/Get-StrykerIncidentReadiness.ps1"
+    }
+
+    It 'is Fail when no break-glass-named admin exists' {
+        $bg = $settings | Where-Object { $_.CheckId -like 'ENTRA-BREAKGLASS-001*' -and $_.Setting -eq 'Break-glass emergency access account' } | Select-Object -First 1
+        $bg | Should -Not -BeNullOrEmpty
+        $bg.Status | Should -Be 'Fail'
+        $bg.CurrentValue | Should -Match 'No break-glass account detected'
+    }
+
+    AfterAll { Remove-Item Function:\Update-CheckProgress -ErrorAction SilentlyContinue }
+}
+
+Describe 'ENTRA-BREAKGLASS-001 threshold (1 break-glass — single point of failure)' {
+    BeforeAll {
+        . "$PSScriptRoot/../../src/M365-Assess/Orchestrator/AssessmentHelpers.ps1"
+        function Get-MgContext { return @{ TenantId = 'test-tenant-id'; AuthType = 'Delegated' } }
+        function global:Update-CheckProgress { param($CheckId, $Setting, $Status) }
+        # Stub Mg cmdlets so Pester's Mock can find them even when
+        # Microsoft.Graph isn't imported (local runs); CI has them anyway.
+        function Get-MgDirectoryRole { param($Filter) }
+        function Get-MgDirectoryRoleMemberAsUser { param($DirectoryRoleId, [switch]$All) }
+        function Get-MgIdentityConditionalAccessPolicy { param([switch]$All) }
+        function Get-MgServicePrincipal { param($Filter, [switch]$All) }
+        function Invoke-MgGraphRequest { param($Method, $Uri, $Body, $ErrorAction) }
+        Mock Import-Module { }
+        Mock Get-MgDirectoryRole {
+            @([PSCustomObject]@{ Id = 'ga-role-id'; DisplayName = 'Global Administrator'; RoleTemplateId = '62e90394-69f5-4237-9190-012177145e10' })
+        }
+        Mock Get-MgDirectoryRoleMemberAsUser {
+            @(
+                [PSCustomObject]@{ Id = 'user-1'; DisplayName = 'Daren Maranya'; UserPrincipalName = 'daren@contoso.com'; SignInActivity = @{ LastSignInDateTime = (Get-Date).AddDays(-1); LastNonInteractiveSignInDateTime = (Get-Date).AddDays(-1) }; OnPremisesSyncEnabled = $false }
+                [PSCustomObject]@{ Id = 'user-2'; DisplayName = 'Break Glass Admin'; UserPrincipalName = 'bgadmin@contoso.com'; SignInActivity = @{ LastSignInDateTime = $null; LastNonInteractiveSignInDateTime = $null }; OnPremisesSyncEnabled = $false }
+            )
+        }
+        Mock Get-MgIdentityConditionalAccessPolicy { @() }
+        Mock Invoke-MgGraphRequest { @{ value = @() } }
+        Mock Get-MgServicePrincipal { @() }
+        . "$PSScriptRoot/../../src/M365-Assess/Security/Get-StrykerIncidentReadiness.ps1"
+    }
+
+    It 'is Warning with single-point-of-failure messaging when only 1 break-glass is detected' {
+        $bg = $settings | Where-Object { $_.CheckId -like 'ENTRA-BREAKGLASS-001*' -and $_.Setting -eq 'Break-glass emergency access account' } | Select-Object -First 1
+        $bg | Should -Not -BeNullOrEmpty
+        $bg.Status | Should -Be 'Warning'
+        $bg.CurrentValue | Should -Match 'single point of failure'
+    }
+
+    AfterAll { Remove-Item Function:\Update-CheckProgress -ErrorAction SilentlyContinue }
+}
+
+Describe 'ENTRA-BREAKGLASS-001 threshold (2+ high-confidence name match)' {
+    BeforeAll {
+        . "$PSScriptRoot/../../src/M365-Assess/Orchestrator/AssessmentHelpers.ps1"
+        function Get-MgContext { return @{ TenantId = 'test-tenant-id'; AuthType = 'Delegated' } }
+        function global:Update-CheckProgress { param($CheckId, $Setting, $Status) }
+        # Stub Mg cmdlets so Pester's Mock can find them even when
+        # Microsoft.Graph isn't imported (local runs); CI has them anyway.
+        function Get-MgDirectoryRole { param($Filter) }
+        function Get-MgDirectoryRoleMemberAsUser { param($DirectoryRoleId, [switch]$All) }
+        function Get-MgIdentityConditionalAccessPolicy { param([switch]$All) }
+        function Get-MgServicePrincipal { param($Filter, [switch]$All) }
+        function Invoke-MgGraphRequest { param($Method, $Uri, $Body, $ErrorAction) }
+        Mock Import-Module { }
+        Mock Get-MgDirectoryRole {
+            @([PSCustomObject]@{ Id = 'ga-role-id'; DisplayName = 'Global Administrator'; RoleTemplateId = '62e90394-69f5-4237-9190-012177145e10' })
+        }
+        Mock Get-MgDirectoryRoleMemberAsUser {
+            @(
+                [PSCustomObject]@{ Id = 'user-1'; DisplayName = 'Break Glass Admin 1'; UserPrincipalName = 'bgadmin1@contoso.onmicrosoft.com'; SignInActivity = @{ LastSignInDateTime = $null; LastNonInteractiveSignInDateTime = $null }; OnPremisesSyncEnabled = $false }
+                [PSCustomObject]@{ Id = 'user-2'; DisplayName = 'Emergency Access 02';  UserPrincipalName = 'bgadmin2@contoso.onmicrosoft.com'; SignInActivity = @{ LastSignInDateTime = $null; LastNonInteractiveSignInDateTime = $null }; OnPremisesSyncEnabled = $false }
+            )
+        }
+        Mock Get-MgIdentityConditionalAccessPolicy { @() }
+        Mock Invoke-MgGraphRequest { @{ value = @() } }
+        Mock Get-MgServicePrincipal { @() }
+        . "$PSScriptRoot/../../src/M365-Assess/Security/Get-StrykerIncidentReadiness.ps1"
+    }
+
+    It 'is Pass when 2+ name-matched break-glass accounts are detected' {
+        $bg = $settings | Where-Object { $_.CheckId -like 'ENTRA-BREAKGLASS-001*' -and $_.Setting -eq 'Break-glass emergency access account' } | Select-Object -First 1
+        $bg | Should -Not -BeNullOrEmpty
+        $bg.Status | Should -Be 'Pass'
+        $bg.CurrentValue | Should -Match 'confidence: High'
+        $bg.CurrentValue | Should -Match 'bgadmin1@contoso.onmicrosoft.com'
+        $bg.CurrentValue | Should -Match 'bgadmin2@contoso.onmicrosoft.com'
+    }
+
+    It 'recommends at least 2 enabled break-glass accounts (post-#888)' {
+        $bg = $settings | Where-Object { $_.CheckId -like 'ENTRA-BREAKGLASS-001*' -and $_.Setting -eq 'Break-glass emergency access account' } | Select-Object -First 1
+        $bg.RecommendedValue | Should -Match '^At least 2'
+    }
+
+    AfterAll { Remove-Item Function:\Update-CheckProgress -ErrorAction SilentlyContinue }
+}
+
+Describe 'ENTRA-BREAKGLASS-001 threshold (2+ medium-confidence CA-exclusion fallback)' {
+    BeforeAll {
+        . "$PSScriptRoot/../../src/M365-Assess/Orchestrator/AssessmentHelpers.ps1"
+        function Get-MgContext { return @{ TenantId = 'test-tenant-id'; AuthType = 'Delegated' } }
+        function global:Update-CheckProgress { param($CheckId, $Setting, $Status) }
+        # Stub Mg cmdlets so Pester's Mock can find them even when
+        # Microsoft.Graph isn't imported (local runs); CI has them anyway.
+        function Get-MgDirectoryRole { param($Filter) }
+        function Get-MgDirectoryRoleMemberAsUser { param($DirectoryRoleId, [switch]$All) }
+        function Get-MgIdentityConditionalAccessPolicy { param([switch]$All) }
+        function Get-MgServicePrincipal { param($Filter, [switch]$All) }
+        function Invoke-MgGraphRequest { param($Method, $Uri, $Body, $ErrorAction) }
+        Mock Import-Module { }
+        Mock Get-MgDirectoryRole {
+            @([PSCustomObject]@{ Id = 'ga-role-id'; DisplayName = 'Global Administrator'; RoleTemplateId = '62e90394-69f5-4237-9190-012177145e10' })
+        }
+        # 2 GAs with non-break-glass-looking names → name-match fails, fallback
+        # to CA-exclusion pattern. Both are excluded from the active CA policy.
+        Mock Get-MgDirectoryRoleMemberAsUser {
+            @(
+                [PSCustomObject]@{ Id = 'user-1'; DisplayName = 'Service Account A'; UserPrincipalName = 'svc-a@contoso.onmicrosoft.com'; SignInActivity = @{ LastSignInDateTime = $null; LastNonInteractiveSignInDateTime = $null }; OnPremisesSyncEnabled = $false }
+                [PSCustomObject]@{ Id = 'user-2'; DisplayName = 'Service Account B'; UserPrincipalName = 'svc-b@contoso.onmicrosoft.com'; SignInActivity = @{ LastSignInDateTime = $null; LastNonInteractiveSignInDateTime = $null }; OnPremisesSyncEnabled = $false }
+            )
+        }
+        Mock Get-MgIdentityConditionalAccessPolicy {
+            @([PSCustomObject]@{
+                DisplayName   = 'Require MFA for all'
+                State         = 'enabled'
+                Conditions    = @{ Users = @{ IncludeRoles = @(); ExcludeUsers = @('user-1','user-2'); ExcludeGroups = @() } }
+                GrantControls = @{ BuiltInControls = @('mfa'); AuthenticationStrength = $null }
+            })
+        }
+        Mock Invoke-MgGraphRequest { @{ value = @() } }
+        Mock Get-MgServicePrincipal { @() }
+        . "$PSScriptRoot/../../src/M365-Assess/Security/Get-StrykerIncidentReadiness.ps1"
+    }
+
+    It 'is Warning when 2+ break-glass detected only via CA-exclusion pattern' {
+        $bg = $settings | Where-Object { $_.CheckId -like 'ENTRA-BREAKGLASS-001*' -and $_.Setting -eq 'Break-glass emergency access account' } | Select-Object -First 1
+        $bg | Should -Not -BeNullOrEmpty
+        $bg.Status | Should -Be 'Warning'
+        $bg.CurrentValue | Should -Match 'confidence: Medium'
+        $bg.CurrentValue | Should -Match 'CA exclusion pattern'
+    }
+
+    AfterAll { Remove-Item Function:\Update-CheckProgress -ErrorAction SilentlyContinue }
 }


### PR DESCRIPTION
## Summary

**PR γ** of v2.11.0 — Data Quality & Accuracy. Bundles two quality-infrastructure issues: Pester coverage for the consolidated break-glass check (#891) + an audit harness for the Review/Unknown/Skipped emission surface (#884).

## #891 — Stryker break-glass test coverage

After PR #892 (#888) consolidated `ENTRA-BREAKGLASS-001` to `Get-StrykerIncidentReadiness.ps1` with the post-Microsoft-CIS-aligned threshold (Pass requires 2+, Warning at 1, Fail at 0), there was no Pester coverage for the new branches. Added 4 dedicated `Describe` blocks covering all threshold scenarios:

| Scenario | Expected status | Asserted |
|---|---|---|
| 0 break-glass detected | Fail | "No break-glass account detected" message |
| 1 detected | Warning | "single point of failure" message |
| 2+ high-confidence (name match) | Pass | "confidence: High" + UPNs visible |
| 2+ medium-confidence (CA-exclusion only) | Warning | "confidence: Medium" + "CA exclusion pattern" |
| RecommendedValue text | always | "At least 2" (post-#888 phrasing) |

Also stubbed Microsoft.Graph cmdlets in `BeforeAll` so Pester's `Mock` can find them locally (was failing standalone, only passing in CI where Microsoft.Graph is imported). Tests now pass in both environments.

## #884 — Review/Unknown/Skipped audit harness + catalogue

Empirical scan: **97 emission sites** total across 20+ collector files:

| Status | Count |
|---|---|
| Review | 68 |
| Skipped | 28 |
| Unknown | 1 |

`docs/research/review-status-audit.md` documents the classification framework (genuine limitation vs collector bug vs triage pending), per-collector breakdown, known examples (e.g., #883 SPO-AUTH-001 was a typo-class bug fixed in v2.10.1; the 22 Skipped emissions in `EntraUserGroupChecks.ps1` are confirmed genuine license/permission gates), and the workflow for individual audits.

`tests/Behavior/Status-Emission-Audit.Tests.ps1` is a **lock-down Pester regression** that caps the count at the audited ceiling. New emissions cannot be added without:
1. Justifying the new emission in the PR description (limitation vs bug?)
2. Adding the new site to the catalogue
3. Raising the ceiling in the test

Without this guardrail, "I couldn't measure it, returning Review" silently accumulates and erodes report credibility.

## Out of scope

- Per-check exhaustive triage of the remaining ~85 emissions is ongoing v2.11.0 follow-up work, filed as bugs as they're triaged.

## Test plan

- [x] Stryker tests: 8/8 passing locally (was 5/8 failing without Mg cmdlet stubs)
- [x] Audit lock-down: 4/4 passing (counts: Review 68 / Skipped 28 / Unknown 1)
- [x] Full Pester: **2307 passed / 0 failed / 3 expected skips** (was 2298 — +9 new tests)
- [ ] CI green
- [x] Live-tenant verification: low surface (audit + tests only — no behavioral change to collectors). Spot-check break-glass row still shows Warning with "single point of failure" message; no new findings introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)