### PR TITLE
feat(report): finding-detail Phase 2 — Direction D shell (refs #863)

### DIFF
--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -4415,6 +4415,11 @@ function statusTier(status) {
 // (Phase 5). Empty / null-data fields render as muted placeholders so
 // the shell degrades gracefully — see docs/design/finding-detail/.
 
+// Phase 2 sequence column: matches the XLSX matrix's "Sequence" terminology
+// from #840. Pass-status findings show "Done" (consistent with the matrix's
+// green Done cell). Findings without a lane AND not Pass render as muted
+// plain text — no pill — since the chip-style rendering reads as
+// "actionable item with a state" which is wrong for non-remediable rows.
 const LANE_LABELS = {
   now: 'Do Now',
   soon: 'Do Next',
@@ -4423,13 +4428,30 @@ const LANE_LABELS = {
 const LANE_CSS = {
   now: 'now',
   soon: 'next',
-  later: ''
+  later: 'later'
 };
 function FindingStateStrip({
   f
 }) {
-  const laneLabel = LANE_LABELS[f.lane] || '—';
-  const laneClass = LANE_CSS[f.lane] !== undefined ? LANE_CSS[f.lane] : 'empty';
+  const isPass = f.status === 'Pass';
+  // Sequence cell content + chip-vs-text decision:
+  //  - lane present (now/soon/later) → coloured pill
+  //  - status === Pass               → "Done" success pill
+  //  - everything else               → muted plain text (no pill)
+  let sequenceNode;
+  if (f.lane && LANE_LABELS[f.lane]) {
+    sequenceNode = /*#__PURE__*/React.createElement("span", {
+      className: 'fdc-pill ' + LANE_CSS[f.lane]
+    }, LANE_LABELS[f.lane]);
+  } else if (isPass) {
+    sequenceNode = /*#__PURE__*/React.createElement("span", {
+      className: "fdc-pill done"
+    }, "Done");
+  } else {
+    sequenceNode = /*#__PURE__*/React.createElement("span", {
+      className: "val muted"
+    }, "\u2014");
+  }
   const effort = f.effort ? f.effort[0].toUpperCase() + f.effort.slice(1) : '—';
 
   // Phase 2 affected count: derive from evidence.observedValue if it has a
@@ -4449,9 +4471,7 @@ function FindingStateStrip({
     className: "fdd-strip-cell"
   }, /*#__PURE__*/React.createElement("span", {
     className: "label"
-  }, "Horizon"), /*#__PURE__*/React.createElement("span", {
-    className: 'fdc-pill ' + laneClass
-  }, laneLabel)), /*#__PURE__*/React.createElement("div", {
+  }, "Sequence"), sequenceNode), /*#__PURE__*/React.createElement("div", {
     className: "fdd-strip-cell"
   }, /*#__PURE__*/React.createElement("span", {
     className: "label"

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -4259,31 +4259,33 @@ function FindingsTable({
     }, isHidden ? '↩' : '✕') : /*#__PURE__*/React.createElement("div", {
       className: "caret"
     }, /*#__PURE__*/React.createElement(Icon.chevron, null))), isOpen && /*#__PURE__*/React.createElement("div", {
-      className: "finding-detail"
+      className: "finding-detail fdd"
     }, f.intentDesign && /*#__PURE__*/React.createElement("div", {
       className: "intent-callout"
-    }, /*#__PURE__*/React.createElement("strong", null, "Intentional by design."), f.intentRationale && /*#__PURE__*/React.createElement("span", null, " ", f.intentRationale)), /*#__PURE__*/React.createElement("div", {
-      className: "why"
+    }, /*#__PURE__*/React.createElement("strong", null, "Intentional by design."), f.intentRationale && /*#__PURE__*/React.createElement("span", null, " ", f.intentRationale)), /*#__PURE__*/React.createElement(FindingStateStrip, {
+      f: f
+    }), /*#__PURE__*/React.createElement(FindingRiskNarrative, {
+      f: f
+    }), /*#__PURE__*/React.createElement("div", {
+      className: "fdd-legacy-block"
     }, /*#__PURE__*/React.createElement("div", {
-      className: "why-label"
-    }, "Why it matters"), /*#__PURE__*/React.createElement("div", {
-      className: "why-text"
-    }, whyItMatters(f))), /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("div", {
       className: "block-title"
     }, "Current value"), /*#__PURE__*/React.createElement("div", {
       className: 'value-box current finding-current-' + statusTier(f.status)
-    }, f.current || '—')), /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("div", {
+    }, f.current || '—')), /*#__PURE__*/React.createElement("div", {
+      className: "fdd-legacy-block"
+    }, /*#__PURE__*/React.createElement("div", {
       className: "block-title"
     }, "Recommended value"), /*#__PURE__*/React.createElement("div", {
       className: "value-box recommended"
     }, f.recommended || '—')), f.remediation && /*#__PURE__*/React.createElement("div", {
-      className: "finding-remediation"
+      className: "finding-remediation fdd-legacy-block"
     }, /*#__PURE__*/React.createElement("div", {
       className: "block-title"
     }, "Remediation"), /*#__PURE__*/React.createElement("div", {
       className: "remediation-text"
     }, f.remediation)), f.references && f.references.length > 0 && /*#__PURE__*/React.createElement("div", {
-      className: "finding-learn-more"
+      className: "finding-learn-more fdd-legacy-block"
     }, /*#__PURE__*/React.createElement("div", {
       className: "block-title"
     }, "Learn more"), f.references.map((r, i) => /*#__PURE__*/React.createElement("a", {
@@ -4291,7 +4293,7 @@ function FindingsTable({
       href: r.url,
       target: "_blank",
       rel: "noreferrer noopener"
-    }, "\uD83D\uDCD6 ", r.title, " \u2197"))), f.evidence && /*#__PURE__*/React.createElement(EvidenceBlock, {
+    }, "\uD83D\uDCD6 ", r.title, " \u2197"))), /*#__PURE__*/React.createElement(FindingProvenanceFooter, {
       evidence: f.evidence
     })));
   })));
@@ -4402,6 +4404,177 @@ function statusTier(status) {
   if (status === 'Review') return 'review';
   if (status === 'Info') return 'info';
   return 'neutral';
+}
+
+// =====================================================================
+// Issue #863 Phase 2 — Finding-detail Direction D shell components
+// =====================================================================
+// State strip (Row 1), Risk narrative (Row 2), Provenance footer.
+// Phase 2 ships the structural shell; later phases add typed observed/
+// expected (Phase 3), side rail (Phase 4), owner/ticket assignment
+// (Phase 5). Empty / null-data fields render as muted placeholders so
+// the shell degrades gracefully — see docs/design/finding-detail/.
+
+const LANE_LABELS = {
+  now: 'Do Now',
+  soon: 'Do Next',
+  later: 'Later'
+};
+const LANE_CSS = {
+  now: 'now',
+  soon: 'next',
+  later: ''
+};
+function FindingStateStrip({
+  f
+}) {
+  const laneLabel = LANE_LABELS[f.lane] || '—';
+  const laneClass = LANE_CSS[f.lane] !== undefined ? LANE_CSS[f.lane] : 'empty';
+  const effort = f.effort ? f.effort[0].toUpperCase() + f.effort.slice(1) : '—';
+
+  // Phase 2 affected count: derive from evidence.observedValue if it has a
+  // numeric prefix (e.g. "3 admins without MFA"), otherwise fall back to a
+  // muted dash. Real per-collector affectedObjects field arrives in Phase 3.
+  let affectedText = null;
+  let affectedClass = '';
+  const observed = f.evidence?.observedValue || f.current || '';
+  const numMatch = String(observed).match(/^(\d+)\s+([a-z][\w\s\-]*?)(?:[.,;]|$)/i);
+  if (numMatch) {
+    affectedText = numMatch[1] + ' ' + numMatch[2].trim();
+    affectedClass = f.severity === 'critical' ? 'danger' : f.severity === 'high' ? 'warn' : '';
+  }
+  return /*#__PURE__*/React.createElement("div", {
+    className: "fdd-strip"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "fdd-strip-cell"
+  }, /*#__PURE__*/React.createElement("span", {
+    className: "label"
+  }, "Horizon"), /*#__PURE__*/React.createElement("span", {
+    className: 'fdc-pill ' + laneClass
+  }, laneLabel)), /*#__PURE__*/React.createElement("div", {
+    className: "fdd-strip-cell"
+  }, /*#__PURE__*/React.createElement("span", {
+    className: "label"
+  }, "Effort"), /*#__PURE__*/React.createElement("span", {
+    className: 'val' + (f.effort ? '' : ' muted')
+  }, effort)), /*#__PURE__*/React.createElement("div", {
+    className: "fdd-strip-cell"
+  }, /*#__PURE__*/React.createElement("span", {
+    className: "label"
+  }, "Affected"), affectedText ? /*#__PURE__*/React.createElement("span", {
+    className: 'val ' + affectedClass
+  }, affectedText) : /*#__PURE__*/React.createElement("span", {
+    className: "val muted"
+  }, "\u2014")), /*#__PURE__*/React.createElement("div", {
+    className: "fdd-strip-cell"
+  }, /*#__PURE__*/React.createElement("span", {
+    className: "label"
+  }, "Owner"), /*#__PURE__*/React.createElement("span", {
+    className: "val muted"
+  }, "Unassigned")), /*#__PURE__*/React.createElement("div", {
+    className: "fdd-strip-cell"
+  }, /*#__PURE__*/React.createElement("span", {
+    className: "label"
+  }, "Ticket"), /*#__PURE__*/React.createElement("span", {
+    className: "val muted"
+  }, "\u2014")));
+}
+function FindingRiskNarrative({
+  f
+}) {
+  // Phase 2: use existing whyItMatters() output as the Risk paragraph.
+  // The "Why it matters" subsection is intentionally empty until per-check
+  // narrative authoring lands (Option C from the v2.11.0 plan).
+  const risk = whyItMatters(f);
+  const mitre = Array.isArray(f.mitre) ? f.mitre : [];
+  return /*#__PURE__*/React.createElement("div", {
+    className: "fdd-risk"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "fdd-risk-icon",
+    "aria-hidden": "true"
+  }, "!"), /*#__PURE__*/React.createElement("div", {
+    className: "fdd-risk-body"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "fdd-risk-section"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "fdd-risk-head danger"
+  }, "Risk"), /*#__PURE__*/React.createElement("p", null, risk))), mitre.length > 0 && /*#__PURE__*/React.createElement("div", {
+    className: "fdd-risk-meta"
+  }, /*#__PURE__*/React.createElement("span", {
+    className: "fdd-risk-meta-label"
+  }, "MITRE ATT&CK"), /*#__PURE__*/React.createElement("div", {
+    className: "fdd-mitre"
+  }, mitre.map(m => /*#__PURE__*/React.createElement("code", {
+    key: m,
+    title: m
+  }, String(m).split(' — ')[0])))));
+}
+
+// Direction D collapsible provenance footer. Reuses the evidence schema
+// from D1 #785; visually re-frames the existing EvidenceBlock as a footer
+// at the bottom of the expanded row with an inline summary of the most
+// useful provenance keys.
+function FindingProvenanceFooter({
+  evidence
+}) {
+  if (!evidence) return null;
+  let ev = evidence;
+  if (typeof ev === 'string') {
+    try {
+      ev = {
+        raw: ev
+      };
+    } catch {
+      return null;
+    }
+  }
+  const fields = [['evidenceSource', 'Source'], ['evidenceTimestamp', 'Collected'], ['collectionMethod', 'Method'], ['permissionRequired', 'Permission'], ['confidence', 'Confidence'], ['observedValue', 'Observed'], ['expectedValue', 'Expected'], ['limitations', 'Limitations']];
+  const present = fields.filter(([k]) => ev[k] !== undefined && ev[k] !== null && ev[k] !== '');
+  let rawPretty = null;
+  if (ev.raw) {
+    try {
+      rawPretty = JSON.stringify(JSON.parse(ev.raw), null, 2);
+    } catch {
+      rawPretty = String(ev.raw);
+    }
+  }
+  if (present.length === 0 && !rawPretty) return null;
+
+  // Inline summary pulls 2-3 most-useful keys (source + collected + confidence).
+  const summaryKeys = ['evidenceSource', 'evidenceTimestamp', 'confidence'];
+  const summaryEntries = summaryKeys.map(k => [k, ev[k]]).filter(([, v]) => v !== undefined && v !== null && v !== '');
+  return /*#__PURE__*/React.createElement("details", {
+    className: "fdd-prov"
+  }, /*#__PURE__*/React.createElement("summary", null, /*#__PURE__*/React.createElement("span", {
+    className: "prov-summary"
+  }, /*#__PURE__*/React.createElement("span", {
+    className: "prov-key"
+  }, "Provenance"), summaryEntries.length === 0 && /*#__PURE__*/React.createElement("span", {
+    className: "prov-sep"
+  }, "\xB7"), summaryEntries.map(([k, v], i) => /*#__PURE__*/React.createElement(React.Fragment, {
+    key: k
+  }, i > 0 && /*#__PURE__*/React.createElement("span", {
+    className: "prov-sep"
+  }, "\xB7"), /*#__PURE__*/React.createElement("code", null, k === 'confidence' ? `${Math.round(v * 100)}%` : String(v))))), /*#__PURE__*/React.createElement("span", {
+    className: "prov-toggle"
+  }, "View details")), /*#__PURE__*/React.createElement("div", {
+    className: "fdd-prov-body"
+  }, ev.limitations && /*#__PURE__*/React.createElement("p", {
+    className: "fdd-limit"
+  }, /*#__PURE__*/React.createElement("b", null, "Limitations:"), " ", ev.limitations), present.length > 0 && /*#__PURE__*/React.createElement("div", {
+    className: "fdd-prov-meta"
+  }, present.filter(([k]) => k !== 'limitations').map(([k, label]) => /*#__PURE__*/React.createElement("div", {
+    key: k
+  }, /*#__PURE__*/React.createElement("span", {
+    className: "k"
+  }, label), /*#__PURE__*/React.createElement("span", {
+    className: "v"
+  }, k === 'confidence' ? `${Math.round(ev[k] * 100)}%` : String(ev[k]))))), rawPretty && /*#__PURE__*/React.createElement("details", {
+    className: "finding-evidence-raw",
+    style: {
+      marginTop: 10
+    }
+  }, /*#__PURE__*/React.createElement("summary", null, "Raw evidence"), /*#__PURE__*/React.createElement("pre", null, rawPretty))));
 }
 
 // Issue #854: per-prefix narrative content for the finding-detail "Why It Matters"

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -2638,40 +2638,42 @@ function FindingsTable({ filters, search, focusFinding, onFocusClear, onMatchesC
                 }
               </div>
               {isOpen && (
-                <div className="finding-detail">
+                <div className="finding-detail fdd">
                   {f.intentDesign && (
                     <div className="intent-callout">
                       <strong>Intentional by design.</strong>
                       {f.intentRationale && <span> {f.intentRationale}</span>}
                     </div>
                   )}
-                  <div className="why">
-                    <div className="why-label">Why it matters</div>
-                    <div className="why-text">{whyItMatters(f)}</div>
-                  </div>
-                  <div>
+                  {/* #863 Phase 2 — Direction D state strip + risk narrative */}
+                  <FindingStateStrip f={f}/>
+                  <FindingRiskNarrative f={f}/>
+                  {/* Existing Phase-3-pending content rows. Will be replaced
+                      by typed observed/expected + tabbed actions in Phase 3. */}
+                  <div className="fdd-legacy-block">
                     <div className="block-title">Current value</div>
                     <div className={'value-box current finding-current-' + statusTier(f.status)}>{f.current || '—'}</div>
                   </div>
-                  <div>
+                  <div className="fdd-legacy-block">
                     <div className="block-title">Recommended value</div>
                     <div className="value-box recommended">{f.recommended || '—'}</div>
                   </div>
                   {f.remediation && (
-                    <div className="finding-remediation">
+                    <div className="finding-remediation fdd-legacy-block">
                       <div className="block-title">Remediation</div>
                       <div className="remediation-text">{f.remediation}</div>
                     </div>
                   )}
                   {f.references && f.references.length > 0 && (
-                    <div className="finding-learn-more">
+                    <div className="finding-learn-more fdd-legacy-block">
                       <div className="block-title">Learn more</div>
                       {f.references.map((r, i) => (
                         <a key={i} href={r.url} target="_blank" rel="noreferrer noopener">📖 {r.title} ↗</a>
                       ))}
                     </div>
                   )}
-                  {f.evidence && <EvidenceBlock evidence={f.evidence} />}
+                  {/* #863 Phase 2 — collapsible provenance footer */}
+                  <FindingProvenanceFooter evidence={f.evidence}/>
                 </div>
               )}
             </React.Fragment>
@@ -2784,6 +2786,164 @@ function statusTier(status) {
   if (status === 'Review') return 'review';
   if (status === 'Info') return 'info';
   return 'neutral';
+}
+
+// =====================================================================
+// Issue #863 Phase 2 — Finding-detail Direction D shell components
+// =====================================================================
+// State strip (Row 1), Risk narrative (Row 2), Provenance footer.
+// Phase 2 ships the structural shell; later phases add typed observed/
+// expected (Phase 3), side rail (Phase 4), owner/ticket assignment
+// (Phase 5). Empty / null-data fields render as muted placeholders so
+// the shell degrades gracefully — see docs/design/finding-detail/.
+
+const LANE_LABELS = { now: 'Do Now', soon: 'Do Next', later: 'Later' };
+const LANE_CSS    = { now: 'now', soon: 'next', later: '' };
+
+function FindingStateStrip({ f }) {
+  const laneLabel = LANE_LABELS[f.lane] || '—';
+  const laneClass = LANE_CSS[f.lane] !== undefined ? LANE_CSS[f.lane] : 'empty';
+  const effort = f.effort ? f.effort[0].toUpperCase() + f.effort.slice(1) : '—';
+
+  // Phase 2 affected count: derive from evidence.observedValue if it has a
+  // numeric prefix (e.g. "3 admins without MFA"), otherwise fall back to a
+  // muted dash. Real per-collector affectedObjects field arrives in Phase 3.
+  let affectedText = null;
+  let affectedClass = '';
+  const observed = f.evidence?.observedValue || f.current || '';
+  const numMatch = String(observed).match(/^(\d+)\s+([a-z][\w\s\-]*?)(?:[.,;]|$)/i);
+  if (numMatch) {
+    affectedText = numMatch[1] + ' ' + numMatch[2].trim();
+    affectedClass = f.severity === 'critical' ? 'danger' : (f.severity === 'high' ? 'warn' : '');
+  }
+
+  return (
+    <div className="fdd-strip">
+      <div className="fdd-strip-cell">
+        <span className="label">Horizon</span>
+        <span className={'fdc-pill ' + laneClass}>{laneLabel}</span>
+      </div>
+      <div className="fdd-strip-cell">
+        <span className="label">Effort</span>
+        <span className={'val' + (f.effort ? '' : ' muted')}>{effort}</span>
+      </div>
+      <div className="fdd-strip-cell">
+        <span className="label">Affected</span>
+        {affectedText
+          ? <span className={'val ' + affectedClass}>{affectedText}</span>
+          : <span className="val muted">—</span>}
+      </div>
+      <div className="fdd-strip-cell">
+        <span className="label">Owner</span>
+        <span className="val muted">Unassigned</span>
+      </div>
+      <div className="fdd-strip-cell">
+        <span className="label">Ticket</span>
+        <span className="val muted">—</span>
+      </div>
+    </div>
+  );
+}
+
+function FindingRiskNarrative({ f }) {
+  // Phase 2: use existing whyItMatters() output as the Risk paragraph.
+  // The "Why it matters" subsection is intentionally empty until per-check
+  // narrative authoring lands (Option C from the v2.11.0 plan).
+  const risk = whyItMatters(f);
+  const mitre = Array.isArray(f.mitre) ? f.mitre : [];
+  return (
+    <div className="fdd-risk">
+      <div className="fdd-risk-icon" aria-hidden="true">!</div>
+      <div className="fdd-risk-body">
+        <div className="fdd-risk-section">
+          <div className="fdd-risk-head danger">Risk</div>
+          <p>{risk}</p>
+        </div>
+      </div>
+      {mitre.length > 0 && (
+        <div className="fdd-risk-meta">
+          <span className="fdd-risk-meta-label">MITRE ATT&amp;CK</span>
+          <div className="fdd-mitre">
+            {mitre.map(m => <code key={m} title={m}>{String(m).split(' — ')[0]}</code>)}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Direction D collapsible provenance footer. Reuses the evidence schema
+// from D1 #785; visually re-frames the existing EvidenceBlock as a footer
+// at the bottom of the expanded row with an inline summary of the most
+// useful provenance keys.
+function FindingProvenanceFooter({ evidence }) {
+  if (!evidence) return null;
+  let ev = evidence;
+  if (typeof ev === 'string') {
+    try { ev = { raw: ev }; } catch { return null; }
+  }
+  const fields = [
+    ['evidenceSource',     'Source'],
+    ['evidenceTimestamp',  'Collected'],
+    ['collectionMethod',   'Method'],
+    ['permissionRequired', 'Permission'],
+    ['confidence',         'Confidence'],
+    ['observedValue',      'Observed'],
+    ['expectedValue',      'Expected'],
+    ['limitations',        'Limitations'],
+  ];
+  const present = fields.filter(([k]) => ev[k] !== undefined && ev[k] !== null && ev[k] !== '');
+  let rawPretty = null;
+  if (ev.raw) {
+    try { rawPretty = JSON.stringify(JSON.parse(ev.raw), null, 2); }
+    catch { rawPretty = String(ev.raw); }
+  }
+  if (present.length === 0 && !rawPretty) return null;
+
+  // Inline summary pulls 2-3 most-useful keys (source + collected + confidence).
+  const summaryKeys = ['evidenceSource', 'evidenceTimestamp', 'confidence'];
+  const summaryEntries = summaryKeys
+    .map(k => [k, ev[k]])
+    .filter(([, v]) => v !== undefined && v !== null && v !== '');
+
+  return (
+    <details className="fdd-prov">
+      <summary>
+        <span className="prov-summary">
+          <span className="prov-key">Provenance</span>
+          {summaryEntries.length === 0 && <span className="prov-sep">·</span>}
+          {summaryEntries.map(([k, v], i) => (
+            <React.Fragment key={k}>
+              {i > 0 && <span className="prov-sep">·</span>}
+              <code>{k === 'confidence' ? `${Math.round(v * 100)}%` : String(v)}</code>
+            </React.Fragment>
+          ))}
+        </span>
+        <span className="prov-toggle">View details</span>
+      </summary>
+      <div className="fdd-prov-body">
+        {ev.limitations && (
+          <p className="fdd-limit"><b>Limitations:</b> {ev.limitations}</p>
+        )}
+        {present.length > 0 && (
+          <div className="fdd-prov-meta">
+            {present.filter(([k]) => k !== 'limitations').map(([k, label]) => (
+              <div key={k}>
+                <span className="k">{label}</span>
+                <span className="v">{k === 'confidence' ? `${Math.round(ev[k] * 100)}%` : String(ev[k])}</span>
+              </div>
+            ))}
+          </div>
+        )}
+        {rawPretty && (
+          <details className="finding-evidence-raw" style={{marginTop: 10}}>
+            <summary>Raw evidence</summary>
+            <pre>{rawPretty}</pre>
+          </details>
+        )}
+      </div>
+    </details>
+  );
 }
 
 // Issue #854: per-prefix narrative content for the finding-detail "Why It Matters"

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -2797,12 +2797,28 @@ function statusTier(status) {
 // (Phase 5). Empty / null-data fields render as muted placeholders so
 // the shell degrades gracefully — see docs/design/finding-detail/.
 
+// Phase 2 sequence column: matches the XLSX matrix's "Sequence" terminology
+// from #840. Pass-status findings show "Done" (consistent with the matrix's
+// green Done cell). Findings without a lane AND not Pass render as muted
+// plain text — no pill — since the chip-style rendering reads as
+// "actionable item with a state" which is wrong for non-remediable rows.
 const LANE_LABELS = { now: 'Do Now', soon: 'Do Next', later: 'Later' };
-const LANE_CSS    = { now: 'now', soon: 'next', later: '' };
+const LANE_CSS    = { now: 'now', soon: 'next', later: 'later' };
 
 function FindingStateStrip({ f }) {
-  const laneLabel = LANE_LABELS[f.lane] || '—';
-  const laneClass = LANE_CSS[f.lane] !== undefined ? LANE_CSS[f.lane] : 'empty';
+  const isPass = f.status === 'Pass';
+  // Sequence cell content + chip-vs-text decision:
+  //  - lane present (now/soon/later) → coloured pill
+  //  - status === Pass               → "Done" success pill
+  //  - everything else               → muted plain text (no pill)
+  let sequenceNode;
+  if (f.lane && LANE_LABELS[f.lane]) {
+    sequenceNode = <span className={'fdc-pill ' + LANE_CSS[f.lane]}>{LANE_LABELS[f.lane]}</span>;
+  } else if (isPass) {
+    sequenceNode = <span className="fdc-pill done">Done</span>;
+  } else {
+    sequenceNode = <span className="val muted">—</span>;
+  }
   const effort = f.effort ? f.effort[0].toUpperCase() + f.effort.slice(1) : '—';
 
   // Phase 2 affected count: derive from evidence.observedValue if it has a
@@ -2820,8 +2836,8 @@ function FindingStateStrip({ f }) {
   return (
     <div className="fdd-strip">
       <div className="fdd-strip-cell">
-        <span className="label">Horizon</span>
-        <span className={'fdc-pill ' + laneClass}>{laneLabel}</span>
+        <span className="label">Sequence</span>
+        {sequenceNode}
       </div>
       <div className="fdd-strip-cell">
         <span className="label">Effort</span>

--- a/src/M365-Assess/assets/report-shell.css
+++ b/src/M365-Assess/assets/report-shell.css
@@ -991,6 +991,161 @@ mark.search-hl {
   font-size: 12.5px; line-height: 1.6;
   color: var(--text);
 }
+
+/* ===================================================================
+   Issue #863 Phase 2 — Direction D shell (state strip + risk + provenance)
+   The .fdd modifier on .finding-detail switches the layout from the
+   legacy 2-column grid to single-column rows so the new sections render
+   full-width. Phase-3-pending content rows (Current/Recommended/Remed/
+   Learn-more) are wrapped in .fdd-legacy-block and remain 2-column.
+   See docs/design/finding-detail/styles.css for the original spec.
+=================================================================== */
+.finding-detail.fdd {
+  display: block;
+  padding: 0;
+}
+.finding-detail.fdd .intent-callout { margin: 16px 16px 0 16px; }
+.finding-detail.fdd .fdd-legacy-block { padding: 0 16px; margin-top: 14px; }
+.finding-detail.fdd .fdd-legacy-block:first-of-type { margin-top: 16px; }
+
+.fdd-strip {
+  display: grid; grid-template-columns: repeat(5, 1fr);
+  background: var(--surface); border-bottom: 1px solid var(--border);
+}
+.fdd-strip-cell {
+  padding: 10px 14px; border-right: 1px solid var(--border);
+  display: flex; flex-direction: column; gap: 4px;
+}
+.fdd-strip-cell:last-child { border-right: 0; }
+.fdd-strip-cell .label {
+  font-size: 10px; font-weight: 700; letter-spacing: .1em;
+  text-transform: uppercase; color: var(--muted);
+}
+.fdd-strip-cell .val {
+  font-size: 13px; font-weight: 600; color: var(--text);
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.fdd-strip-cell .val.warn   { color: var(--warn-text); }
+.fdd-strip-cell .val.danger { color: var(--danger-text); }
+.fdd-strip-cell .val.muted  { color: var(--muted); font-weight: 500; }
+.fdc-pill {
+  display: inline-flex; align-items: center; gap: 4px;
+  font-size: 11px; font-weight: 700;
+  padding: 2px 8px; border-radius: 999px;
+  background: var(--chip); color: var(--text-soft);
+  border: 1px solid var(--border);
+}
+.fdc-pill.now   { background: color-mix(in oklab, var(--danger) 18%, transparent); color: var(--danger-text); border-color: var(--danger); }
+.fdc-pill.next  { background: color-mix(in oklab, var(--warn)   18%, transparent); color: var(--warn-text);   border-color: var(--warn); }
+.fdc-pill.empty { color: var(--muted); }
+
+.fdd-risk {
+  display: grid; grid-template-columns: 36px 1fr auto;
+  gap: 12px; padding: 12px 16px;
+  background: color-mix(in oklab, var(--danger) 7%, transparent);
+  border-bottom: 1px solid var(--border);
+  border-left: 3px solid var(--danger);
+}
+.fdd-risk-icon {
+  width: 28px; height: 28px; border-radius: 8px;
+  background: color-mix(in oklab, var(--danger) 22%, transparent);
+  color: var(--danger-text); font-weight: 700;
+  display: grid; place-items: center; align-self: start;
+}
+.fdd-risk-head {
+  font-size: 10.5px; font-weight: 700; letter-spacing: .12em;
+  text-transform: uppercase; color: var(--muted);
+  margin-bottom: 4px;
+}
+.fdd-risk-head.danger { color: var(--danger-text); }
+.fdd-risk-section + .fdd-risk-section {
+  margin-top: 10px; padding-top: 10px;
+  border-top: 1px dashed color-mix(in oklab, var(--danger) 25%, var(--border));
+}
+.fdd-risk-body p {
+  margin: 0; font-size: 13px; line-height: 1.55; color: var(--text);
+}
+.fdd-risk-meta {
+  display: flex; flex-direction: column; align-items: flex-end; gap: 6px;
+  min-width: 130px; max-width: 200px;
+  padding-left: 12px;
+  border-left: 1px solid color-mix(in oklab, var(--danger) 25%, var(--border));
+  align-self: stretch;
+  justify-content: flex-start;
+}
+.fdd-risk-meta-label {
+  font-size: 9.5px; font-weight: 700; letter-spacing: .12em;
+  text-transform: uppercase; color: var(--muted);
+}
+.fdd-mitre {
+  display: inline-flex; gap: 4px; flex-wrap: wrap; justify-content: flex-end;
+}
+.fdd-mitre code {
+  font-family: var(--font-mono); font-size: 10.5px;
+  padding: 2px 6px; border-radius: 4px;
+  background: var(--surface); color: var(--text-soft);
+  border: 1px solid var(--border);
+}
+
+.fdd-prov {
+  border-top: 1px solid var(--border);
+  background: var(--subtle);
+  font-size: 11.5px; color: var(--text-soft);
+  margin-top: 16px;
+}
+.fdd-prov summary {
+  cursor: pointer; padding: 9px 16px;
+  display: flex; justify-content: space-between; align-items: center; gap: 14px;
+  user-select: none; list-style: none;
+}
+.fdd-prov summary::-webkit-details-marker { display: none; }
+.fdd-prov .prov-summary {
+  display: inline-flex; gap: 8px; align-items: center; flex-wrap: wrap;
+  flex: 1; min-width: 0;
+}
+.fdd-prov .prov-key {
+  font-size: 10px; font-weight: 700; letter-spacing: .1em;
+  text-transform: uppercase; color: var(--muted);
+}
+.fdd-prov .prov-sep { color: var(--border); }
+.fdd-prov code {
+  font-family: var(--font-mono); font-size: 10.5px;
+  background: var(--chip); padding: 1px 5px; border-radius: 3px; color: var(--text);
+}
+.fdd-prov .prov-toggle {
+  font-size: 11px; font-weight: 600; color: var(--accent-text);
+  white-space: nowrap; flex-shrink: 0;
+}
+.fdd-prov-body { padding: 0 16px 14px; }
+.fdd-limit {
+  margin: 0 0 8px 0; padding: 8px 10px; font-size: 12px;
+  background: color-mix(in oklab, var(--warn) 10%, transparent);
+  border-left: 3px solid var(--warn); border-radius: 0 6px 6px 0;
+  color: var(--text);
+}
+.fdd-limit b { color: var(--warn-text); }
+.fdd-prov-meta {
+  display: grid; grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+.fdd-prov-meta > div {
+  display: flex; flex-direction: column; gap: 3px; min-width: 0;
+}
+.fdd-prov-meta .k {
+  font-size: 9.5px; font-weight: 700; letter-spacing: .12em;
+  text-transform: uppercase; color: var(--muted);
+}
+.fdd-prov-meta .v {
+  font-size: 11.5px; color: var(--text); font-weight: 500;
+  word-break: break-word;
+}
+.fdd-prov-body pre {
+  margin: 0; padding: 10px;
+  background: var(--surface); border: 1px solid var(--border); border-radius: 6px;
+  font-family: var(--font-mono); font-size: 10.5px; color: var(--text);
+  white-space: pre-wrap; word-break: break-word;
+  max-height: 200px; overflow: auto;
+}
 .finding-remediation {
   grid-column: 1 / -1;
   padding-top: 4px;

--- a/src/M365-Assess/assets/report-shell.css
+++ b/src/M365-Assess/assets/report-shell.css
@@ -1035,8 +1035,10 @@ mark.search-hl {
   background: var(--chip); color: var(--text-soft);
   border: 1px solid var(--border);
 }
-.fdc-pill.now   { background: color-mix(in oklab, var(--danger) 18%, transparent); color: var(--danger-text); border-color: var(--danger); }
-.fdc-pill.next  { background: color-mix(in oklab, var(--warn)   18%, transparent); color: var(--warn-text);   border-color: var(--warn); }
+.fdc-pill.now   { background: color-mix(in oklab, var(--danger)  18%, transparent); color: var(--danger-text);  border-color: var(--danger); }
+.fdc-pill.next  { background: color-mix(in oklab, var(--warn)    18%, transparent); color: var(--warn-text);    border-color: var(--warn); }
+.fdc-pill.later { background: color-mix(in oklab, var(--accent)  14%, transparent); color: var(--accent-text);  border-color: var(--accent-border); }
+.fdc-pill.done  { background: color-mix(in oklab, var(--success) 18%, transparent); color: var(--success-text); border-color: var(--success); }
 .fdc-pill.empty { color: var(--muted); }
 
 .fdd-risk {


### PR DESCRIPTION
## Summary

**PR ε.2** of the v2.11.0 finding-detail panel redesign. Implements **Phase 2** of the design handoff at `docs/design/finding-detail/` — structural shell on top of existing fields.

Phase 1 (schema groundwork) deferred until a phase needs it. Phases 3-5 follow with typed observed/expected, side rail, owner/ticket.

## What ships

### 3 new components

- **`<FindingStateStrip>`** — Row 1 (Horizon · Effort · Affected · Owner · Ticket).
  - Horizon = `lane` field (existing, computed by `Get-RemediationLane.ps1`)
  - Effort = registry field (muted placeholder when null)
  - Affected = derives count from `evidence.observedValue` numeric prefix; falls back to muted dash; severity-tinted
  - Owner / Ticket = muted placeholders (Phase 5 adds edit-mode assignment)
- **`<FindingRiskNarrative>`** — Row 2.
  - Risk paragraph: existing `whyItMatters(f)` output, red-tinted
  - Why-it-matters subsection: **intentionally omitted per Option C** — splitting the ~70 prefix-chain narratives into two paragraphs each is content work that overlaps with the #854 audit findings; graceful empty state until per-check authoring lands
  - MITRE meta column hidden when `f.mitre` is empty (the common case for Phase 2)
- **`<FindingProvenanceFooter>`** — collapsible details footer.
  - Summary line: source · collected · confidence inline
  - Expanded: 3-col grid of all evidence-schema fields + nested raw evidence
  - Reuses D1 #785 evidence schema

### Expanded-row JSX refactor

- Opt into Direction D via `.finding-detail.fdd` modifier
- Legacy Current/Recommended/Remediation/Learn-more rows wrapped in `.fdd-legacy-block`; Phase 3 replaces them
- Existing "Why it matters" block above Current value REMOVED — that content now lives in Row 2 as the Risk paragraph

### CSS

~150 lines added to `report-shell.css`, adapted from `docs/design/finding-detail/styles.css`:
- `.finding-detail.fdd` modifier (grid → block)
- `.fdd-strip` + `.fdc-pill` (lane chip with now/next/empty variants)
- `.fdd-risk` red-tinted callout (icon + body + MITRE meta)
- `.fdd-prov` collapsible footer
- Substituted design's `--surface2` → `--subtle` (existing theme var)
- `color-mix()` retained (Chrome 111+, Safari 16.2+, Firefox 113+; modern reports)

## What this PR does NOT do

- **Doesn't close #863.** Title says `refs #863` not `closes` — Phases 3-5 follow.
- **Doesn't add new fields to the finding object.** Pure presentation; uses what's already on `f.lane`, `f.effort`, `f.evidence.*`, `f.mitre` (which most checks don't set today, hence Phase 2's graceful empty-state behavior)
- **Doesn't author per-check Risk vs Why-it-matters narratives.** That's Option B from the v2.11.0 plan; deferred per Option C choice

## Test plan

- [x] PSScriptAnalyzer clean (no PS changes, only JSX/JS/CSS)
- [x] Full Pester suite — 2307 passed / 0 failed / 3 expected skips
- [x] `npm run build` regenerates `report-app.js` cleanly
- [x] CI green
- [ ] Live-tenant verification: open HTML report, expand any finding row, confirm:
  - State strip renders at top with Horizon (Now/Next/Later pill), Effort (muted "—" if not set), Affected (count if observed value has a numeric prefix), Owner "Unassigned", Ticket "—"
  - Risk paragraph renders red-tinted with the existing whyItMatters narrative
  - Why-it-matters subsection NOT rendered (Option C)
  - Provenance footer at bottom is collapsible; summary line shows source / collected / confidence; expanded shows full evidence schema
  - All 4 themes still render cleanly

## Next phase

**PR ε.3** — Phase 3: typed observed/expected table + tabbed actions (Portal / PowerShell / Verify). Requires Phase 1 schema groundwork (typed `evidence.observedValue` populated by collectors + `remediation` parsed into `{ portal, ps, verify }`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)