### PR TITLE
docs(design): finding-detail panel redesign handoff (refs #863)

### DIFF
--- a/docs/design/finding-detail/README.md
+++ b/docs/design/finding-detail/README.md
@@ -1,0 +1,106 @@
+# Finding-detail panel redesign — design handoff
+
+Frozen snapshot of the design package exported from [Claude Design](https://claude.ai/design) on 2026-04-28. This is the source-of-truth spec for **issue #863** (Finding-detail panel redesign — Direction D hybrid).
+
+Replaces the closed #674 (the prior detail-panel redesign attempt that was rejected as "too busy without adding actual info or value"). Direction D addresses that critique by being structurally denser, not just visually busier — it makes room for value-bearing fields the report doesn't currently expose.
+
+## What's in here
+
+| File | Purpose |
+|---|---|
+| **`direction-d.jsx`** | **The implementation reference.** Final design after the user iterated through 3 alternates (A — narrative-first, B — structured-claim, C — workflow-state). Direction D synthesizes the strongest pieces of each into one shippable pattern. |
+| `fd-host.jsx` | Surrounding harness (table → expanded row container) showing how `<FindingDetail/>` is mounted. Useful for understanding the parent contract, not part of the redesign itself. |
+| `mock-findings.js` | Three realistic mock findings (ENTRA-MFA-001 boolean shape, DEFENDER-SAFELINKS-001 multi-setting shape, CA-EXCLUSION-001 list-shape) covering the structured-claim variations the typed evidence table needs to render. |
+| `styles.css` | All new CSS classes used by Direction D (`.fd-*` and `.fdd-*` namespaces). The implementer should fold these into `src/M365-Assess/assets/report-shell.css` and adapt to the existing CSS-variable theme contract. |
+| `redesign.css` | Snapshot of base styles from the canvas standalone. Most overlap with the live `report-shell.css`; the new bits live in `styles.css`. |
+| `index.html` | Canvas host that loads the design standalone in a browser. Useful for visual review before implementation. |
+| `design-canvas.jsx` | Canvas chrome (artboard + section). Not implementation-relevant — surrounding harness. |
+
+## Not included (deliberately)
+
+The original design bundle contained `report-shell.css` and `report-themes.css` so the canvas could load standalone. **Those are not duplicated here** — they live at `src/M365-Assess/assets/report-shell.css` and `report-themes.css`. The design intent is captured in `styles.css` only; the existing report styles are referenced from the live source.
+
+## How to view the canvas
+
+```bash
+cd docs/design/finding-detail
+cp ../../../src/M365-Assess/assets/report-shell.css .
+cp ../../../src/M365-Assess/assets/report-themes.css .
+start index.html   # Windows
+open index.html    # macOS
+xdg-open index.html # Linux
+```
+
+(Don't commit those copies — they would drift from the live source.)
+
+You don't need to render the canvas to implement — the JSX/CSS source IS the spec.
+
+## Layout summary
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│ Row 1: STATE STRIP                                                        │
+│  Horizon · Effort · Affected · Owner · Ticket                             │
+├──────────────────────────────────────────────────────────────────────────┤
+│ Row 2: RISK NARRATIVE (red-tinted)                                        │
+│  Risk:           one paragraph — what an attacker can do                  │
+│  Why it matters: audit/compliance consequence, framework count, mandates  │
+│  (right meta:    MITRE T-codes)                                           │
+├────────────────────────────────────┬─────────────────────────────────────┤
+│ Row 3a: STRUCTURED CLAIM           │ Row 3b: SIDE RAIL                   │
+│  one-line typed assertion          │  Mappings (frameworks + controlIds) │
+│  OBSERVED / EXPECTED / DELTA       │  Trend pips (last N runs)           │
+│  typed table; sample chips for     │  Related findings (cluster)         │
+│  list-shaped values                │  Learn more (refs)                  │
+│  Action tabs:                      │                                     │
+│   [Portal] [PowerShell] [Verify]   │                                     │
+├──────────────────────────────────────────────────────────────────────────┤
+│ Footer: PROVENANCE (collapsible)                                          │
+│  Source · Timestamp · Confidence · Permission · Raw evidence              │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+## Schema additions
+
+The current finding object carries: `checkId`, `setting`, `status`, `severity`, `domain`, `current`, `recommended`, `remediation`, `frameworks`, `fwMeta`, `evidence`, `references`. Direction D requires these **new** fields:
+
+| Field | Type | Source / how to populate |
+|---|---|---|
+| `lane` | `'now' \| 'soon' \| 'later'` | Already computed via `Get-RemediationLane.ps1` (#715); just surface on the finding object |
+| `effort` | `'small' \| 'medium' \| 'large'` | Per-check field in `controls/registry.json` (some entries already have it) |
+| `owner` | `string \| null` | NEW — opt-in user-assignment in edit mode (persists via `REPORT_OVERRIDES`) |
+| `ticket` | `{ system, id, status } \| null` | NEW — opt-in user-assignment in edit mode |
+| `history` | `[{ date, status, note }]` | NEW — derived from baseline-trend data |
+| `affectedObjects` | `{ kind, count, sample[] }` | NEW — populated by collectors when known |
+| `riskNarrative` | `string` | NEW — separate from `whyItMatters` (split current narrative into "what attacker does" + "audit consequence") |
+| `mitre` | `string[]` | NEW — per-check field where applicable (e.g., T1078) |
+| `relatedFindings` | `checkId[]` | NEW — derived clustering OR explicit |
+| `remediation` (structured) | `{ portal: string[], ps: string, verify: string }` | NEW — restructure the freeform `remediation` string |
+| `evidence` (typed) | `{ observedValue, expectedValue, evidenceSource, evidenceTimestamp, collectionMethod, permissionRequired, confidence, limitations, raw }` | Already present (D1 #785); thread through new layout |
+
+## Phased implementation plan
+
+The redesign is large enough that it ships in phases. Each phase degrades gracefully when later-phase fields are missing.
+
+| Phase | Scope | Status |
+|---|---|---|
+| **1. Schema groundwork** | Extend collectors + registry + `Build-ReportData.ps1` to surface new fields where derivable. | TODO |
+| **2. UI shell** | Row 1 (state strip) + Row 2 (risk narrative split) + collapsible provenance footer. Renders off existing fields with graceful empty-state. | TODO — first implementation PR after this docs handoff |
+| **3. Typed observed/expected + tabbed actions** | Requires typed `evidence.observedValue` / `expectedValue` + remediation restructure. | TODO |
+| **4. Side rail** | Mappings (existing) + Trend (needs baseline integration) + Related (clustering) + Learn more. | TODO |
+| **5. Owner / ticket assignment** | Edit-mode metadata overlay similar to `<HideableBlock>` (#712). | TODO |
+
+## Implementation guidance
+
+The polished JSX in `direction-d.jsx` should be **adapted, not copied verbatim** into `src/M365-Assess/assets/report-app.jsx`. Adapt:
+
+- Data sources: `direction-d.jsx` references locally-defined helpers; live code uses `STATUS_COLORS`, `STATUS_TIERS`, etc.
+- Hook names: align with existing `useState` / `useMemo` conventions
+- CSS class merging: fold `styles.css` into `src/M365-Assess/assets/report-shell.css` and adapt to the live theme variable contract
+- Edit-mode integration: hideable wrapper from #712, edit-mode context already in scope
+
+See **issue #863** for the full per-phase implementation plan.
+
+## Related design handoffs
+
+- `docs/design/framework-redesign/` (#856 / shipped via #855) — the framework coverage redesign followed the same handoff pattern. Use it as the structural template.

--- a/docs/design/finding-detail/design-canvas.jsx
+++ b/docs/design/finding-detail/design-canvas.jsx
@@ -1,0 +1,622 @@
+
+// DesignCanvas.jsx — Figma-ish design canvas wrapper
+// Warm gray grid bg + Sections + Artboards + PostIt notes.
+// Artboards are reorderable (grip-drag), labels/titles are inline-editable,
+// and any artboard can be opened in a fullscreen focus overlay (←/→/Esc).
+// State persists to a .design-canvas.state.json sidecar via the host
+// bridge. No assets, no deps.
+//
+// Usage:
+//   <DesignCanvas>
+//     <DCSection id="onboarding" title="Onboarding" subtitle="First-run variants">
+//       <DCArtboard id="a" label="A · Dusk" width={260} height={480}>…</DCArtboard>
+//       <DCArtboard id="b" label="B · Minimal" width={260} height={480}>…</DCArtboard>
+//     </DCSection>
+//   </DesignCanvas>
+
+const DC = {
+  bg: '#f0eee9',
+  grid: 'rgba(0,0,0,0.06)',
+  label: 'rgba(60,50,40,0.7)',
+  title: 'rgba(40,30,20,0.85)',
+  subtitle: 'rgba(60,50,40,0.6)',
+  postitBg: '#fef4a8',
+  postitText: '#5a4a2a',
+  font: '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+};
+
+// One-time CSS injection (classes are dc-prefixed so they don't collide with
+// the hosted design's own styles).
+if (typeof document !== 'undefined' && !document.getElementById('dc-styles')) {
+  const s = document.createElement('style');
+  s.id = 'dc-styles';
+  s.textContent = [
+    '.dc-editable{cursor:text;outline:none;white-space:nowrap;border-radius:3px;padding:0 2px;margin:0 -2px}',
+    '.dc-editable:focus{background:#fff;box-shadow:0 0 0 1.5px #c96442}',
+    '[data-dc-slot]{transition:transform .18s cubic-bezier(.2,.7,.3,1)}',
+    '[data-dc-slot].dc-dragging{transition:none;z-index:10;pointer-events:none}',
+    '[data-dc-slot].dc-dragging .dc-card{box-shadow:0 12px 40px rgba(0,0,0,.25),0 0 0 2px #c96442;transform:scale(1.02)}',
+    '.dc-card{transition:box-shadow .15s,transform .15s}',
+    '.dc-card *{scrollbar-width:none}',
+    '.dc-card *::-webkit-scrollbar{display:none}',
+    '.dc-labelrow{display:flex;align-items:center;gap:4px;height:24px}',
+    '.dc-grip{cursor:grab;display:flex;align-items:center;padding:5px 4px;border-radius:4px;transition:background .12s}',
+    '.dc-grip:hover{background:rgba(0,0,0,.08)}',
+    '.dc-grip:active{cursor:grabbing}',
+    '.dc-labeltext{cursor:pointer;border-radius:4px;padding:3px 6px;display:flex;align-items:center;transition:background .12s}',
+    '.dc-labeltext:hover{background:rgba(0,0,0,.05)}',
+    '.dc-expand{position:absolute;bottom:100%;right:0;margin-bottom:5px;z-index:2;opacity:0;transition:opacity .12s,background .12s;',
+    '  width:22px;height:22px;border-radius:5px;border:none;cursor:pointer;padding:0;',
+    '  background:transparent;color:rgba(60,50,40,.7);display:flex;align-items:center;justify-content:center}',
+    '.dc-expand:hover{background:rgba(0,0,0,.06);color:#2a251f}',
+    '[data-dc-slot]:hover .dc-expand{opacity:1}',
+  ].join('\n');
+  document.head.appendChild(s);
+}
+
+const DCCtx = React.createContext(null);
+
+// ─────────────────────────────────────────────────────────────
+// DesignCanvas — stateful wrapper around the pan/zoom viewport.
+// Owns runtime state (per-section order, renamed titles/labels, focused
+// artboard). Order/titles/labels persist to a .design-canvas.state.json
+// sidecar next to the HTML. Reads go via plain fetch() so the saved
+// arrangement is visible anywhere the HTML + sidecar are served together
+// (omelette preview, direct link, downloaded zip). Writes go through the
+// host's window.omelette bridge — editing requires the omelette runtime.
+// Focus is ephemeral.
+// ─────────────────────────────────────────────────────────────
+const DC_STATE_FILE = '.design-canvas.state.json';
+
+function DesignCanvas({ children, minScale, maxScale, style }) {
+  const [state, setState] = React.useState({ sections: {}, focus: null });
+  // Hold rendering until the sidecar read settles so the saved order/titles
+  // appear on first paint (no source-order flash). didRead gates writes until
+  // the read settles so the empty initial state can't clobber a slow read;
+  // skipNextWrite suppresses the one echo-write that would otherwise follow
+  // hydration.
+  const [ready, setReady] = React.useState(false);
+  const didRead = React.useRef(false);
+  const skipNextWrite = React.useRef(false);
+
+  React.useEffect(() => {
+    let off = false;
+    fetch('./' + DC_STATE_FILE)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((saved) => {
+        if (off || !saved || !saved.sections) return;
+        skipNextWrite.current = true;
+        setState((s) => ({ ...s, sections: saved.sections }));
+      })
+      .catch(() => {})
+      .finally(() => { didRead.current = true; if (!off) setReady(true); });
+    const t = setTimeout(() => { if (!off) setReady(true); }, 150);
+    return () => { off = true; clearTimeout(t); };
+  }, []);
+
+  React.useEffect(() => {
+    if (!didRead.current) return;
+    if (skipNextWrite.current) { skipNextWrite.current = false; return; }
+    const t = setTimeout(() => {
+      window.omelette?.writeFile(DC_STATE_FILE, JSON.stringify({ sections: state.sections })).catch(() => {});
+    }, 250);
+    return () => clearTimeout(t);
+  }, [state.sections]);
+
+  // Build registries synchronously from children so FocusOverlay can read
+  // them in the same render. Only direct DCSection > DCArtboard children are
+  // walked — wrapping them in other elements opts out of focus/reorder.
+  const registry = {};     // slotId -> { sectionId, artboard }
+  const sectionMeta = {};  // sectionId -> { title, subtitle, slotIds[] }
+  const sectionOrder = [];
+  React.Children.forEach(children, (sec) => {
+    if (!sec || sec.type !== DCSection) return;
+    const sid = sec.props.id ?? sec.props.title;
+    if (!sid) return;
+    sectionOrder.push(sid);
+    const persisted = state.sections[sid] || {};
+    const srcIds = [];
+    React.Children.forEach(sec.props.children, (ab) => {
+      if (!ab || ab.type !== DCArtboard) return;
+      const aid = ab.props.id ?? ab.props.label;
+      if (!aid) return;
+      registry[`${sid}/${aid}`] = { sectionId: sid, artboard: ab };
+      srcIds.push(aid);
+    });
+    const kept = (persisted.order || []).filter((k) => srcIds.includes(k));
+    sectionMeta[sid] = {
+      title: persisted.title ?? sec.props.title,
+      subtitle: sec.props.subtitle,
+      slotIds: [...kept, ...srcIds.filter((k) => !kept.includes(k))],
+    };
+  });
+
+  const api = React.useMemo(() => ({
+    state,
+    section: (id) => state.sections[id] || {},
+    patchSection: (id, p) => setState((s) => ({
+      ...s,
+      sections: { ...s.sections, [id]: { ...s.sections[id], ...(typeof p === 'function' ? p(s.sections[id] || {}) : p) } },
+    })),
+    setFocus: (slotId) => setState((s) => ({ ...s, focus: slotId })),
+  }), [state]);
+
+  // Esc exits focus; any outside pointerdown commits an in-progress rename.
+  React.useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') api.setFocus(null); };
+    const onPd = (e) => {
+      const ae = document.activeElement;
+      if (ae && ae.isContentEditable && !ae.contains(e.target)) ae.blur();
+    };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('pointerdown', onPd, true);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('pointerdown', onPd, true);
+    };
+  }, [api]);
+
+  return (
+    <DCCtx.Provider value={api}>
+      <DCViewport minScale={minScale} maxScale={maxScale} style={style}>{ready && children}</DCViewport>
+      {state.focus && registry[state.focus] && (
+        <DCFocusOverlay entry={registry[state.focus]} sectionMeta={sectionMeta} sectionOrder={sectionOrder} />
+      )}
+    </DCCtx.Provider>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCViewport — transform-based pan/zoom (internal)
+//
+// Input mapping (Figma-style):
+//   • trackpad pinch  → zoom   (ctrlKey wheel; Safari gesture* events)
+//   • trackpad scroll → pan    (two-finger)
+//   • mouse wheel     → zoom   (notched; distinguished from trackpad scroll)
+//   • middle-drag / primary-drag-on-bg → pan
+//
+// Transform state lives in a ref and is written straight to the DOM
+// (translate3d + will-change) so wheel ticks don't go through React —
+// keeps pans at 60fps on dense canvases.
+// ─────────────────────────────────────────────────────────────
+function DCViewport({ children, minScale = 0.1, maxScale = 8, style = {} }) {
+  const vpRef = React.useRef(null);
+  const worldRef = React.useRef(null);
+  const tf = React.useRef({ x: 0, y: 0, scale: 1 });
+
+  const apply = React.useCallback(() => {
+    const { x, y, scale } = tf.current;
+    const el = worldRef.current;
+    if (el) el.style.transform = `translate3d(${x}px, ${y}px, 0) scale(${scale})`;
+  }, []);
+
+  React.useEffect(() => {
+    const vp = vpRef.current;
+    if (!vp) return;
+
+    const zoomAt = (cx, cy, factor) => {
+      const r = vp.getBoundingClientRect();
+      const px = cx - r.left, py = cy - r.top;
+      const t = tf.current;
+      const next = Math.min(maxScale, Math.max(minScale, t.scale * factor));
+      const k = next / t.scale;
+      // keep the world point under the cursor fixed
+      t.x = px - (px - t.x) * k;
+      t.y = py - (py - t.y) * k;
+      t.scale = next;
+      apply();
+    };
+
+    // Mouse-wheel vs trackpad-scroll heuristic. A physical wheel sends
+    // line-mode deltas (Firefox) or large integer pixel deltas with no X
+    // component (Chrome/Safari, typically multiples of 100/120). Trackpad
+    // two-finger scroll sends small/fractional pixel deltas, often with
+    // non-zero deltaX. ctrlKey is set by the browser for trackpad pinch.
+    const isMouseWheel = (e) =>
+      e.deltaMode !== 0 ||
+      (e.deltaX === 0 && Number.isInteger(e.deltaY) && Math.abs(e.deltaY) >= 40);
+
+    const onWheel = (e) => {
+      e.preventDefault();
+      if (isGesturing) return; // Safari: gesture* owns the pinch — discard concurrent wheels
+      if (e.ctrlKey) {
+        // trackpad pinch (or explicit ctrl+wheel)
+        zoomAt(e.clientX, e.clientY, Math.exp(-e.deltaY * 0.01));
+      } else if (isMouseWheel(e)) {
+        // notched mouse wheel — fixed-ratio step per click
+        zoomAt(e.clientX, e.clientY, Math.exp(-Math.sign(e.deltaY) * 0.18));
+      } else {
+        // trackpad two-finger scroll — pan
+        tf.current.x -= e.deltaX;
+        tf.current.y -= e.deltaY;
+        apply();
+      }
+    };
+
+    // Safari sends native gesture* events for trackpad pinch with a smooth
+    // e.scale; preferring these over the ctrl+wheel fallback gives a much
+    // better feel there. No-ops on other browsers. Safari also fires
+    // ctrlKey wheel events during the same pinch — isGesturing makes
+    // onWheel drop those entirely so they neither zoom nor pan.
+    let gsBase = 1;
+    let isGesturing = false;
+    const onGestureStart = (e) => { e.preventDefault(); isGesturing = true; gsBase = tf.current.scale; };
+    const onGestureChange = (e) => {
+      e.preventDefault();
+      zoomAt(e.clientX, e.clientY, (gsBase * e.scale) / tf.current.scale);
+    };
+    const onGestureEnd = (e) => { e.preventDefault(); isGesturing = false; };
+
+    // Drag-pan: middle button anywhere, or primary button on canvas
+    // background (anything that isn't an artboard or an inline editor).
+    let drag = null;
+    const onPointerDown = (e) => {
+      const onBg = !e.target.closest('[data-dc-slot], .dc-editable');
+      if (!(e.button === 1 || (e.button === 0 && onBg))) return;
+      e.preventDefault();
+      vp.setPointerCapture(e.pointerId);
+      drag = { id: e.pointerId, lx: e.clientX, ly: e.clientY };
+      vp.style.cursor = 'grabbing';
+    };
+    const onPointerMove = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      tf.current.x += e.clientX - drag.lx;
+      tf.current.y += e.clientY - drag.ly;
+      drag.lx = e.clientX; drag.ly = e.clientY;
+      apply();
+    };
+    const onPointerUp = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      vp.releasePointerCapture(e.pointerId);
+      drag = null;
+      vp.style.cursor = '';
+    };
+
+    vp.addEventListener('wheel', onWheel, { passive: false });
+    vp.addEventListener('gesturestart', onGestureStart, { passive: false });
+    vp.addEventListener('gesturechange', onGestureChange, { passive: false });
+    vp.addEventListener('gestureend', onGestureEnd, { passive: false });
+    vp.addEventListener('pointerdown', onPointerDown);
+    vp.addEventListener('pointermove', onPointerMove);
+    vp.addEventListener('pointerup', onPointerUp);
+    vp.addEventListener('pointercancel', onPointerUp);
+    return () => {
+      vp.removeEventListener('wheel', onWheel);
+      vp.removeEventListener('gesturestart', onGestureStart);
+      vp.removeEventListener('gesturechange', onGestureChange);
+      vp.removeEventListener('gestureend', onGestureEnd);
+      vp.removeEventListener('pointerdown', onPointerDown);
+      vp.removeEventListener('pointermove', onPointerMove);
+      vp.removeEventListener('pointerup', onPointerUp);
+      vp.removeEventListener('pointercancel', onPointerUp);
+    };
+  }, [apply, minScale, maxScale]);
+
+  const gridSvg = `url("data:image/svg+xml,%3Csvg width='120' height='120' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M120 0H0v120' fill='none' stroke='${encodeURIComponent(DC.grid)}' stroke-width='1'/%3E%3C/svg%3E")`;
+  return (
+    <div
+      ref={vpRef}
+      className="design-canvas"
+      style={{
+        height: '100vh', width: '100vw',
+        background: DC.bg,
+        overflow: 'hidden',
+        overscrollBehavior: 'none',
+        touchAction: 'none',
+        position: 'relative',
+        fontFamily: DC.font,
+        boxSizing: 'border-box',
+        ...style,
+      }}
+    >
+      <div
+        ref={worldRef}
+        style={{
+          position: 'absolute', top: 0, left: 0,
+          transformOrigin: '0 0',
+          willChange: 'transform',
+          width: 'max-content', minWidth: '100%',
+          minHeight: '100%',
+          padding: '60px 0 80px',
+        }}
+      >
+        <div style={{ position: 'absolute', inset: -6000, backgroundImage: gridSvg, backgroundSize: '120px 120px', pointerEvents: 'none', zIndex: -1 }} />
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCSection — editable title + h-row of artboards in persisted order
+// ─────────────────────────────────────────────────────────────
+function DCSection({ id, title, subtitle, children, gap = 48 }) {
+  const ctx = React.useContext(DCCtx);
+  const sid = id ?? title;
+  const all = React.Children.toArray(children);
+  const artboards = all.filter((c) => c && c.type === DCArtboard);
+  const rest = all.filter((c) => !(c && c.type === DCArtboard));
+  const srcOrder = artboards.map((a) => a.props.id ?? a.props.label);
+  const sec = (ctx && sid && ctx.section(sid)) || {};
+
+  const order = React.useMemo(() => {
+    const kept = (sec.order || []).filter((k) => srcOrder.includes(k));
+    return [...kept, ...srcOrder.filter((k) => !kept.includes(k))];
+  }, [sec.order, srcOrder.join('|')]);
+
+  const byId = Object.fromEntries(artboards.map((a) => [a.props.id ?? a.props.label, a]));
+
+  return (
+    <div data-dc-section={sid} style={{ marginBottom: 80, position: 'relative' }}>
+      <div style={{ padding: '0 60px 56px' }}>
+        <DCEditable tag="div" value={sec.title ?? title}
+          onChange={(v) => ctx && sid && ctx.patchSection(sid, { title: v })}
+          style={{ fontSize: 28, fontWeight: 600, color: DC.title, letterSpacing: -0.4, marginBottom: 6, display: 'inline-block' }} />
+        {subtitle && <div style={{ fontSize: 16, color: DC.subtitle }}>{subtitle}</div>}
+      </div>
+      <div style={{ display: 'flex', gap, padding: '0 60px', alignItems: 'flex-start', width: 'max-content' }}>
+        {order.map((k) => (
+          <DCArtboardFrame key={k} sectionId={sid} artboard={byId[k]} order={order}
+            label={(sec.labels || {})[k] ?? byId[k].props.label}
+            onRename={(v) => ctx && ctx.patchSection(sid, (x) => ({ labels: { ...x.labels, [k]: v } }))}
+            onReorder={(next) => ctx && ctx.patchSection(sid, { order: next })}
+            onFocus={() => ctx && ctx.setFocus(`${sid}/${k}`)} />
+        ))}
+      </div>
+      {rest}
+    </div>
+  );
+}
+
+// DCArtboard — marker; rendered by DCArtboardFrame via DCSection.
+function DCArtboard() { return null; }
+
+function DCArtboardFrame({ sectionId, artboard, label, order, onRename, onReorder, onFocus }) {
+  const { id: rawId, label: rawLabel, width = 260, height = 480, children, style = {} } = artboard.props;
+  const id = rawId ?? rawLabel;
+  const ref = React.useRef(null);
+
+  // Live drag-reorder: dragged card sticks to cursor; siblings slide into
+  // their would-be slots in real time via transforms. DOM order only
+  // changes on drop.
+  const onGripDown = (e) => {
+    e.preventDefault(); e.stopPropagation();
+    const me = ref.current;
+    // translateX is applied in local (pre-scale) space but pointer deltas and
+    // getBoundingClientRect().left are screen-space — divide by the viewport's
+    // current scale so the dragged card tracks the cursor at any zoom level.
+    const scale = me.getBoundingClientRect().width / me.offsetWidth || 1;
+    const peers = Array.from(document.querySelectorAll(`[data-dc-section="${sectionId}"] [data-dc-slot]`));
+    const homes = peers.map((el) => ({ el, id: el.dataset.dcSlot, x: el.getBoundingClientRect().left }));
+    const slotXs = homes.map((h) => h.x);
+    const startIdx = order.indexOf(id);
+    const startX = e.clientX;
+    let liveOrder = order.slice();
+    me.classList.add('dc-dragging');
+
+    const layout = () => {
+      for (const h of homes) {
+        if (h.id === id) continue;
+        const slot = liveOrder.indexOf(h.id);
+        h.el.style.transform = `translateX(${(slotXs[slot] - h.x) / scale}px)`;
+      }
+    };
+
+    const move = (ev) => {
+      const dx = ev.clientX - startX;
+      me.style.transform = `translateX(${dx / scale}px)`;
+      const cur = homes[startIdx].x + dx;
+      let nearest = 0, best = Infinity;
+      for (let i = 0; i < slotXs.length; i++) {
+        const d = Math.abs(slotXs[i] - cur);
+        if (d < best) { best = d; nearest = i; }
+      }
+      if (liveOrder.indexOf(id) !== nearest) {
+        liveOrder = order.filter((k) => k !== id);
+        liveOrder.splice(nearest, 0, id);
+        layout();
+      }
+    };
+
+    const up = () => {
+      document.removeEventListener('pointermove', move);
+      document.removeEventListener('pointerup', up);
+      const finalSlot = liveOrder.indexOf(id);
+      me.classList.remove('dc-dragging');
+      me.style.transform = `translateX(${(slotXs[finalSlot] - homes[startIdx].x) / scale}px)`;
+      // After the settle transition, kill transitions + clear transforms +
+      // commit the reorder in the same frame so there's no visual snap-back.
+      setTimeout(() => {
+        for (const h of homes) { h.el.style.transition = 'none'; h.el.style.transform = ''; }
+        if (liveOrder.join('|') !== order.join('|')) onReorder(liveOrder);
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+          for (const h of homes) h.el.style.transition = '';
+        }));
+      }, 180);
+    };
+    document.addEventListener('pointermove', move);
+    document.addEventListener('pointerup', up);
+  };
+
+  return (
+    <div ref={ref} data-dc-slot={id} style={{ position: 'relative', flexShrink: 0 }}>
+      <div className="dc-labelrow" style={{ position: 'absolute', bottom: '100%', left: -4, marginBottom: 4, color: DC.label }}>
+        <div className="dc-grip" onPointerDown={onGripDown} title="Drag to reorder">
+          <svg width="9" height="13" viewBox="0 0 9 13" fill="currentColor"><circle cx="2" cy="2" r="1.1"/><circle cx="7" cy="2" r="1.1"/><circle cx="2" cy="6.5" r="1.1"/><circle cx="7" cy="6.5" r="1.1"/><circle cx="2" cy="11" r="1.1"/><circle cx="7" cy="11" r="1.1"/></svg>
+        </div>
+        <div className="dc-labeltext" onClick={onFocus} title="Click to focus">
+          <DCEditable value={label} onChange={onRename} onClick={(e) => e.stopPropagation()}
+            style={{ fontSize: 15, fontWeight: 500, color: DC.label, lineHeight: 1 }} />
+        </div>
+      </div>
+      <button className="dc-expand" onClick={onFocus} onPointerDown={(e) => e.stopPropagation()} title="Focus">
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"><path d="M7 1h4v4M5 11H1V7M11 1L7.5 4.5M1 11l3.5-3.5"/></svg>
+      </button>
+      <div className="dc-card"
+        style={{ borderRadius: 2, boxShadow: '0 1px 3px rgba(0,0,0,.08),0 4px 16px rgba(0,0,0,.06)', overflow: 'hidden', width, height, background: '#fff', ...style }}>
+        {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb', fontSize: 13, fontFamily: DC.font }}>{id}</div>}
+      </div>
+    </div>
+  );
+}
+
+// Inline rename — commits on blur or Enter.
+function DCEditable({ value, onChange, style, tag = 'span', onClick }) {
+  const T = tag;
+  return (
+    <T className="dc-editable" contentEditable suppressContentEditableWarning
+      onClick={onClick}
+      onPointerDown={(e) => e.stopPropagation()}
+      onBlur={(e) => onChange && onChange(e.currentTarget.textContent)}
+      onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); e.currentTarget.blur(); } }}
+      style={style}>{value}</T>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Focus mode — overlay one artboard; ←/→ within section, ↑/↓ across
+// sections, Esc or backdrop click to exit.
+// ─────────────────────────────────────────────────────────────
+function DCFocusOverlay({ entry, sectionMeta, sectionOrder }) {
+  const ctx = React.useContext(DCCtx);
+  const { sectionId, artboard } = entry;
+  const sec = ctx.section(sectionId);
+  const meta = sectionMeta[sectionId];
+  const peers = meta.slotIds;
+  const aid = artboard.props.id ?? artboard.props.label;
+  const idx = peers.indexOf(aid);
+  const secIdx = sectionOrder.indexOf(sectionId);
+
+  const go = (d) => { const n = peers[(idx + d + peers.length) % peers.length]; if (n) ctx.setFocus(`${sectionId}/${n}`); };
+  const goSection = (d) => {
+    const ns = sectionOrder[(secIdx + d + sectionOrder.length) % sectionOrder.length];
+    const first = sectionMeta[ns] && sectionMeta[ns].slotIds[0];
+    if (first) ctx.setFocus(`${ns}/${first}`);
+  };
+
+  React.useEffect(() => {
+    const k = (e) => {
+      if (e.key === 'ArrowLeft') { e.preventDefault(); go(-1); }
+      if (e.key === 'ArrowRight') { e.preventDefault(); go(1); }
+      if (e.key === 'ArrowUp') { e.preventDefault(); goSection(-1); }
+      if (e.key === 'ArrowDown') { e.preventDefault(); goSection(1); }
+    };
+    document.addEventListener('keydown', k);
+    return () => document.removeEventListener('keydown', k);
+  });
+
+  const { width = 260, height = 480, children } = artboard.props;
+  const [vp, setVp] = React.useState({ w: window.innerWidth, h: window.innerHeight });
+  React.useEffect(() => { const r = () => setVp({ w: window.innerWidth, h: window.innerHeight }); window.addEventListener('resize', r); return () => window.removeEventListener('resize', r); }, []);
+  const scale = Math.max(0.1, Math.min((vp.w - 200) / width, (vp.h - 260) / height, 2));
+
+  const [ddOpen, setDd] = React.useState(false);
+  const Arrow = ({ dir, onClick }) => (
+    <button onClick={(e) => { e.stopPropagation(); onClick(); }}
+      style={{ position: 'absolute', top: '50%', [dir]: 28, transform: 'translateY(-50%)',
+        border: 'none', background: 'rgba(255,255,255,.08)', color: 'rgba(255,255,255,.9)',
+        width: 44, height: 44, borderRadius: 22, fontSize: 18, cursor: 'pointer',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'background .15s' }}
+      onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.18)')}
+      onMouseLeave={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.08)')}>
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+        <path d={dir === 'left' ? 'M11 3L5 9l6 6' : 'M7 3l6 6-6 6'} /></svg>
+    </button>
+  );
+
+  // Portal to body so position:fixed is the real viewport regardless of any
+  // transform on DesignCanvas's ancestors (including the canvas zoom itself).
+  return ReactDOM.createPortal(
+    <div onClick={() => ctx.setFocus(null)}
+      onWheel={(e) => e.preventDefault()}
+      style={{ position: 'fixed', inset: 0, zIndex: 100, background: 'rgba(24,20,16,.6)', backdropFilter: 'blur(14px)',
+        fontFamily: DC.font, color: '#fff' }}>
+
+      {/* top bar: section dropdown (left) · close (right) */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 72, display: 'flex', alignItems: 'flex-start', padding: '16px 20px 0', gap: 16 }}>
+        <div style={{ position: 'relative' }}>
+          <button onClick={() => setDd((o) => !o)}
+            style={{ border: 'none', background: 'transparent', color: '#fff', cursor: 'pointer', padding: '6px 8px',
+              borderRadius: 6, textAlign: 'left', fontFamily: 'inherit' }}>
+            <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span style={{ fontSize: 18, fontWeight: 600, letterSpacing: -0.3 }}>{meta.title}</span>
+              <svg width="11" height="11" viewBox="0 0 11 11" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" style={{ opacity: .7 }}><path d="M2 4l3.5 3.5L9 4"/></svg>
+            </span>
+            {meta.subtitle && <span style={{ display: 'block', fontSize: 13, opacity: .6, fontWeight: 400, marginTop: 2 }}>{meta.subtitle}</span>}
+          </button>
+          {ddOpen && (
+            <div style={{ position: 'absolute', top: '100%', left: 0, marginTop: 4, background: '#2a251f', borderRadius: 8,
+              boxShadow: '0 8px 32px rgba(0,0,0,.4)', padding: 4, minWidth: 200, zIndex: 10 }}>
+              {sectionOrder.map((sid) => (
+                <button key={sid} onClick={() => { setDd(false); const f = sectionMeta[sid].slotIds[0]; if (f) ctx.setFocus(`${sid}/${f}`); }}
+                  style={{ display: 'block', width: '100%', textAlign: 'left', border: 'none', cursor: 'pointer',
+                    background: sid === sectionId ? 'rgba(255,255,255,.1)' : 'transparent', color: '#fff',
+                    padding: '8px 12px', borderRadius: 5, fontSize: 14, fontWeight: sid === sectionId ? 600 : 400, fontFamily: 'inherit' }}>
+                  {sectionMeta[sid].title}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <div style={{ flex: 1 }} />
+        <button onClick={() => ctx.setFocus(null)}
+          onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.12)')}
+          onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+          style={{ border: 'none', background: 'transparent', color: 'rgba(255,255,255,.7)', width: 32, height: 32,
+            borderRadius: 16, fontSize: 20, cursor: 'pointer', lineHeight: 1, transition: 'background .12s' }}>×</button>
+      </div>
+
+      {/* card centered, label + index below — only the card itself stops
+          propagation so any backdrop click (including the margins around
+          the card) exits focus */}
+      <div
+        style={{ position: 'absolute', top: 64, bottom: 56, left: 100, right: 100, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 16 }}>
+        <div onClick={(e) => e.stopPropagation()} style={{ width: width * scale, height: height * scale, position: 'relative' }}>
+          <div style={{ width, height, transform: `scale(${scale})`, transformOrigin: 'top left', background: '#fff', borderRadius: 2, overflow: 'hidden',
+            boxShadow: '0 20px 80px rgba(0,0,0,.4)' }}>
+            {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb' }}>{aid}</div>}
+          </div>
+        </div>
+        <div onClick={(e) => e.stopPropagation()} style={{ fontSize: 14, fontWeight: 500, opacity: .85, textAlign: 'center' }}>
+          {(sec.labels || {})[aid] ?? artboard.props.label}
+          <span style={{ opacity: .5, marginLeft: 10, fontVariantNumeric: 'tabular-nums' }}>{idx + 1} / {peers.length}</span>
+        </div>
+      </div>
+
+      <Arrow dir="left" onClick={() => go(-1)} />
+      <Arrow dir="right" onClick={() => go(1)} />
+
+      {/* dots */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', bottom: 20, left: '50%', transform: 'translateX(-50%)', display: 'flex', gap: 8 }}>
+        {peers.map((p, i) => (
+          <button key={p} onClick={() => ctx.setFocus(`${sectionId}/${p}`)}
+            style={{ border: 'none', padding: 0, cursor: 'pointer', width: 6, height: 6, borderRadius: 3,
+              background: i === idx ? '#fff' : 'rgba(255,255,255,.3)' }} />
+        ))}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Post-it — absolute-positioned sticky note
+// ─────────────────────────────────────────────────────────────
+function DCPostIt({ children, top, left, right, bottom, rotate = -2, width = 180 }) {
+  return (
+    <div style={{
+      position: 'absolute', top, left, right, bottom, width,
+      background: DC.postitBg, padding: '14px 16px',
+      fontFamily: '"Comic Sans MS", "Marker Felt", "Segoe Print", cursive',
+      fontSize: 14, lineHeight: 1.4, color: DC.postitText,
+      boxShadow: '0 2px 8px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08)',
+      transform: `rotate(${rotate}deg)`,
+      zIndex: 5,
+    }}>{children}</div>
+  );
+}
+
+Object.assign(window, { DesignCanvas, DCSection, DCArtboard, DCPostIt });
+

--- a/docs/design/finding-detail/direction-d.jsx
+++ b/docs/design/finding-detail/direction-d.jsx
@@ -1,0 +1,307 @@
+// Direction D — HYBRID (B + C + A)
+// Synthesizes the strongest pieces of each model into a single shippable
+// pattern designed for the live report and a Claude-Code handoff.
+//
+// Schema (target state — additions on top of today's finding shape):
+//   {
+//     // ── claim & diff (typed observed/expected from B) ──────────────
+//     setting, section, domain, severity, status, checkId,
+//     evidence: { observedValue, expectedValue, evidenceSource, evidenceTimestamp,
+//                 collectionMethod, permissionRequired, confidence, limitations, raw },
+//
+//     // ── workflow state (from C) ────────────────────────────────────
+//     lane: 'now'|'soon'|'later',  effort: 'small'|'medium'|'large',
+//     owner: string|null,  ticket: { system, id, status }|null,
+//     history: [{ date, status, note }],
+//     affectedObjects: { kind, count, sample[] },
+//
+//     // ── narrative + action (from A) ────────────────────────────────
+//     riskNarrative: string,                 // one paragraph: what an attacker can do
+//     remediation: { portal: string, ps?: string, verify?: string },
+//     references: [{ title, url }],
+//     mitre: [string],
+//
+//     // ── compliance basis (typed mapping) ───────────────────────────
+//     frameworks: [fwId],
+//     fwMeta: { [fwId]: { controlId, profiles: [string] } },
+//     relatedFindings: [checkId],
+//   }
+//
+// Layout:
+//   Row 1: state strip (lane · effort · affected · owner · ticket)
+//   Row 2: risk narrative (the "why it matters" lede)
+//   Row 3: split — left = typed observed/expected table + remediation tabs
+//                  right = side rail (mappings · trend · related · evidence)
+//   Footer: collapsible raw evidence (forensic depth on demand)
+
+function DirectionD({ finding }) {
+  const f = finding || window.MOCK_FINDINGS[0];
+  const FW = window.FD_FW_NAMES;
+  const ev = f.evidence || {};
+  const [actionTab, setActionTab] = React.useState('portal');
+
+  const laneLabel = { now: 'Do Now', soon: 'Do Next', later: 'Later' }[f.lane] || '—';
+  const laneClass = { now: 'now', soon: 'next', later: '' }[f.lane] || 'empty';
+
+  const ps = (f.remediation || '').match(/Run:\s*([^.]*)/)?.[1].trim();
+  const portalSummary = (() => {
+    const m = (f.remediation || '').match(/^(.*?)(Run:.*)$/s);
+    return m ? m[1].trim() : f.remediation;
+  })();
+
+  // Structured claim sentence (B) — the typed assertion
+  const claim = ({
+    'ENTRA-MFA-001':       <>Phishable authentication methods are <b>enabled for the admin role-assignable group</b>. Phishing-resistant methods are <b>disabled tenant-wide</b>.</>,
+    'DEFENDER-SAFELINKS-002': <>Safe Links is enabled for <b>Email only</b>. Office apps and Teams are <b>unprotected</b>, and click-through is <b>permitted</b>.</>,
+    'CA-EXCLUSION-001':    <>The "Require MFA for admins" policy <b>excludes 4 directory roles</b> covering 4 admin users; only break-glass exclusions are sanctioned.</>,
+  })[f.checkId];
+
+  // Numbered remediation procedure (B) — the actual click-by-click
+  const procedure = ({
+    'ENTRA-MFA-001':       ['Open Entra admin center → Protection → Authentication methods → Policies.', 'For each phishable method (SMS, Voice, Email OTP), set Target → Exclude → "Admins (role-assignable)" group.', 'Enable FIDO2 for the same admin group with Target → Include.', 'Verify with Get-MgPolicyAuthenticationMethodPolicy.'],
+    'DEFENDER-SAFELINKS-002': ['Microsoft 365 Defender → Email & collaboration → Policies & rules → Safe Links → "Default" policy.', 'Toggle "Office 365 apps" → ON.', 'Toggle "Teams" → ON.', 'Uncheck "Let users click through to original URL".', 'Save and verify with Get-SafeLinksPolicy "Default".'],
+    'CA-EXCLUSION-001':    ['Entra admin center → Protection → Conditional Access → Policies → "Require MFA for admins".', 'Under Users → Exclude → remove all directory-role exclusions.', 'Remove individual admin user exclusions.', 'Keep only the dedicated break-glass user(s); document them in the runbook.', 'Quarterly: re-verify with Get-MgIdentityConditionalAccessPolicy.'],
+  })[f.checkId] || [];
+  const verify = ({
+    'ENTRA-MFA-001':       'Get-MgPolicyAuthenticationMethodPolicy | Select-Object -ExpandProperty AuthenticationMethodConfigurations | Where-Object State -EQ "enabled"',
+    'DEFENDER-SAFELINKS-002': 'Get-SafeLinksPolicy "Default" | Select EnableSafeLinksForEmail, EnableSafeLinksForOffice, EnableSafeLinksForTeams, AllowClickThrough',
+    'CA-EXCLUSION-001':    'Get-MgIdentityConditionalAccessPolicy -Filter "displayName eq \'Require MFA for admins\'" | Select-Object -ExpandProperty Conditions',
+  })[f.checkId];
+
+  const risk = ({
+    'ENTRA-MFA-001':       'A compromised admin password without phishing-resistant MFA hands an attacker the entire tenant. SMS and voice are subject to SIM-swap; push fatigue defeats Authenticator. FIDO2 / WHfB / cert-based are the only methods CISA still classifies as phishing-resistant.',
+    'DEFENDER-SAFELINKS-002': 'Office and Teams are dominant phishing-link delivery channels. Without Safe Links rewriting URLs at click-time, zero-day phishing pages bypass perimeter scanning entirely. Click-through allow gives users a one-click escape from the protection.',
+    'CA-EXCLUSION-001':    'Every excluded admin is an MFA-free path to Global Admin. Directory-role exclusions silently grant exclusion to any future user added to the role. Only documented, monitored break-glass accounts should ever appear here.',
+  })[f.checkId];
+
+  // Why it matters (compliance / audit consequence — from B's "Implication")
+  const whyItMatters = ({
+    'ENTRA-MFA-001':       <>This control maps to <b>{f.frameworks.length} frameworks</b>; the gap is a finding in any audit using {f.frameworks.slice(0,2).map(fw => FW[fw]).join(' or ')}. Phishing-resistant MFA for privileged accounts is also a CISA SCuBA M365 baseline requirement and a US federal mandate (M-22-09).</>,
+    'DEFENDER-SAFELINKS-002': <>Safe Links coverage gaps fail explicit checks in <b>{f.frameworks.length} frameworks</b> including {f.frameworks.slice(0,2).map(fw => FW[fw]).join(' and ')}. The "Office apps + Teams" coverage is the line item assessors look for; "Email only" is documented as insufficient.</>,
+    'CA-EXCLUSION-001':    <>Conditional Access exclusions are explicitly inventoried by <b>{f.frameworks.length} frameworks</b>; an exclusion list with anything beyond named break-glass accounts is a documented audit failure under {f.frameworks.slice(0,2).map(fw => FW[fw]).join(' and ')}. The control is also called out by name in CISA SCuBA AAD §2.1.</>,
+  })[f.checkId];
+
+  const initials = (s) => s ? s.split(/\s|@/)[0].slice(0,2).toUpperCase() : '—';
+
+  return (
+    <div className="fd-d">
+      {/* Row 1 — state strip */}
+      <div className="fdd-strip">
+        <div className="fdd-strip-cell">
+          <span className="label">Horizon</span>
+          <span className={'fdc-pill ' + laneClass}>{laneLabel}</span>
+        </div>
+        <div className="fdd-strip-cell">
+          <span className="label">Effort</span>
+          <span className="val">{(f.effort || 'medium')[0].toUpperCase() + (f.effort || 'medium').slice(1)}</span>
+        </div>
+        <div className="fdd-strip-cell">
+          <span className="label">Affected</span>
+          <span className={'val ' + (f.severity === 'critical' ? 'danger' : 'warn')}>
+            {f.affectedObjects?.count} {f.affectedObjects?.kind}
+          </span>
+        </div>
+        <div className="fdd-strip-cell">
+          <span className="label">Owner</span>
+          {f.owner
+            ? <span className="val ownerRow">
+                <span className="fdc-avatar" style={{width:18, height:18, fontSize:9}}>{initials(f.owner)}</span>
+                {f.owner}
+              </span>
+            : <span className="val muted">Unassigned · <a href="#" style={{color:'var(--accent-text)'}}>Assign</a></span>}
+        </div>
+        <div className="fdd-strip-cell">
+          <span className="label">Ticket</span>
+          {f.ticket
+            ? <a href="#" className="val" style={{color:'var(--accent-text)', textDecoration:'none'}}>
+                {f.ticket.system} {f.ticket.id} <span style={{fontSize:10, color:'var(--muted)'}}>· {f.ticket.status}</span>
+              </a>
+            : <span className="fdc-pill empty" style={{cursor:'pointer'}}>+ Create ticket</span>}
+        </div>
+      </div>
+
+      {/* Row 2 — risk + why it matters */}
+      <div className="fdd-risk">
+        <div className="fdd-risk-icon">!</div>
+        <div className="fdd-risk-body">
+          <div className="fdd-risk-section">
+            <div className="fdd-risk-head danger">Risk</div>
+            <p>{risk}</p>
+          </div>
+          <div className="fdd-risk-section">
+            <div className="fdd-risk-head">Why it matters</div>
+            <p>{whyItMatters}</p>
+          </div>
+        </div>
+        {f.mitre?.length > 0 && (
+          <div className="fdd-risk-meta">
+            <span className="fdd-risk-meta-label">MITRE ATT&CK</span>
+            <div className="fdd-mitre">
+              {f.mitre.map(m => <code key={m} title={m}>{m.split(' — ')[0]}</code>)}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Row 3 — main + side rail */}
+      <div className="fdd-grid">
+        <div className="fdd-main">
+          {/* Finding claim (from B) — the structured assertion */}
+          <div className="fdd-claim">
+            <span className="kicker">Finding</span>
+            <span className="body">{claim}</span>
+          </div>
+
+          {/* Typed observed/expected/delta (from B) */}
+          <table className="fdb-diff-table">
+            <tbody>
+              <tr>
+                <th>Observed</th>
+                <td className="observed">{ev.observedValue || f.current}</td>
+              </tr>
+              <tr>
+                <th>Expected</th>
+                <td className="expected">{ev.expectedValue || f.recommended}</td>
+              </tr>
+              <tr>
+                <th>Delta</th>
+                <td style={{color:'var(--danger-text)', fontSize:12.5}}>
+                  {f.affectedObjects?.count} {f.affectedObjects?.kind} non-compliant
+                  {window.FD_SEV_LABEL && <> · severity <b>{window.FD_SEV_LABEL[f.severity]}</b></>}
+                  {f.affectedObjects?.sample?.length > 0 && (
+                    <span className="fdd-samples">
+                      {f.affectedObjects.sample.slice(0,4).map(s => (
+                        <code key={s} className="fdd-sample">{s}</code>
+                      ))}
+                      {f.affectedObjects.sample.length > 4 && (
+                        <span className="fdd-sample-more">+{f.affectedObjects.sample.length - 4} more</span>
+                      )}
+                    </span>
+                  )}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+
+          {/* Action block (from A) with numbered procedure (from B) */}
+          <div className="fda-fix" style={{marginTop:0}}>
+            <div className="fda-fix-tabs">
+              <button className={'fda-fix-tab' + (actionTab==='portal'?' active':'')} onClick={()=>setActionTab('portal')}>
+                Portal <span className="count">{procedure.length || 'UI'}{procedure.length ? ' steps' : ''}</span>
+              </button>
+              {ps && <button className={'fda-fix-tab' + (actionTab==='ps'?' active':'')} onClick={()=>setActionTab('ps')}>
+                PowerShell <span className="count">script</span>
+              </button>}
+              {verify && <button className={'fda-fix-tab' + (actionTab==='verify'?' active':'')} onClick={()=>setActionTab('verify')}>
+                Verify <span className="count">cmd</span>
+              </button>}
+            </div>
+            <div className="fda-fix-body">
+              {actionTab === 'portal' && (
+                procedure.length > 0
+                  ? <ol className="fdd-procedure">{procedure.map((step, i) => <li key={i}>{step}</li>)}</ol>
+                  : <p>{portalSummary}</p>
+              )}
+              {actionTab === 'ps' && ps && <pre><button className="copy-btn">⧉ Copy</button>{ps}</pre>}
+              {actionTab === 'verify' && verify && <pre><button className="copy-btn">⧉ Copy</button>{verify}</pre>}
+            </div>
+          </div>
+        </div>
+
+        {/* Side rail — provenance, mappings, trend, related */}
+        <aside className="fdd-side">
+          <div className="fdc-card">
+            <div className="h">Compliance mappings</div>
+            <div className="fdc-fws">
+              {f.frameworks.map(fw => {
+                const meta = f.fwMeta?.[fw];
+                const profs = (meta?.profiles || []).filter(Boolean);
+                return (
+                  <div key={fw} className="fdd-fw-line">
+                    <span className="nm">{FW[fw] || fw}</span>
+                    <code>{meta?.controlId || '—'}</code>
+                    {profs.length > 0 && (
+                      <span className="lvls">
+                        {profs.map(p => <span key={p} className="lvl">{p}</span>)}
+                      </span>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="fdc-card">
+            <div className="h">Trend · last 3 runs</div>
+            <div className="fdc-history">
+              {(f.history || []).map(h => (
+                <div key={h.date} className="fdc-hist-row">
+                  <span className="date">{h.date}</span>
+                  <span className={'pip ' + (h.status==='Pass'?'pass':h.status==='Warn'?'warn':'fail')}/>
+                  <span className="note">{h.note}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {f.relatedFindings?.length > 0 && (
+            <div className="fdc-card">
+              <div className="h">Related</div>
+              <div className="fdc-related">
+                {f.relatedFindings.map(r => (
+                  <a key={r} href={'#'+r} style={{fontFamily:'var(--font-mono)'}}>↳ {r}</a>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {(f.references || []).length > 0 && (
+            <div className="fdc-card">
+              <div className="h">Learn more</div>
+              <div className="fdc-related">
+                {f.references.map(r => (
+                  <a key={r.url} href={r.url} target="_blank" rel="noreferrer noopener">📖 {r.title} ↗</a>
+                ))}
+              </div>
+            </div>
+          )}
+        </aside>
+      </div>
+
+      {/* Footer — provenance + raw evidence (forensic depth on demand) */}
+      <details className="fdd-prov">
+        <summary>
+          <span className="prov-summary">
+            <span className="prov-key">Source:</span> <code>{ev.evidenceSource}</code>
+            <span className="prov-sep">·</span>
+            <span className="prov-key">Collected:</span> <code>{ev.evidenceTimestamp ? new Date(ev.evidenceTimestamp).toISOString().slice(0,16).replace('T',' ') + ' UTC' : '—'}</code>
+            <span className="prov-sep">·</span>
+            <span className="prov-key">Confidence:</span>
+            <span className="fdd-conf">
+              <span className="fdd-conf-bar"><i style={{width: `${(ev.confidence || 1)*100}%`}}/></span>
+              <b>{Math.round((ev.confidence || 1)*100)}%</b>
+            </span>
+            <span className="prov-sep">·</span>
+            <span className="prov-key">Permission:</span> <code>{ev.permissionRequired || '—'}</code>
+          </span>
+          <span className="prov-toggle">View raw evidence ▾</span>
+        </summary>
+        <div className="fdd-prov-body">
+          <div className="fdd-prov-meta">
+            <div><span className="k">Method</span><span className="v">{ev.collectionMethod || '—'}</span></div>
+            <div><span className="k">Run ID</span><code>{f.checkId.toLowerCase()}-26e4a31</code></div>
+            <div><span className="k">Tenant</span><code>contoso.onmicrosoft.com</code></div>
+          </div>
+          {ev.limitations && (
+            <div className="fdd-limit">
+              <b>⚠ Limitations:</b> {ev.limitations}
+            </div>
+          )}
+          <pre>{ev.raw ? (() => { try { return JSON.stringify(JSON.parse(ev.raw), null, 2); } catch { return ev.raw; }})() : JSON.stringify({observed: ev.observedValue, expected: ev.expectedValue}, null, 2)}</pre>
+        </div>
+      </details>
+    </div>
+  );
+}
+
+window.DirectionD = DirectionD;

--- a/docs/design/finding-detail/fd-host.jsx
+++ b/docs/design/finding-detail/fd-host.jsx
@@ -1,0 +1,42 @@
+// Shared bits for finding-detail directions: a faux table-row header that
+// hosts the expanded panel below, plus tiny status/severity chips. Each
+// direction renders <FdHost finding={...}><Fd?Detail/></FdHost> for parity.
+
+const FD_STATUS_COLORS = { Pass:'pass', Fail:'fail', Warn:'warn', Review:'review', Info:'info' };
+const FD_SEV_LABEL = { critical:'Critical', high:'High', medium:'Medium', low:'Low', info:'Info', none:'None' };
+
+function FdHost({ finding, children }) {
+  const f = finding;
+  return (
+    <div className="fd-host">
+      <div className="fd-host-row">
+        <div>
+          <span className={'status-badge ' + FD_STATUS_COLORS[f.status]}>
+            <span className="dot"/>{f.status}
+          </span>
+        </div>
+        <div>
+          <div className="t">{f.setting}</div>
+          <div className="sub">{f.section}</div>
+        </div>
+        <div className="finding-dom">{f.domain}</div>
+        <div>
+          <code style={{fontFamily:'var(--font-mono)', fontSize:11.5, color:'var(--text-soft)'}}>{f.checkId}</code>
+        </div>
+        <div>
+          <span className={'sev-badge ' + f.severity}>
+            <span className="bar"><i/><i/><i/><i/></span>
+            <span>{FD_SEV_LABEL[f.severity]}</span>
+          </span>
+        </div>
+        <div className="caret">›</div>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+window.FdHost = FdHost;
+window.FD_STATUS_COLORS = FD_STATUS_COLORS;
+window.FD_SEV_LABEL = FD_SEV_LABEL;
+window.FD_FW_NAMES = window.MOCK_FRAMEWORK_NAMES;

--- a/docs/design/finding-detail/index.html
+++ b/docs/design/finding-detail/index.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="neon" data-mode="dark" data-density="compact">
+<head>
+<meta charset="UTF-8"/>
+<title>Finding Detail — Handoff</title>
+<link rel="stylesheet" href="report-themes.css"/>
+<link rel="stylesheet" href="report-shell.css"/>
+<link rel="stylesheet" href="styles.css"/>
+<style>
+  body { background: #0a0616; }
+  .dc-artboard-inner { background: var(--bg); }
+</style>
+</head>
+<body>
+<div id="root"></div>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+<script src="mock-findings.js"></script>
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="fd-host.jsx"></script>
+<script type="text/babel" src="direction-d.jsx"></script>
+
+<script type="text/babel">
+const { useState } = React;
+
+function Frame({ tag, title, blurb, model, children }) {
+  return (
+    <div className="dir-frame">
+      <div className="dir-note">
+        <span className="dir-tag">{tag}</span>
+        <div style={{flex:1}}>
+          <b>{title}</b> — {blurb}
+          {model && <div style={{marginTop:6, fontSize:11.5, color:'var(--muted)', fontFamily:'var(--font-mono)'}}>
+            <b style={{color:'var(--accent-text)'}}>Schema:</b> {model}
+          </div>}
+        </div>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function Canvas() {
+  const F = window.MOCK_FINDINGS;
+  return (
+    <DesignCanvas
+      title="Finding detail — handoff design"
+      subtitle="The recommended pattern for the expanded finding row, shown rendering three real M365-Assess findings (boolean toggle, multi-setting policy, list-shaped evidence). Built for handoff to Claude Code: every section maps to a discrete data field on the finding object.">
+
+      <DCSection id="d" title="Hybrid finding-detail row">
+        <DCArtboard id="d-1" label="ENTRA-MFA-001 — boolean toggle" width={1180} height={920}>
+          <Frame
+            tag="Handoff"
+            title="Finding detail — full schema"
+            model="{ ...claim, evidence: typed, lane, effort, owner, ticket, history[], affectedObjects, riskNarrative, remediation: { portal, ps, verify }, frameworks, fwMeta, mitre, relatedFindings, references }"
+            blurb="State strip (lane · effort · affected · owner · ticket) → risk narrative with MITRE tags → typed observed/expected/delta with sample chips → tabbed action block (Portal procedure · PowerShell · Verify) → side rail (mappings · trend · related · learn-more) → collapsible provenance footer (source · timestamp · confidence · permission · raw evidence). The simplest finding shape — a single boolean control.">
+            <FdHost finding={F[0]}><DirectionD finding={F[0]}/></FdHost>
+          </Frame>
+        </DCArtboard>
+
+        <DCArtboard id="d-2" label="DEFENDER-SAFELINKS-002 — multi-setting policy + Jira ticket" width={1180} height={920}>
+          <Frame
+            tag="Handoff"
+            title="Finding detail — populated workflow state"
+            blurb="Same component rendering a Warn-status finding with an owner and an in-progress Jira ticket. Trend pips show movement (Fail → Warn → Warn) — the signal a stand-up needs. Typed observed/expected reads as a clean delta of three boolean flips.">
+            <FdHost finding={F[1]}><DirectionD finding={F[1]}/></FdHost>
+          </Frame>
+        </DCArtboard>
+
+        <DCArtboard id="d-3" label="CA-EXCLUSION-001 — list-shaped evidence + related cluster" width={1180} height={960}>
+          <Frame
+            tag="Handoff"
+            title="Finding detail — list-shaped evidence"
+            blurb="List-shaped evidence (4 excluded roles) lives natively in the typed observed/expected table; sample chips show the affected admins. The 'Limitations' note appears in the expanded provenance footer. Related findings card surfaces the identity-hardening cluster.">
+            <FdHost finding={F[2]}><DirectionD finding={F[2]}/></FdHost>
+          </Frame>
+        </DCArtboard>
+      </DCSection>
+
+    </DesignCanvas>
+  );
+}
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<Canvas/>);
+</script>
+</body>
+</html>

--- a/docs/design/finding-detail/mock-findings.js
+++ b/docs/design/finding-detail/mock-findings.js
@@ -1,0 +1,155 @@
+// Realistic M365-Assess findings for the finding-detail explorations.
+// Shape mirrors the live REPORT_DATA contract: checkId, setting, section, domain,
+// severity, status, current, recommended, remediation, frameworks[], fwMeta{},
+// references[], evidence{...}, intentDesign, lane, effort.
+//
+// Three findings span the dominant content patterns:
+//   1. ENTRA-MFA-001  — boolean toggle, simple current/recommended, multi-fw
+//   2. DEFENDER-SAFELINKS-002 — policy with multiple sub-settings, structured evidence
+//   3. CA-EXCLUSION-001 — list-shaped evidence (excluded users), workflow-heavy
+
+window.MOCK_FINDINGS = [
+  {
+    checkId: 'ENTRA-MFA-001',
+    setting: 'Phishing-resistant MFA required for all Global Admins',
+    section: 'Authentication methods policy',
+    domain: 'Identity & MFA',
+    severity: 'critical',
+    status: 'Fail',
+    lane: 'now',
+    effort: 'small',
+    intentDesign: false,
+    current: 'SMS + Voice + Authenticator app (push) enabled for admin role-assignable group',
+    recommended: 'FIDO2 security key OR Windows Hello for Business OR certificate-based authentication only. Disable SMS, Voice, Email OTP for admins.',
+    remediation: 'Open Entra admin center → Protection → Authentication methods → Policies. For each phishable method (SMS, Voice, Email OTP), set Target → Exclude group → "Admins (role-assignable)". Run: Update-MgPolicyAuthenticationMethodPolicyAuthenticationMethodConfiguration -AuthenticationMethodConfigurationId Sms -ExcludeTargets @(@{Id="<admin-group-id>"; TargetType="group"}).',
+    frameworks: ['cis-m365-v6', 'nist-800-53', 'cmmc', 'iso-27001', 'nist-csf'],
+    fwMeta: {
+      'cis-m365-v6':  { controlId: '1.1.1', profiles: ['E3-L1', 'E5-L1'] },
+      'nist-800-53':  { controlId: 'IA-2(1), IA-2(11)', profiles: ['Mod', 'High'] },
+      'cmmc':         { controlId: 'IA.L2-3.5.3', profiles: ['L2', 'L3'] },
+      'iso-27001':    { controlId: 'A.8.5', profiles: [] },
+      'nist-csf':     { controlId: 'PR.AA-03', profiles: [] },
+    },
+    references: [
+      { title: 'CISA — Implementing Phishing-Resistant MFA', url: 'https://www.cisa.gov/sites/default/files/publications/fact-sheet-implementing-phishing-resistant-mfa-508c.pdf' },
+      { title: 'Microsoft — Authentication methods policy', url: 'https://learn.microsoft.com/entra/identity/authentication/concept-authentication-methods-manage' },
+    ],
+    evidence: {
+      observedValue: 'SMS=enabled, Voice=enabled, MicrosoftAuthenticator=enabled (push+passwordless), Fido2=disabled, WindowsHelloForBusiness=disabled, X509Certificate=disabled',
+      expectedValue: 'Fido2=enabled OR WindowsHelloForBusiness=enabled OR X509Certificate=enabled; SMS, Voice, Email disabled for admin-assignable role group',
+      evidenceSource: 'Graph: GET /policies/authenticationMethodsPolicy',
+      evidenceTimestamp: '2026-04-26T14:32:08Z',
+      collectionMethod: 'graph-readonly',
+      permissionRequired: 'Policy.Read.All',
+      confidence: 1.0,
+      raw: '{"id":"authenticationMethodsPolicy","authenticationMethodConfigurations":[{"id":"Sms","state":"enabled","includeTargets":[{"targetType":"group","id":"all_users"}]},{"id":"Voice","state":"enabled","includeTargets":[{"targetType":"group","id":"all_users"}]},{"id":"Fido2","state":"disabled"}]}',
+    },
+    affectedObjects: { kind: 'admins', count: 7, sample: ['ceo@contoso.com', 'cto@contoso.com', 'gadmin1@contoso.com', '+ 4 more'] },
+    history: [
+      { date: '2026-01-12', status: 'Fail', note: 'Initial baseline' },
+      { date: '2026-02-08', status: 'Fail', note: 'No change' },
+      { date: '2026-04-26', status: 'Fail', note: 'Currently failing' },
+    ],
+    mitre: ['T1078.004 — Cloud Accounts', 'T1556.006 — Modify Auth Process: MFA'],
+    relatedFindings: ['ENTRA-CLOUDADMIN-003', 'CA-EXCLUSION-001', 'ENTRA-BREAKGLASS-002'],
+    owner: null,
+    ticket: null,
+  },
+
+  {
+    checkId: 'DEFENDER-SAFELINKS-002',
+    setting: 'Safe Links policy enabled for Office apps and Teams',
+    section: 'Defender for Office 365 — Safe Links',
+    domain: 'Email Security',
+    severity: 'high',
+    status: 'Warn',
+    lane: 'soon',
+    effort: 'small',
+    intentDesign: false,
+    current: 'Safe Links Email policy: ON. Office apps: OFF. Teams: OFF. Track user clicks: ON. Allow click-through: ON.',
+    recommended: 'Enable Safe Links across Email + Office apps + Teams. Disable click-through on the original URL. Track user clicks. Apply to all recipients.',
+    remediation: 'Microsoft 365 Defender → Email & collaboration → Policies & rules → Safe Links → Edit "Default" policy. Toggle "Office 365 apps" and "Teams" to ON. Uncheck "Let users click through to original URL". Run: Set-SafeLinksPolicy -Identity "Default" -EnableSafeLinksForOffice $true -EnableSafeLinksForTeams $true -AllowClickThrough $false -TrackClicks $true.',
+    frameworks: ['cis-m365-v6', 'nist-800-53', 'iso-27001'],
+    fwMeta: {
+      'cis-m365-v6':  { controlId: '2.1.1', profiles: ['E5-L1'] },
+      'nist-800-53':  { controlId: 'SC-44, SI-8', profiles: ['Mod'] },
+      'iso-27001':    { controlId: 'A.8.7', profiles: [] },
+    },
+    references: [
+      { title: 'Microsoft — Safe Links recommended settings', url: 'https://learn.microsoft.com/defender-office-365/recommended-settings-for-eop-and-office365' },
+    ],
+    evidence: {
+      observedValue: 'EnableSafeLinksForEmail=true, EnableSafeLinksForOffice=false, EnableSafeLinksForTeams=false, AllowClickThrough=true, TrackClicks=true',
+      expectedValue: 'EnableSafeLinksForEmail=true, EnableSafeLinksForOffice=true, EnableSafeLinksForTeams=true, AllowClickThrough=false, TrackClicks=true',
+      evidenceSource: 'Exchange Online: Get-SafeLinksPolicy "Default"',
+      evidenceTimestamp: '2026-04-26T14:34:51Z',
+      collectionMethod: 'exchange-online-powershell',
+      permissionRequired: 'Security Administrator',
+      confidence: 1.0,
+    },
+    affectedObjects: { kind: 'users', count: 1247, sample: ['All licensed users'] },
+    history: [
+      { date: '2026-01-12', status: 'Fail', note: 'Initial baseline — all off' },
+      { date: '2026-03-04', status: 'Warn', note: 'Email enabled' },
+      { date: '2026-04-26', status: 'Warn', note: 'Office + Teams still off' },
+    ],
+    mitre: ['T1566.002 — Spearphishing Link'],
+    relatedFindings: ['DEFENDER-SAFEATTACH-001', 'DEFENDER-ANTIPHISH-002'],
+    owner: 'Security ops',
+    ticket: { system: 'Jira', id: 'SEC-1421', status: 'In progress' },
+  },
+
+  {
+    checkId: 'CA-EXCLUSION-001',
+    setting: 'Conditional Access — admin role exclusions from MFA policy',
+    section: 'Conditional Access policies',
+    domain: 'Identity & MFA',
+    severity: 'critical',
+    status: 'Fail',
+    lane: 'now',
+    effort: 'medium',
+    intentDesign: false,
+    current: '4 directory roles excluded from "Require MFA for admins" CA policy: Global Administrator (1 user), Privileged Role Administrator (2 users), Helpdesk Administrator (1 user). 1 emergency-access account included (expected).',
+    recommended: 'Only break-glass / emergency-access accounts may be excluded from MFA. All other admin accounts must be enforced. Document break-glass exclusions with quarterly review.',
+    remediation: 'Entra admin center → Protection → Conditional Access → Policies → "Require MFA for admins". Under Users → Exclude → remove all directory roles and individual admin user exclusions. Keep only the dedicated break-glass user(s). Verify with: Get-MgIdentityConditionalAccessPolicy -Filter "displayName eq \'Require MFA for admins\'" | Select-Object -ExpandProperty Conditions.',
+    frameworks: ['cis-m365-v6', 'nist-800-53', 'cmmc'],
+    fwMeta: {
+      'cis-m365-v6':  { controlId: '1.1.3', profiles: ['E3-L1'] },
+      'nist-800-53':  { controlId: 'AC-6(5), IA-2(1)', profiles: ['Mod', 'High'] },
+      'cmmc':         { controlId: 'AC.L2-3.1.5', profiles: ['L2'] },
+    },
+    references: [
+      { title: 'Microsoft — Securing privileged access', url: 'https://learn.microsoft.com/security/privileged-access-workstations/overview' },
+    ],
+    evidence: {
+      observedValue: '[{"role":"Global Administrator","userCount":1,"users":["legacy-svc@contoso.com"]},{"role":"Privileged Role Administrator","userCount":2,"users":["pra1@contoso.com","pra2@contoso.com"]},{"role":"Helpdesk Administrator","userCount":1,"users":["help@contoso.com"]}]',
+      expectedValue: 'Only documented break-glass accounts excluded. Maximum 2 break-glass accounts.',
+      evidenceSource: 'Graph: GET /identity/conditionalAccess/policies/{id}',
+      evidenceTimestamp: '2026-04-26T14:36:22Z',
+      collectionMethod: 'graph-readonly',
+      permissionRequired: 'Policy.Read.All',
+      confidence: 1.0,
+      limitations: 'Excluded users count derived from directory role membership at scan time; may drift if memberships change.',
+    },
+    affectedObjects: { kind: 'admins', count: 4, sample: ['legacy-svc@contoso.com', 'pra1@contoso.com', 'pra2@contoso.com', 'help@contoso.com'] },
+    history: [
+      { date: '2026-01-12', status: 'Fail', note: '6 exclusions' },
+      { date: '2026-03-04', status: 'Fail', note: '5 exclusions (1 removed)' },
+      { date: '2026-04-26', status: 'Fail', note: '4 exclusions remain' },
+    ],
+    mitre: ['T1078.004 — Cloud Accounts', 'T1098 — Account Manipulation'],
+    relatedFindings: ['ENTRA-MFA-001', 'ENTRA-BREAKGLASS-002', 'ENTRA-PIM-001'],
+    owner: 'Identity team',
+    ticket: null,
+  },
+];
+
+window.MOCK_FRAMEWORK_NAMES = {
+  'cis-m365-v6':  'CIS M365 v6',
+  'nist-800-53':  'NIST 800-53',
+  'cmmc':         'CMMC 2.0',
+  'iso-27001':    'ISO 27001',
+  'nist-csf':     'NIST CSF',
+  'pci-dss':      'PCI-DSS',
+  'hipaa':        'HIPAA',
+};

--- a/docs/design/finding-detail/redesign.css
+++ b/docs/design/finding-detail/redesign.css
@@ -1,0 +1,556 @@
+/* Framework Redesign — direction-specific styles */
+/* Inherits all theme tokens from report-themes.css + report-shell.css */
+
+/* ============= Shared utilities ============= */
+.fw-readiness-pill {
+  display:inline-block; padding:2px 8px; border-radius:10px;
+  font-size:11px; font-weight:700; letter-spacing:.04em;
+  text-transform:uppercase; line-height:1.4;
+}
+.fw-readiness-pill.pass { background:var(--success-soft); color:var(--success-text); }
+.fw-readiness-pill.warn { background:var(--warn-soft); color:var(--warn-text); }
+.fw-readiness-pill.fail { background:var(--danger-soft); color:var(--danger-text); }
+
+.leg-dot {
+  display:inline-block; width:8px; height:8px; border-radius:2px; margin-right:5px;
+  vertical-align:middle;
+}
+.leg-dot.pass { background:var(--success); }
+.leg-dot.warn { background:var(--warn); }
+.leg-dot.fail { background:var(--danger); }
+.leg-dot.review { background:var(--accent); opacity:.7; }
+.leg-dot.info { background:var(--muted); opacity:.5; }
+
+/* family chart shared by all directions */
+.fw-fam-chart { display:flex; flex-direction:column; gap:4px; }
+.fw-fam-row {
+  display:grid; grid-template-columns: 36px 180px 1fr 70px 44px;
+  align-items:center; gap:10px; padding:7px 8px; border-radius:6px;
+  font-size:13px;
+}
+.fw-fam-row:hover { background:var(--hover); }
+.fw-fam-code {
+  font-family:var(--font-mono); font-size:11px; color:var(--muted);
+  background:var(--chip); padding:2px 6px; border-radius:4px;
+  text-align:center; font-weight:600;
+}
+.fw-fam-name { color:var(--text); font-weight:500; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.fw-fam-track { display:flex; }
+.fw-fam-bar { height:8px; border-radius:4px; flex:1; }
+.fw-fam-stat {
+  font-family:var(--font-mono); font-size:11px; text-align:right;
+}
+.fw-fam-stat.pass { color:var(--success-text); }
+.fw-fam-stat.warn { color:var(--warn-text); }
+.fw-fam-stat.fail { color:var(--danger-text); font-weight:600; }
+.fw-fam-pct {
+  font-family:var(--font-mono); font-size:13px; font-weight:700;
+  font-variant-numeric:tabular-nums; text-align:right; color:var(--text);
+}
+
+/* ============= Direction A — Toolbar + Focus ============= */
+.fw-tb-toolbar {
+  display:flex; align-items:flex-end; gap:18px;
+  background:var(--bg-elev); border:1px solid var(--border);
+  border-radius:10px; padding:14px 16px; margin-bottom:18px;
+  flex-wrap:wrap;
+}
+.fw-tb-divider {
+  width:1px; align-self:stretch; background:var(--border);
+  margin:4px 0;
+}
+.fw-tb-trigger {
+  display:flex; align-items:center; gap:10px;
+  background:var(--input-bg); border:1px solid var(--border-strong);
+  border-radius:8px; padding:9px 12px; min-width:340px;
+  cursor:pointer; color:var(--text); transition:border-color .15s, box-shadow .15s;
+}
+.fw-tb-trigger:hover { border-color:var(--accent-border); }
+.fw-tb-trigger[aria-expanded=true] { border-color:var(--accent); box-shadow:0 0 0 3px var(--accent-ring); }
+.fw-tb-trigger-name { font-weight:600; font-size:14px; flex:1; text-align:left; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.fw-tb-trigger-id { font-family:var(--font-mono); font-size:11px; color:var(--muted); }
+.fw-tb-menu {
+  position:absolute; top:calc(100% + 6px); left:0; min-width:480px;
+  background:var(--bg-elev); border:1px solid var(--border-strong);
+  border-radius:8px; box-shadow:0 8px 24px var(--shadow);
+  padding:4px; z-index:20; max-height:60vh; overflow-y:auto;
+}
+.fw-tb-opt {
+  display:flex; align-items:center; gap:14px; width:100%;
+  padding:10px 12px; border-radius:6px; cursor:pointer;
+  background:none; border:0; text-align:left; color:var(--text);
+}
+.fw-tb-opt:hover { background:var(--hover); }
+.fw-tb-opt.active { background:var(--accent-soft); }
+.fw-tb-opt-name { font-size:13px; font-weight:600; }
+.fw-tb-opt-id { font-family:var(--font-mono); font-size:11px; color:var(--muted); margin-top:1px; }
+.fw-tb-opt-score { text-align:right; flex-shrink:0; }
+.fw-tb-opt-pct { font-family:var(--font-mono); font-size:15px; font-weight:700; }
+.fw-tb-opt-pct.pass { color:var(--success-text); }
+.fw-tb-opt-pct.warn { color:var(--warn-text); }
+.fw-tb-opt-pct.fail { color:var(--danger-text); }
+.fw-tb-opt-gaps { font-size:11px; color:var(--muted); margin-top:2px; }
+
+.fw-tb-actions { margin-left:auto; display:flex; gap:8px; align-items:flex-end; }
+.fw-tb-info-btn, .fw-tb-clear {
+  display:inline-flex; align-items:center; gap:5px;
+  background:none; border:1px solid var(--border); color:var(--text-soft);
+  border-radius:6px; padding:7px 10px; font-size:12px; cursor:pointer;
+}
+.fw-tb-info-btn:hover, .fw-tb-clear:hover { border-color:var(--accent-border); color:var(--text); }
+.fw-tb-cta { padding:8px 14px !important; }
+
+.fw-tb-info-blurb {
+  background:var(--bg-elev-2); border:1px solid var(--border);
+  border-radius:8px; padding:12px 14px; margin-bottom:14px;
+  font-size:13px; color:var(--text-soft); line-height:1.55;
+}
+
+.fw-tb-score {
+  background:var(--bg-elev); border:1px solid var(--border);
+  border-radius:10px; padding:18px 20px; margin-bottom:18px;
+}
+.fw-tb-score-num {
+  display:flex; align-items:center; gap:18px; margin-bottom:14px;
+}
+.fw-tb-score-pct {
+  font-family:var(--font-display); font-size:64px; font-weight:700;
+  letter-spacing:-.03em; line-height:1; font-variant-numeric:tabular-nums;
+}
+.fw-tb-score-pct.pass { color:var(--success-text); }
+.fw-tb-score-pct.warn { color:var(--warn-text); }
+.fw-tb-score-pct.fail { color:var(--danger-text); }
+.fw-tb-score-meta { display:flex; flex-direction:column; }
+.fw-tb-score-bar { height:12px !important; border-radius:6px !important; margin-bottom:10px; }
+.fw-tb-score-legend {
+  display:flex; gap:18px; font-size:12px; color:var(--text-soft);
+  font-variant-numeric:tabular-nums; flex-wrap:wrap;
+}
+
+.fw-tb-fam-section {
+  background:var(--bg-elev); border:1px solid var(--border);
+  border-radius:10px; padding:18px 20px;
+}
+.fw-tb-fam-head { margin-bottom:12px; }
+
+/* ============= Direction B — Pinned chips + side rail ============= */
+.fw-chips-rail {
+  display:flex; gap:10px; flex-wrap:wrap; margin-bottom:18px;
+  padding-bottom:14px; border-bottom:1px solid var(--border);
+}
+.fw-chip-b {
+  background:var(--bg-elev); border:1px solid var(--border);
+  border-radius:10px; padding:10px 12px; min-width:160px; flex:0 1 180px;
+  cursor:pointer; color:var(--text); text-align:left;
+  transition:border-color .15s, transform .15s;
+}
+.fw-chip-b:hover { border-color:var(--border-strong); transform:translateY(-1px); }
+.fw-chip-b.active {
+  border-color:var(--accent); box-shadow:0 0 0 1px var(--accent-border) inset, 0 4px 14px var(--accent-ring);
+  background:var(--surface);
+}
+.fw-chip-b-top {
+  display:flex; align-items:baseline; justify-content:space-between;
+  margin-bottom:6px;
+}
+.fw-chip-b-name { font-size:13px; font-weight:600; }
+.fw-chip-b-pct {
+  font-family:var(--font-mono); font-size:13px; font-weight:700;
+  font-variant-numeric:tabular-nums;
+}
+.fw-chip-b-pct.pass { color:var(--success-text); }
+.fw-chip-b-pct.warn { color:var(--warn-text); }
+.fw-chip-b-pct.fail { color:var(--danger-text); }
+.fw-chip-b-bar { height:6px !important; border-radius:3px !important; margin-bottom:6px; }
+.fw-chip-b-meta {
+  display:flex; gap:6px; font-size:11px; color:var(--muted);
+  font-family:var(--font-mono);
+}
+.fw-chip-b-more {
+  background:transparent; border-style:dashed;
+  display:flex; flex-direction:column; justify-content:center;
+}
+.fw-chip-b-more:hover { background:var(--hover); }
+
+.fw-focus-b {
+  background:var(--bg-elev); border:1px solid var(--border);
+  border-radius:12px; padding:20px 22px;
+}
+.fw-focus-b-head {
+  display:flex; align-items:flex-start; gap:18px; margin-bottom:14px;
+  padding-bottom:14px; border-bottom:1px solid var(--border);
+}
+.fw-focus-b-name { font-family:var(--font-display); font-size:22px; font-weight:700; letter-spacing:-.02em; }
+.fw-focus-b-org { font-size:12px; color:var(--muted); margin-top:2px; }
+.fw-focus-b-readiness { text-align:right; flex-shrink:0; }
+.fw-focus-b-pct {
+  font-family:var(--font-display); font-size:42px; font-weight:700;
+  letter-spacing:-.03em; line-height:1; font-variant-numeric:tabular-nums;
+}
+.fw-focus-b-pct.pass { color:var(--success-text); }
+.fw-focus-b-pct.warn { color:var(--warn-text); }
+.fw-focus-b-pct.fail { color:var(--danger-text); }
+.fw-focus-b-profiles { display:flex; gap:6px; align-items:center; flex-wrap:wrap; margin-bottom:14px; }
+.fw-focus-b-mainbar { height:12px !important; border-radius:6px !important; margin-bottom:10px; }
+.fw-focus-b-legend {
+  display:flex; gap:18px; font-size:12px; color:var(--text-soft);
+  font-variant-numeric:tabular-nums; align-items:center; flex-wrap:wrap;
+}
+
+.fw-compare-grid {
+  display:grid; grid-template-columns: 1fr 1fr; gap:14px;
+}
+.fw-compare-grid .fw-focus-b-name { font-size:18px; }
+.fw-compare-grid .fw-focus-b-pct { font-size:32px; }
+
+/* ============= Direction C — Comparison table ============= */
+.fw-cmp-table {
+  background:var(--bg-elev); border:1px solid var(--border);
+  border-radius:10px; overflow:hidden; margin-bottom:14px;
+}
+.fw-cmp-row {
+  display:grid; grid-template-columns: 2fr 90px 110px 110px 1.4fr 50px;
+  align-items:center; gap:14px; padding:12px 16px;
+  border-bottom:1px solid var(--border); cursor:pointer;
+  transition:background .12s;
+}
+.fw-cmp-row:last-child { border-bottom:0; }
+.fw-cmp-row:hover { background:var(--hover); }
+.fw-cmp-row.focused { background:var(--accent-soft); border-left:3px solid var(--accent); padding-left:13px; }
+.fw-cmp-head {
+  background:var(--bg-elev-2); cursor:default;
+  font-size:11px; color:var(--muted); text-transform:uppercase;
+  letter-spacing:.08em; font-weight:700;
+  padding-top:10px; padding-bottom:10px;
+}
+.fw-cmp-head:hover { background:var(--bg-elev-2); }
+.fw-cmp-name { font-size:14px; font-weight:600; }
+.fw-cmp-id { font-family:var(--font-mono); font-size:11px; color:var(--muted); margin-top:1px; }
+.fw-cmp-pct-cell { text-align:right; }
+.fw-cmp-pct {
+  font-family:var(--font-mono); font-size:20px; font-weight:700;
+  font-variant-numeric:tabular-nums; line-height:1;
+}
+.fw-cmp-pct.pass { color:var(--success-text); }
+.fw-cmp-pct.warn { color:var(--warn-text); }
+.fw-cmp-pct.fail { color:var(--danger-text); }
+.fw-cmp-pct-sub { font-size:11px; color:var(--muted); font-family:var(--font-mono); margin-top:2px; }
+.fw-cmp-gaps {
+  font-family:var(--font-mono); font-size:14px; font-weight:700;
+  font-variant-numeric:tabular-nums;
+}
+.fw-cmp-gaps .pass { color:var(--success-text); }
+.fw-cmp-gaps .warn { color:var(--warn-text); }
+.fw-cmp-gaps .fail { color:var(--danger-text); }
+.fw-cmp-act { display:flex; align-items:center; gap:6px; justify-content:flex-end; }
+.fw-cmp-rm-btn {
+  background:none; border:0; color:var(--muted); cursor:pointer;
+  font-size:18px; line-height:1; padding:0 4px; border-radius:3px;
+  opacity:0; transition:opacity .15s;
+}
+.fw-cmp-row:hover .fw-cmp-rm-btn { opacity:.7; }
+.fw-cmp-rm-btn:hover { color:var(--danger-text); opacity:1 !important; }
+.fw-cmp-chev { color:var(--muted); font-size:14px; }
+
+.fw-cmp-detail {
+  background:var(--bg-elev); border:1px solid var(--accent-border);
+  border-radius:10px; padding:18px 20px;
+}
+.fw-cmp-detail-head {
+  display:flex; align-items:flex-end; gap:14px;
+  flex-wrap:wrap;
+}
+.fw-cmp-detail-name { font-family:var(--font-display); font-size:20px; font-weight:700; letter-spacing:-.02em; }
+
+/* ============= Direction Merged — donut + adaptive ============= */
+.fw-donut-wrap {
+  position:relative; flex-shrink:0;
+}
+.fw-donut { display:block; }
+.fw-donut-center {
+  position:absolute; inset:0;
+  display:flex; flex-direction:column; align-items:center; justify-content:center;
+  pointer-events:none;
+}
+.fw-donut-pct {
+  font-family:var(--font-display); font-weight:700;
+  font-size:38px; line-height:1; letter-spacing:-.02em;
+  font-variant-numeric:tabular-nums;
+}
+.fw-donut-pct span {
+  font-size:.5em; color:var(--muted); font-weight:500; margin-left:1px;
+}
+.fw-donut-pct.pass { color:var(--success-text); }
+.fw-donut-pct.warn { color:var(--warn-text); }
+.fw-donut-pct.fail { color:var(--danger-text); }
+.fw-donut-sub {
+  font-size:11px; color:var(--muted); font-family:var(--font-mono);
+  margin-top:4px; font-variant-numeric:tabular-nums;
+}
+
+.fw-merged-score { padding:20px 22px; }
+.fw-merged-score-grid {
+  display:grid; grid-template-columns: auto 1fr auto;
+  align-items:center; gap:24px;
+}
+.fw-merged-score-info { min-width:0; }
+.fw-merged-score-name {
+  font-family:var(--font-display); font-size:22px; font-weight:700;
+  letter-spacing:-.02em; line-height:1.2;
+}
+.fw-merged-score-org { font-size:12px; color:var(--muted); margin-top:2px; }
+.fw-merged-score-cta {
+  display:flex; flex-direction:column; align-items:flex-end; gap:8px;
+  align-self:stretch; justify-content:center;
+}
+
+/* Coverage comparison chart */
+.fw-cov-chart {
+  background:var(--bg-elev); border:1px solid var(--border);
+  border-radius:10px; padding:18px 20px; margin-bottom:14px;
+}
+.fw-cov-chart-head {
+  display:flex; align-items:flex-end; justify-content:space-between;
+  margin-bottom:14px; gap:14px;
+}
+.fw-cov-chart-axis {
+  display:flex; justify-content:space-between;
+  width:50%; max-width:520px;
+  font-size:10px; color:var(--muted); font-family:var(--font-mono);
+  letter-spacing:.04em;
+  padding-right:90px; /* aligns with track right edge */
+}
+.fw-cov-chart-body { display:flex; flex-direction:column; gap:3px; }
+.fw-cov-row {
+  display:grid; grid-template-columns: 130px 1fr 80px;
+  align-items:center; gap:14px;
+  background:none; border:0; padding:8px 10px; border-radius:6px;
+  cursor:pointer; color:var(--text); text-align:left;
+  transition:background .12s;
+}
+.fw-cov-row:hover { background:var(--hover); }
+.fw-cov-row.focused {
+  background:var(--accent-soft);
+  box-shadow:inset 3px 0 0 var(--accent);
+}
+.fw-cov-name {
+  font-size:13px; font-weight:600;
+  white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
+}
+.fw-cov-track {
+  position:relative; height:14px;
+}
+.fw-cov-bar {
+  height:14px !important; border-radius:4px !important;
+}
+.fw-cov-marker {
+  position:absolute; top:-2px; bottom:-2px;
+  width:2px; background:var(--text);
+  transform:translateX(-1px);
+  pointer-events:none;
+}
+.fw-cov-marker-pct {
+  position:absolute; bottom:calc(100% + 2px); left:50%;
+  transform:translateX(-50%);
+  font-family:var(--font-mono); font-size:10px; font-weight:700;
+  font-variant-numeric:tabular-nums;
+  background:var(--bg-elev); padding:1px 4px; border-radius:3px;
+  border:1px solid var(--border);
+  white-space:nowrap;
+}
+.fw-cov-marker-pct.pass { color:var(--success-text); }
+.fw-cov-marker-pct.warn { color:var(--warn-text); }
+.fw-cov-marker-pct.fail { color:var(--danger-text); }
+.fw-cov-gaps {
+  font-family:var(--font-mono); font-size:11px; font-weight:600;
+  text-align:right; font-variant-numeric:tabular-nums;
+}
+.fw-cov-gaps.pass { color:var(--success-text); }
+.fw-cov-gaps.warn { color:var(--warn-text); }
+.fw-cov-gaps.fail { color:var(--danger-text); }
+.fw-cov-chart-legend {
+  display:flex; gap:14px; font-size:11px; color:var(--text-soft);
+  margin-top:10px; padding-top:10px; border-top:1px solid var(--border);
+}
+
+.fw-merged-detail .fw-merged-score-grid { gap:18px; }
+
+.ct.pass { color:var(--success-text); }
+.ct.warn { color:var(--warn-text); }
+.ct.fail { color:var(--danger-text); }
+
+/* ============= Direction Merged — polish additions ============= */
+
+/* Manage frameworks dropdown */
+.fw-manage-menu {
+  right:0; left:auto; min-width:380px;
+  top:calc(100% + 6px); max-height:70vh;
+  animation: fw-menu-in .14s cubic-bezier(.22,1,.36,1);
+}
+@keyframes fw-menu-in {
+  from { opacity:0; transform:translateY(-4px); }
+  to   { opacity:1; transform:translateY(0); }
+}
+.fw-manage-head {
+  padding:8px 12px 10px;
+  border-bottom:1px solid var(--border);
+  margin-bottom:4px;
+  display:flex; align-items:center; justify-content:space-between; gap:12px;
+}
+.fw-manage-eyebrow {
+  font-size:11px; color:var(--muted); text-transform:uppercase;
+  letter-spacing:.08em; font-weight:600;
+}
+.fw-manage-bulk { display:flex; gap:6px; align-items:center; font-size:11px; color:var(--muted); }
+.fw-manage-bulk button {
+  background:none; border:0; color:var(--accent-text);
+  font-size:11px; font-weight:600; cursor:pointer; padding:2px 4px;
+  border-radius:3px;
+}
+.fw-manage-bulk button:hover { background:var(--accent-soft); }
+.fw-manage-bulk button:disabled { color:var(--muted); cursor:not-allowed; opacity:.5; }
+.fw-manage-bulk button:disabled:hover { background:none; }
+
+/* Sortable column headers */
+.fw-cmp-sort {
+  background:none; border:0; padding:0; cursor:pointer;
+  color:var(--muted); font-size:11px; font-weight:700;
+  text-transform:uppercase; letter-spacing:.06em;
+  font-family:inherit;
+  display:inline-flex; align-items:center; gap:5px;
+  transition:color .12s;
+}
+.fw-cmp-sort:hover { color:var(--text); }
+.fw-sort-caret {
+  display:inline-block; width:10px; font-size:9px; line-height:1;
+  color:var(--muted); opacity:.4;
+}
+.fw-sort-caret.active { color:var(--accent-text); opacity:1; }
+
+/* Donut percentage tone fallback for review */
+.fw-donut-pct.review { color:var(--accent-text); }
+
+/* Coverage row hover lift */
+.fw-cov-row {
+  background:none; border:0; padding:6px 8px; border-radius:6px;
+  font-family:inherit; cursor:pointer;
+  text-align:left;
+}
+.fw-cov-row .fw-cov-bar { transition:filter .15s; }
+.fw-cov-row:hover .fw-cov-bar { filter:brightness(1.12); }
+.fw-cov-row.focused .fw-cov-bar { box-shadow:0 0 0 1px var(--accent); }
+
+/* Family chart — clickable */
+.fw-fam-row-btn {
+  background:none; border:0; width:100%;
+  padding:7px 8px; border-radius:6px;
+  font-family:inherit; cursor:pointer;
+  text-align:left;
+  transition:background .12s;
+}
+.fw-fam-row-btn.focused {
+  background:var(--accent-soft);
+  box-shadow:inset 3px 0 0 var(--accent);
+}
+.fw-fam-row-btn:hover .fw-fam-bar { filter:brightness(1.12); }
+
+/* Filter banner */
+.fw-filter-banner {
+  display:flex; align-items:center; gap:8px;
+  background:var(--accent-soft); color:var(--accent-text);
+  border:1px solid var(--accent-border); border-radius:6px;
+  padding:8px 12px; margin-bottom:12px;
+  font-size:12px;
+  animation: fw-banner-in .2s cubic-bezier(.22,1,.36,1);
+}
+@keyframes fw-banner-in {
+  from { opacity:0; transform:translateY(-3px); }
+  to   { opacity:1; transform:translateY(0); }
+}
+.fw-filter-banner button {
+  margin-left:auto; background:none; border:0;
+  color:var(--accent-text); font-weight:600; cursor:pointer;
+  font-size:11px; text-transform:uppercase; letter-spacing:.06em;
+  padding:2px 6px; border-radius:3px;
+}
+.fw-filter-banner button:hover { background:rgba(255,255,255,.06); }
+
+/* Primary CTA button */
+.fw-gaps-cta {
+  display:inline-flex; align-items:center; gap:10px;
+  background:var(--accent); color:#fff;
+  border:1px solid var(--accent);
+  border-radius:8px;
+  padding:10px 16px;
+  font-size:13px; font-weight:600;
+  font-family:inherit;
+  cursor:pointer;
+  box-shadow:0 1px 0 rgba(255,255,255,.06) inset, 0 4px 14px -4px var(--accent);
+  transition:transform .12s, box-shadow .15s, filter .15s;
+}
+.fw-gaps-cta:hover { filter:brightness(1.1); box-shadow:0 1px 0 rgba(255,255,255,.08) inset, 0 6px 18px -4px var(--accent); }
+.fw-gaps-cta:active { transform:translateY(1px); }
+.fw-gaps-cta-num {
+  font-family:var(--font-mono); font-weight:700;
+  background:rgba(0,0,0,.22); border-radius:4px;
+  padding:2px 7px; font-size:13px;
+  font-variant-numeric:tabular-nums;
+}
+.fw-gaps-cta-label { white-space:nowrap; }
+
+/* Detail panel — fade transition between focused frameworks */
+.fw-merged-detail-anim {
+  animation: fw-detail-fade .35s cubic-bezier(.22,1,.36,1);
+}
+@keyframes fw-detail-fade {
+  from { opacity:0; transform:translateY(4px); }
+  to   { opacity:1; transform:translateY(0); }
+}
+.fw-merged-detail-eyebrow {
+  font-size:11px; color:var(--muted);
+  text-transform:uppercase; letter-spacing:.08em; font-weight:600;
+  margin-bottom:2px;
+  display:inline-flex; align-items:center; gap:6px;
+}
+.fw-merged-detail-arrow {
+  display:inline-flex; align-items:center; justify-content:center;
+  width:18px; height:18px; border-radius:50%;
+  background:var(--accent-soft); color:var(--accent-text);
+  font-size:11px; font-weight:700;
+  border:1px solid var(--accent-border);
+}
+
+/* Empty state */
+.fw-empty-state {
+  background:var(--bg-elev); border:1px dashed var(--border);
+  border-radius:10px; padding:48px 24px;
+  display:flex; flex-direction:column; align-items:center; gap:10px;
+  text-align:center;
+}
+.fw-empty-icon { color:var(--muted); margin-bottom:6px; }
+.fw-empty-title {
+  font-family:var(--font-display); font-size:18px; font-weight:700;
+  color:var(--text); letter-spacing:-.01em;
+}
+.fw-empty-msg { font-size:13px; color:var(--muted); margin-bottom:8px; }
+
+/* ============= Canvas chrome ============= */
+.dir-frame {
+  background:var(--bg);
+  padding:32px 36px;
+  min-height:760px;
+  color:var(--text);
+}
+
+.dir-note {
+  background:var(--bg-elev-2); border-left:3px solid var(--accent);
+  padding:10px 14px; margin-bottom:18px; border-radius:0 6px 6px 0;
+  font-size:12px; color:var(--text-soft); line-height:1.55;
+}
+.dir-note b { color:var(--text); font-weight:700; }
+.dir-note .dir-tag {
+  font-family:var(--font-mono); font-size:11px; font-weight:700;
+  background:var(--accent-soft); color:var(--accent-text);
+  padding:2px 6px; border-radius:3px; margin-right:8px;
+  text-transform:uppercase; letter-spacing:.06em;
+}

--- a/docs/design/finding-detail/styles.css
+++ b/docs/design/finding-detail/styles.css
@@ -1,0 +1,708 @@
+/* Finding-detail explorations — local styles, layered on report-shell.css */
+
+/* Direction frame chrome (mirrors framework-redesign) */
+.dir-frame {
+  display: flex; flex-direction: column; gap: 14px;
+  padding: 18px; height: 100%; box-sizing: border-box;
+  background: var(--bg);
+}
+.dir-note {
+  font-size: 12px; line-height: 1.55; color: var(--text-soft);
+  padding: 10px 12px; background: var(--surface);
+  border: 1px solid var(--border); border-radius: 8px;
+  display: flex; gap: 10px; align-items: baseline; flex-wrap: wrap;
+}
+.dir-note b { color: var(--text); }
+.dir-tag {
+  display: inline-block; padding: 2px 8px; border-radius: 999px;
+  font-size: 10px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase;
+  background: var(--accent-soft); color: var(--accent-text);
+  border: 1px solid var(--accent-border);
+  flex-shrink: 0;
+}
+
+/* The fake "table row + expanded panel" container that hosts each direction */
+.fd-host {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+}
+.fd-host-row {
+  display: grid; grid-template-columns: 90px 1fr 180px 100px 110px 28px;
+  gap: 12px; align-items: center;
+  padding: 12px 14px; background: var(--surface);
+  border-bottom: 1px solid var(--border); cursor: default;
+}
+.fd-host-row .t { font-weight: 600; font-size: 13.5px; color: var(--text); }
+.fd-host-row .sub { font-size: 11.5px; color: var(--muted); margin-top: 2px; }
+.fd-host-row .caret { color: var(--accent); transform: rotate(90deg); }
+
+/* ============================================================ */
+/* Direction A — Diagnosis-first */
+/* ============================================================ */
+.fd-a {
+  padding: 16px 18px 18px;
+  background: var(--subtle);
+  display: grid; grid-template-columns: 1fr 1fr; gap: 14px;
+}
+.fd-a .fda-banner {
+  grid-column: 1 / -1;
+  display: grid; grid-template-columns: auto 1fr auto;
+  gap: 14px; align-items: center;
+  padding: 12px 14px;
+  background: color-mix(in oklab, var(--danger) 8%, transparent);
+  border-left: 3px solid var(--danger);
+  border-radius: 0 8px 8px 0;
+}
+.fda-banner .impact-icon {
+  width: 36px; height: 36px; border-radius: 8px;
+  display: grid; place-items: center;
+  background: color-mix(in oklab, var(--danger) 18%, transparent);
+  color: var(--danger-text);
+  font-weight: 700;
+}
+.fda-banner .impact-text { font-size: 13px; line-height: 1.5; color: var(--text); }
+.fda-banner .impact-text b { color: var(--danger-text); }
+.fda-banner .impact-meta {
+  display: flex; flex-direction: column; align-items: flex-end; gap: 4px;
+  font-size: 11px; color: var(--muted);
+}
+.fda-banner .impact-mitre {
+  display: inline-flex; gap: 4px; flex-wrap: wrap; justify-content: flex-end;
+}
+.fda-banner .impact-mitre code {
+  font-family: var(--font-mono); font-size: 10.5px;
+  padding: 2px 6px; border-radius: 4px;
+  background: var(--surface2); color: var(--text-soft);
+  border: 1px solid var(--border);
+}
+.fd-a .fda-diff {
+  display: grid; grid-template-columns: 1fr auto 1fr; gap: 10px; align-items: stretch;
+  grid-column: 1 / -1;
+}
+.fda-diff-cell {
+  padding: 10px 12px; background: var(--surface);
+  border: 1px solid var(--border); border-radius: 8px;
+  display: flex; flex-direction: column; gap: 6px;
+}
+.fda-diff-cell.current  { border-left: 3px solid var(--danger); }
+.fda-diff-cell.target { border-left: 3px solid var(--success); }
+.fda-diff-cell .label {
+  font-size: 10.5px; font-weight: 700; letter-spacing: .1em;
+  text-transform: uppercase; color: var(--muted);
+}
+.fda-diff-cell.current .label { color: var(--danger-text); }
+.fda-diff-cell.target .label { color: var(--success-text); }
+.fda-diff-cell .val {
+  font-family: var(--font-mono); font-size: 12px;
+  line-height: 1.55; color: var(--text); word-break: break-word;
+}
+.fda-diff-arrow {
+  align-self: center; color: var(--muted);
+  font-family: var(--font-mono); font-size: 18px;
+}
+.fd-a .fda-fix {
+  grid-column: 1 / -1;
+  background: var(--surface);
+  border: 1px solid var(--border); border-radius: 8px;
+  overflow: hidden;
+}
+.fda-fix-tabs {
+  display: flex; gap: 0; border-bottom: 1px solid var(--border);
+  background: var(--surface2);
+}
+.fda-fix-tab {
+  padding: 9px 14px; font-size: 12px; font-weight: 600;
+  color: var(--text-soft); background: transparent;
+  border: 0; cursor: pointer; position: relative;
+  border-right: 1px solid var(--border);
+}
+.fda-fix-tab.active { color: var(--accent-text); background: var(--surface); }
+.fda-fix-tab.active::after {
+  content: ''; position: absolute; left: 0; right: 0; bottom: -1px; height: 2px;
+  background: var(--accent);
+}
+.fda-fix-tab .count {
+  margin-left: 6px; font-size: 10px;
+  background: var(--chip); padding: 1px 6px; border-radius: 999px;
+  color: var(--muted);
+}
+.fda-fix-body { padding: 12px 14px; }
+.fda-fix-body p { margin: 0 0 8px 0; font-size: 13px; line-height: 1.55; color: var(--text); }
+.fda-fix-body pre {
+  margin: 6px 0 0 0; padding: 10px 12px;
+  background: #0c1226; border: 1px solid color-mix(in oklab, var(--accent) 30%, var(--border));
+  border-radius: 6px;
+  font-family: var(--font-mono); font-size: 11.5px; line-height: 1.6;
+  color: #c4d2ff; white-space: pre-wrap; word-break: break-word;
+  position: relative;
+}
+.fda-fix-body .copy-btn {
+  position: absolute; top: 6px; right: 6px;
+  padding: 3px 8px; font-size: 10px; font-weight: 600;
+  background: rgba(155,135,245,0.18); color: #c4b5fd;
+  border: 1px solid rgba(155,135,245,0.35); border-radius: 4px;
+  cursor: pointer;
+}
+.fd-a .fda-meta {
+  grid-column: 1 / -1;
+  display: grid; grid-template-columns: 1fr 1fr; gap: 10px;
+}
+.fda-meta-card {
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 8px; padding: 10px 12px;
+}
+.fda-meta-card .label {
+  font-size: 10.5px; font-weight: 700; letter-spacing: .1em;
+  text-transform: uppercase; color: var(--muted); margin-bottom: 6px;
+}
+.fda-fw-grid { display: flex; flex-direction: column; gap: 4px; }
+.fda-fw-row {
+  display: grid; grid-template-columns: 92px 1fr auto;
+  gap: 8px; align-items: center;
+  padding: 4px 0; font-size: 12px;
+  border-bottom: 1px dashed var(--border);
+}
+.fda-fw-row:last-child { border-bottom: 0; }
+.fda-fw-row .fw-name { color: var(--text-soft); font-weight: 500; }
+.fda-fw-row code {
+  font-family: var(--font-mono); font-size: 11.5px;
+  color: var(--text); background: var(--chip);
+  padding: 1px 6px; border-radius: 3px;
+}
+.fda-fw-row .levels { display: inline-flex; gap: 3px; }
+.fda-fw-row .lvl {
+  font-size: 9.5px; font-weight: 700; padding: 1px 5px;
+  border-radius: 3px; background: var(--accent-soft);
+  color: var(--accent-text); border: 1px solid var(--accent-border);
+}
+.fda-disclosure {
+  grid-column: 1 / -1;
+  font-size: 12px; color: var(--muted);
+}
+.fda-disclosure summary {
+  cursor: pointer; padding: 6px 0; font-weight: 600; color: var(--text-soft);
+  user-select: none;
+}
+
+/* ============================================================ */
+/* Direction B — Evidence-first */
+/* ============================================================ */
+.fd-b {
+  padding: 0;
+  background: var(--subtle);
+  border-top: 1px solid var(--border);
+}
+.fdb-grid {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  min-height: 360px;
+}
+.fdb-rail {
+  background: var(--surface2);
+  border-right: 1px solid var(--border);
+  padding: 14px;
+  display: flex; flex-direction: column; gap: 10px;
+  font-size: 12px;
+}
+.fdb-rail .stamp {
+  display: flex; align-items: center; gap: 8px;
+  padding: 8px 10px; background: var(--surface);
+  border: 1px solid var(--border); border-radius: 6px;
+  font-family: var(--font-mono); font-size: 11px; color: var(--text);
+}
+.fdb-rail .stamp .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--success); flex-shrink: 0;
+}
+.fdb-kv {
+  display: grid; grid-template-columns: 96px 1fr;
+  gap: 6px 10px; font-size: 12px;
+  padding: 8px 10px; background: var(--surface);
+  border: 1px solid var(--border); border-radius: 6px;
+}
+.fdb-kv dt { color: var(--muted); font-weight: 600; }
+.fdb-kv dd { margin: 0; color: var(--text); word-break: break-word; }
+.fdb-kv code {
+  font-family: var(--font-mono); font-size: 11px;
+  color: var(--text); background: var(--chip);
+  padding: 1px 5px; border-radius: 3px;
+}
+.fdb-confidence {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 11.5px; color: var(--text-soft);
+}
+.fdb-confidence .bar {
+  flex: 1; height: 4px; background: var(--chip); border-radius: 2px; overflow: hidden;
+}
+.fdb-confidence .bar i {
+  display: block; height: 100%; background: var(--success); border-radius: 2px;
+}
+.fdb-rail-section {
+  font-size: 10.5px; font-weight: 700; letter-spacing: .12em;
+  text-transform: uppercase; color: var(--muted);
+  margin: 4px 0 -2px 0;
+}
+
+.fdb-main {
+  padding: 14px 16px;
+  display: flex; flex-direction: column; gap: 14px;
+}
+.fdb-claim {
+  font-size: 14px; line-height: 1.55; color: var(--text);
+  padding: 10px 12px;
+  background: var(--surface); border: 1px solid var(--border); border-radius: 8px;
+  border-left: 3px solid var(--accent);
+}
+.fdb-claim b { color: var(--accent-text); }
+
+.fdb-diff-table {
+  width: 100%; border-collapse: collapse;
+  background: var(--surface); border: 1px solid var(--border); border-radius: 8px;
+  overflow: hidden;
+  font-size: 12px;
+}
+.fdb-diff-table th, .fdb-diff-table td {
+  padding: 8px 12px; text-align: left; vertical-align: top;
+  border-bottom: 1px solid var(--border);
+}
+.fdb-diff-table tr:last-child th, .fdb-diff-table tr:last-child td { border-bottom: 0; }
+.fdb-diff-table th {
+  width: 130px; color: var(--muted); font-weight: 600;
+  background: var(--surface2);
+  font-size: 10.5px; letter-spacing: .1em; text-transform: uppercase;
+}
+.fdb-diff-table td.observed { font-family: var(--font-mono); color: var(--text); border-left: 3px solid var(--danger); }
+.fdb-diff-table td.expected { font-family: var(--font-mono); color: var(--text); border-left: 3px solid var(--success); }
+
+.fdb-block {
+  background: var(--surface); border: 1px solid var(--border); border-radius: 8px;
+  padding: 12px 14px;
+}
+.fdb-block-head {
+  font-size: 10.5px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase;
+  color: var(--muted); margin-bottom: 8px;
+}
+.fdb-block p { margin: 0; font-size: 12.5px; line-height: 1.55; color: var(--text); }
+.fdb-block ol { margin: 0; padding-left: 18px; font-size: 12.5px; line-height: 1.55; color: var(--text); }
+.fdb-block ol li { margin-bottom: 4px; }
+.fdb-block pre {
+  margin: 8px 0 0 0; padding: 10px 12px;
+  background: #0c1226; border-radius: 6px;
+  border: 1px solid color-mix(in oklab, var(--accent) 30%, var(--border));
+  font-family: var(--font-mono); font-size: 11.5px; line-height: 1.6;
+  color: #c4d2ff; white-space: pre-wrap; word-break: break-word;
+}
+
+.fdb-raw {
+  font-size: 11.5px; color: var(--muted);
+}
+.fdb-raw summary {
+  cursor: pointer; font-weight: 600; color: var(--text-soft); padding: 4px 0;
+}
+.fdb-raw pre {
+  margin: 6px 0 0 0; padding: 10px;
+  background: var(--surface2); border: 1px solid var(--border); border-radius: 6px;
+  font-family: var(--font-mono); font-size: 10.5px; color: var(--text);
+  white-space: pre-wrap; word-break: break-word; max-height: 160px; overflow: auto;
+}
+
+/* ============================================================ */
+/* Direction C — Workflow-first */
+/* ============================================================ */
+.fd-c {
+  padding: 0;
+  background: var(--subtle);
+}
+.fdc-strip {
+  display: grid; grid-template-columns: repeat(5, 1fr);
+  gap: 0; background: var(--surface);
+  border-bottom: 1px solid var(--border);
+}
+.fdc-strip-cell {
+  padding: 10px 14px; border-right: 1px solid var(--border);
+  display: flex; flex-direction: column; gap: 3px;
+}
+.fdc-strip-cell:last-child { border-right: 0; }
+.fdc-strip-cell .label {
+  font-size: 10px; font-weight: 700; letter-spacing: .1em;
+  text-transform: uppercase; color: var(--muted);
+}
+.fdc-strip-cell .val {
+  font-size: 13px; font-weight: 600; color: var(--text);
+}
+.fdc-strip-cell .val.warn { color: var(--warn-text); }
+.fdc-strip-cell .val.danger { color: var(--danger-text); }
+.fdc-strip-cell .val.muted { color: var(--muted); font-style: italic; font-weight: 500; }
+.fdc-pill {
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 2px 8px; border-radius: 999px;
+  font-size: 11px; font-weight: 600;
+  background: var(--accent-soft); color: var(--accent-text);
+  border: 1px solid var(--accent-border);
+  width: fit-content;
+}
+.fdc-pill.now { background: color-mix(in oklab, var(--danger) 14%, transparent); color: var(--danger-text); border-color: color-mix(in oklab, var(--danger) 35%, transparent); }
+.fdc-pill.next { background: color-mix(in oklab, var(--warn) 14%, transparent); color: var(--warn-text); border-color: color-mix(in oklab, var(--warn) 35%, transparent); }
+.fdc-pill.empty { background: transparent; color: var(--muted); border: 1px dashed var(--border); }
+
+.fdc-body {
+  display: grid; grid-template-columns: 1fr 280px;
+  gap: 14px; padding: 14px 16px;
+}
+.fdc-body-main { display: flex; flex-direction: column; gap: 12px; }
+
+.fdc-summary {
+  font-size: 13px; line-height: 1.55; color: var(--text);
+}
+.fdc-summary .what { display: block; margin-bottom: 6px; }
+.fdc-summary .why  { display: block; color: var(--text-soft); font-size: 12.5px; }
+
+.fdc-diff {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 8px;
+}
+.fdc-diff-card {
+  padding: 8px 10px; border-radius: 6px;
+  background: var(--surface); border: 1px solid var(--border);
+  font-family: var(--font-mono); font-size: 11.5px; line-height: 1.5;
+  word-break: break-word;
+}
+.fdc-diff-card.current { border-left: 3px solid var(--danger); }
+.fdc-diff-card.target { border-left: 3px solid var(--success); }
+.fdc-diff-card .h {
+  font-family: var(--font-sans); font-size: 10px; font-weight: 700;
+  letter-spacing: .12em; text-transform: uppercase;
+  color: var(--muted); display: block; margin-bottom: 4px;
+}
+
+.fdc-actions {
+  background: var(--surface); border: 1px solid var(--border); border-radius: 8px;
+  overflow: hidden;
+}
+.fdc-actions-head {
+  padding: 8px 12px; background: var(--surface2);
+  border-bottom: 1px solid var(--border);
+  display: flex; justify-content: space-between; align-items: center;
+  font-size: 10.5px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase;
+  color: var(--muted);
+}
+.fdc-actions-head .toggle {
+  display: inline-flex; gap: 4px;
+}
+.fdc-actions-head .toggle button {
+  padding: 3px 9px; font-size: 10.5px; font-weight: 600;
+  background: var(--chip); color: var(--text-soft);
+  border: 1px solid var(--border); border-radius: 4px;
+  cursor: pointer; letter-spacing: 0; text-transform: none;
+}
+.fdc-actions-head .toggle button.active {
+  background: var(--accent); color: var(--bg); border-color: var(--accent);
+}
+.fdc-actions-body { padding: 12px 14px; font-size: 12.5px; line-height: 1.55; color: var(--text); }
+.fdc-actions-body p { margin: 0 0 8px 0; }
+.fdc-actions-body pre {
+  margin: 0; padding: 10px 12px;
+  background: #0c1226; border: 1px solid color-mix(in oklab, var(--accent) 30%, var(--border));
+  border-radius: 6px;
+  font-family: var(--font-mono); font-size: 11.5px; line-height: 1.6;
+  color: #c4d2ff; white-space: pre-wrap; word-break: break-word;
+}
+
+.fdc-side {
+  display: flex; flex-direction: column; gap: 10px;
+}
+.fdc-card {
+  background: var(--surface); border: 1px solid var(--border); border-radius: 8px;
+  padding: 10px 12px;
+}
+.fdc-card .h {
+  font-size: 10px; font-weight: 700; letter-spacing: .12em;
+  text-transform: uppercase; color: var(--muted); margin-bottom: 8px;
+}
+.fdc-card .ownerRow {
+  display: flex; align-items: center; gap: 8px; font-size: 12.5px; color: var(--text);
+}
+.fdc-avatar {
+  width: 24px; height: 24px; border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent), color-mix(in oklab, var(--accent) 60%, var(--success)));
+  color: var(--bg); display: grid; place-items: center;
+  font-size: 10px; font-weight: 700;
+}
+.fdc-card .assign {
+  display: inline-block; margin-top: 8px; font-size: 11.5px;
+  color: var(--accent-text); cursor: pointer; text-decoration: underline dotted;
+}
+
+.fdc-history {
+  display: flex; flex-direction: column; gap: 6px;
+}
+.fdc-hist-row {
+  display: grid; grid-template-columns: 80px auto 1fr; gap: 8px;
+  align-items: baseline; font-size: 11.5px;
+}
+.fdc-hist-row .date { color: var(--muted); font-family: var(--font-mono); font-size: 11px; }
+.fdc-hist-row .pip {
+  width: 8px; height: 8px; border-radius: 50%; align-self: center;
+}
+.fdc-hist-row .pip.fail { background: var(--danger); }
+.fdc-hist-row .pip.warn { background: var(--warn); }
+.fdc-hist-row .pip.pass { background: var(--success); }
+.fdc-hist-row .note { color: var(--text-soft); }
+
+.fdc-fws {
+  display: flex; flex-direction: column; gap: 4px;
+}
+.fdc-fw-line {
+  display: grid; grid-template-columns: 92px 1fr;
+  gap: 8px; font-size: 11.5px; align-items: center;
+  padding: 3px 0; border-bottom: 1px dashed var(--border);
+}
+.fdc-fw-line:last-child { border-bottom: 0; }
+.fdc-fw-line .nm { color: var(--muted); }
+.fdc-fw-line code {
+  font-family: var(--font-mono); font-size: 11px;
+  background: var(--chip); padding: 1px 5px; border-radius: 3px; color: var(--text);
+}
+.fdc-related {
+  display: flex; flex-direction: column; gap: 4px;
+}
+.fdc-related a {
+  font-size: 11.5px; color: var(--accent-text); text-decoration: none;
+}
+.fdc-related a:hover { text-decoration: underline; }
+
+.fdc-raw {
+  margin-top: 4px; font-size: 11px; color: var(--muted);
+}
+.fdc-raw summary { cursor: pointer; font-weight: 600; padding: 4px 0; }
+
+/* ============================================================ */
+/* Direction D — Hybrid (B + C + A) */
+/* ============================================================ */
+.fd-d {
+  background: var(--subtle);
+  display: flex; flex-direction: column;
+}
+.fdd-strip {
+  display: grid; grid-template-columns: repeat(5, 1fr);
+  background: var(--surface); border-bottom: 1px solid var(--border);
+}
+.fdd-strip-cell {
+  padding: 10px 14px; border-right: 1px solid var(--border);
+  display: flex; flex-direction: column; gap: 4px;
+}
+.fdd-strip-cell:last-child { border-right: 0; }
+.fdd-strip-cell .label {
+  font-size: 10px; font-weight: 700; letter-spacing: .1em;
+  text-transform: uppercase; color: var(--muted);
+}
+.fdd-strip-cell .val {
+  font-size: 13px; font-weight: 600; color: var(--text);
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.fdd-strip-cell .val.warn   { color: var(--warn-text); }
+.fdd-strip-cell .val.danger { color: var(--danger-text); }
+.fdd-strip-cell .val.muted  { color: var(--muted); font-weight: 500; }
+.fdd-strip-cell .val.ownerRow { font-weight: 600; }
+
+.fdd-risk {
+  display: grid; grid-template-columns: 36px 1fr auto;
+  gap: 12px; padding: 12px 16px;
+  background: color-mix(in oklab, var(--danger) 7%, transparent);
+  border-bottom: 1px solid var(--border);
+  border-left: 3px solid var(--danger);
+}
+.fdd-risk-meta {
+  display: flex; flex-direction: column; align-items: flex-end; gap: 6px;
+  min-width: 130px; max-width: 200px;
+  padding-left: 12px;
+  border-left: 1px solid color-mix(in oklab, var(--danger) 25%, var(--border));
+  align-self: stretch;
+  justify-content: flex-start;
+}
+.fdd-risk-meta-label {
+  font-size: 9.5px; font-weight: 700; letter-spacing: .12em;
+  text-transform: uppercase; color: var(--muted);
+}
+.fdd-risk-lede { color: var(--danger-text); font-weight: 700; }
+.fdd-risk-icon {
+  width: 28px; height: 28px; border-radius: 8px;
+  background: color-mix(in oklab, var(--danger) 22%, transparent);
+  color: var(--danger-text); font-weight: 700;
+  display: grid; place-items: center; align-self: start;
+}
+.fdd-risk-head {
+  font-size: 10.5px; font-weight: 700; letter-spacing: .12em;
+  text-transform: uppercase; color: var(--muted);
+  margin-bottom: 4px;
+}
+.fdd-risk-head.danger { color: var(--danger-text); }
+.fdd-risk-section + .fdd-risk-section {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px dashed color-mix(in oklab, var(--danger) 25%, var(--border));
+}
+.fdd-risk-body p {
+  margin: 0; font-size: 13px; line-height: 1.55; color: var(--text);
+}
+.fdd-mitre {
+  display: inline-flex; gap: 4px; flex-wrap: wrap; justify-content: flex-end;
+}
+.fdd-mitre code {
+  font-family: var(--font-mono); font-size: 10.5px;
+  padding: 2px 6px; border-radius: 4px;
+  background: var(--surface); color: var(--text-soft);
+  border: 1px solid var(--border);
+}
+
+.fdd-grid {
+  display: grid; grid-template-columns: 1fr 300px;
+  gap: 14px; padding: 14px 16px;
+}
+.fdd-main { display: flex; flex-direction: column; gap: 12px; }
+.fdd-side { display: flex; flex-direction: column; gap: 10px; }
+
+.fdd-fw-line {
+  display: grid; grid-template-columns: 90px 1fr auto;
+  gap: 6px; align-items: center; font-size: 11.5px;
+  padding: 4px 0; border-bottom: 1px dashed var(--border);
+}
+.fdd-fw-line:last-child { border-bottom: 0; }
+.fdd-fw-line .nm { color: var(--muted); }
+.fdd-fw-line code {
+  font-family: var(--font-mono); font-size: 11px;
+  background: var(--chip); padding: 1px 5px; border-radius: 3px; color: var(--text);
+}
+.fdd-fw-line .lvls { display: inline-flex; gap: 3px; }
+.fdd-fw-line .lvl {
+  font-size: 9px; font-weight: 700; padding: 1px 4px; border-radius: 3px;
+  background: var(--accent-soft); color: var(--accent-text);
+  border: 1px solid var(--accent-border);
+}
+
+.fdd-prov {
+  border-top: 1px solid var(--border);
+  background: var(--surface2);
+  font-size: 11.5px; color: var(--text-soft);
+}
+.fdd-prov summary {
+  cursor: pointer; padding: 9px 16px;
+  display: flex; justify-content: space-between; align-items: center; gap: 14px;
+  user-select: none; list-style: none;
+}
+.fdd-prov summary::-webkit-details-marker { display: none; }
+.fdd-prov .prov-summary {
+  display: inline-flex; gap: 8px; align-items: center; flex-wrap: wrap;
+  flex: 1; min-width: 0;
+}
+.fdd-prov .prov-key {
+  font-size: 10px; font-weight: 700; letter-spacing: .1em;
+  text-transform: uppercase; color: var(--muted);
+}
+.fdd-prov .prov-sep { color: var(--border); }
+.fdd-prov code {
+  font-family: var(--font-mono); font-size: 10.5px;
+  background: var(--chip); padding: 1px 5px; border-radius: 3px; color: var(--text);
+}
+.fdd-prov .prov-toggle {
+  font-size: 11px; font-weight: 600; color: var(--accent-text);
+  white-space: nowrap; flex-shrink: 0;
+}
+.fdd-prov[open] .prov-toggle::after { content: ''; }
+.fdd-prov-body { padding: 0 16px 14px; }
+.fdd-limit {
+  margin: 0 0 8px 0; padding: 8px 10px; font-size: 12px;
+  background: color-mix(in oklab, var(--warn) 10%, transparent);
+  border-left: 3px solid var(--warn); border-radius: 0 6px 6px 0;
+  color: var(--text);
+}
+.fdd-limit b { color: var(--warn-text); }
+.fdd-prov-body pre {
+  margin: 0; padding: 10px;
+  background: var(--surface); border: 1px solid var(--border); border-radius: 6px;
+  font-family: var(--font-mono); font-size: 10.5px; color: var(--text);
+  white-space: pre-wrap; word-break: break-word;
+  max-height: 200px; overflow: auto;
+}
+
+/* D — Finding claim */
+.fdd-claim {
+  display: grid; grid-template-columns: auto 1fr;
+  gap: 10px; align-items: baseline;
+  padding: 10px 12px;
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-border);
+  border-radius: 6px;
+  font-size: 13px; line-height: 1.5; color: var(--text);
+}
+.fdd-claim .kicker {
+  font-size: 10px; font-weight: 700; letter-spacing: .12em;
+  text-transform: uppercase; color: var(--accent-text);
+  white-space: nowrap;
+}
+.fdd-claim b { font-weight: 700; color: var(--text); }
+
+/* D — affected sample chips inside Delta row */
+.fdd-samples {
+  display: inline-flex; flex-wrap: wrap; gap: 4px;
+  margin-left: 8px; vertical-align: middle;
+}
+.fdd-sample {
+  font-family: var(--font-mono); font-size: 10.5px;
+  background: var(--chip); color: var(--text);
+  padding: 1px 6px; border-radius: 3px;
+  border: 1px solid var(--border);
+}
+.fdd-sample-more {
+  font-size: 10.5px; color: var(--muted); font-weight: 600;
+  align-self: center;
+}
+
+/* D — numbered remediation procedure */
+.fdd-procedure {
+  margin: 0; padding-left: 22px;
+  display: flex; flex-direction: column; gap: 6px;
+  font-size: 12.5px; line-height: 1.5; color: var(--text);
+}
+.fdd-procedure li::marker {
+  font-weight: 700; color: var(--accent-text);
+}
+
+/* D — confidence bar in provenance summary */
+.fdd-conf {
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.fdd-conf-bar {
+  display: inline-block; width: 48px; height: 5px;
+  background: var(--chip); border-radius: 3px; overflow: hidden;
+  border: 1px solid var(--border);
+}
+.fdd-conf-bar i {
+  display: block; height: 100%;
+  background: linear-gradient(90deg, var(--accent), color-mix(in oklab, var(--accent) 70%, var(--ok) 30%));
+  border-radius: 2px;
+}
+.fdd-conf b { color: var(--text); font-size: 11.5px; }
+
+/* D — provenance meta strip (method, run id, tenant) */
+.fdd-prov-meta {
+  display: grid; grid-template-columns: repeat(3, 1fr);
+  gap: 10px; margin-bottom: 10px;
+  padding: 8px 10px;
+  background: var(--surface); border: 1px solid var(--border); border-radius: 6px;
+}
+.fdd-prov-meta > div {
+  display: flex; flex-direction: column; gap: 3px; min-width: 0;
+}
+.fdd-prov-meta .k {
+  font-size: 9.5px; font-weight: 700; letter-spacing: .12em;
+  text-transform: uppercase; color: var(--muted);
+}
+.fdd-prov-meta .v {
+  font-size: 11.5px; color: var(--text); font-weight: 500;
+}
+.fdd-prov-meta code {
+  font-family: var(--font-mono); font-size: 10.5px;
+  color: var(--text); background: transparent; padding: 0;
+}


### PR DESCRIPTION
## Summary

**PR ε.1** of the v2.11.0 finding-detail panel redesign work. Same shape as #856 framework-redesign handoff: lock the design package as in-repo source-of-truth before implementation begins.

**Direction D** — chosen by the user after iterating through 3 alternates (A narrative-first, B structured-claim, C workflow-state). Synthesizes the strongest pieces of each.

Replaces closed **#674** (prior detail-panel redesign rejected as "too busy without adding actual info or value"). Direction D addresses that critique by being **structurally denser**, not just visually busier — it makes room for value-bearing fields the report doesn't currently expose.

## What's committed

```
docs/design/finding-detail/
├── README.md             — layout summary, schema additions, 5-phase plan
├── direction-d.jsx       — THE implementation reference (~307 lines)
├── fd-host.jsx           — parent harness (table → expanded row container)
├── mock-findings.js      — 3 realistic findings covering shape variations
├── styles.css            — new .fd-* / .fdd-* CSS to fold into report-shell.css
├── redesign.css          — base style snapshot from canvas standalone
├── index.html            — canvas host for visual review
└── design-canvas.jsx     — canvas chrome
```

Not committed (deliberately, per the #856 pattern): `report-shell.css` / `report-themes.css` from the bundle. Those live at `src/M365-Assess/assets/` and copying here would drift from the live source.

## Implementation phases (ship independently)

Each phase degrades gracefully when later-phase fields are missing:

| Phase | Scope | Status |
|---|---|---|
| **1. Schema groundwork** | Extend collectors + registry + `Build-ReportData.ps1` to surface new fields where derivable. | TODO |
| **2. UI shell** | Row 1 (state strip) + Row 2 (risk narrative split) + collapsible provenance footer. Renders off existing fields. | TODO — next PR |
| **3. Typed observed/expected + tabbed actions** | Requires typed `evidence.observedValue` / `expectedValue` + remediation restructure. | TODO |
| **4. Side rail** | Mappings + Trend + Related + Learn more. | TODO |
| **5. Owner / ticket assignment** | Edit-mode metadata overlay (HideableBlock-pattern). | TODO |

This PR is **docs-only**. No functional change. Just locks down the design package.

## Test plan

- [x] No code changes — Pester / build / lint not affected
- [x] Files copied verbatim from the design bundle (`/tmp/finding-detail-design/...`)
- [x] No duplicate `report-shell.css` / `report-themes.css` (avoid drift from live)
- [ ] CI green (docs-only, should be quick)

## Next PR

**PR ε.2** — Phase 2 (UI shell). Implements Row 1 state strip + Row 2 risk-narrative split + collapsible provenance footer using existing fields. Schedule for the next sprint cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)