### PR TITLE
docs: add REPORT-USER-GUIDE.md for HTML report's interactive features (closes #897)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Invoke-M365Assessment -TenantId 'contoso.onmicrosoft.com'
 
 Results land in a timestamped folder with CSV data + HTML report + XLSX compliance matrix.
 
-> **New to M365 Assess?** See the [Quickstart guide](docs/QUICKSTART.md) for step-by-step setup on a fresh Windows machine.
+> **New to M365 Assess?** See the [Quickstart guide](docs/QUICKSTART.md) for step-by-step setup on a fresh Windows machine. Once the assessment runs and you've opened the HTML report, the [Report user guide](docs/REPORT-USER-GUIDE.md) walks through edit mode, Finalize, theme toggles, sortable/resizable columns, and other interactive controls.
 
 ## Prerequisites
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -80,7 +80,7 @@ Results land in a timestamped folder (e.g., `M365-Assessment/Assessment_20260330
 | `*_Assessment-Report.html` | React-based HTML report with all findings |
 | `*_Compliance-Matrix.xlsx` | Framework compliance matrix (requires ImportExcel) |
 
-Open the HTML report in any browser to review findings.
+Open the HTML report in any browser to review findings. The report is interactive — see [`REPORT-USER-GUIDE.md`](REPORT-USER-GUIDE.md) for the walkthrough of edit mode, Finalize, theme toggles, sortable/resizable columns, and other controls.
 
 ## What You Need
 

--- a/docs/REPORT-USER-GUIDE.md
+++ b/docs/REPORT-USER-GUIDE.md
@@ -1,0 +1,180 @@
+# Using the M365-Assess HTML report
+
+A walkthrough of the interactive features in the assessment HTML output. If you've just generated your first report and want to know what you can DO with it, this is the doc.
+
+For setting up + running the assessment itself, see [`QUICKSTART.md`](QUICKSTART.md). For the data shape behind the report, see [`REPORT-SCHEMA.md`](REPORT-SCHEMA.md). For front-end internals (build, components), see [`REPORT-FRONTEND.md`](REPORT-FRONTEND.md).
+
+---
+
+## What is interactive?
+
+The report is a single self-contained HTML file. It looks static, but it's a real React app — most of the surface is interactive:
+
+| Surface | Interaction |
+|---|---|
+| Section headers | Click to collapse / expand |
+| FilterBar (top of findings table) | Multi-select chips: Status / Severity / Framework / Domain / Level |
+| Findings table columns | Click headers to sort; drag right edges to resize |
+| Findings table rows | Click any row to expand into the detail panel |
+| Roadmap section | Drag tasks between Now / Next / Later lanes (or use the menu on each card) |
+| Topbar | Theme toggle (4 themes) · density toggle · text-size A− / A+ · Edit mode toggle · Finalize |
+
+Everything except Finalize is non-destructive — you can click around freely without affecting the on-disk file.
+
+---
+
+## Edit mode
+
+The Edit mode toggle in the topbar is the entry point to consultant-side enrichment of the report. You can:
+
+1. **Hide any card or section** that's not useful for the current customer
+2. **Hide individual findings** (the "this isn't relevant for this engagement" case)
+3. **Reassign roadmap lanes** (move a finding from Later → Now if the customer wants it prioritised)
+4. **Reset all** of the above to defaults
+
+When edit mode is on:
+- An **EDIT MODE banner** appears at the top of the page (visual signal that you're in edit mode)
+- Hover-over actions appear on cards and rows (✕ icons)
+- Toolbar shows a **Reset all** button
+
+Click the toggle again to exit edit mode (your edits stay applied; they aren't discarded by exiting).
+
+### Hiding a card or section
+
+In edit mode, hover over any card / section / framework cell / appendix sub-card / roadmap lane. A small ✕ overlay appears in the top-right corner. Click it.
+
+The element stays visible in edit mode but at 40% opacity, with a ↩ Restore button. Outside edit mode, the element is fully hidden.
+
+To restore:
+- In edit mode: click the ↩ button on the faded element
+- Or: click **Reset all** in the toolbar to restore everything
+
+### Hiding a finding
+
+Same flow — hover the finding row in edit mode, click ✕. The row disappears from the visible findings table (and from KPI tile counts, framework rollups, etc.) until restored.
+
+### Reassigning a roadmap lane
+
+The Roadmap section shows tasks in three lanes — Do Now, Do Next, Later — based on each finding's severity + effort. The lane assignment is computed automatically by `Get-RemediationLane.ps1`.
+
+In edit mode, you can override the lane:
+- Click a roadmap card → the menu shows "Move to Do Now / Do Next / Later"
+- Or drag the card to a different lane
+
+A `custom` badge appears on overridden cards. Click **Reset** on the card to revert to the auto-computed lane.
+
+### What gets persisted
+
+Edit-mode changes live only in browser memory until you Finalize (next section). Closing the browser without Finalizing loses all edits.
+
+---
+
+## Finalize → fresh HTML
+
+The **Finalize** button in the topbar writes a NEW HTML file with your current overrides baked in. This is the customer-facing version of the report.
+
+**File location:** your browser's default download folder. Filename: `<TenantName>-M365-Report.html` (spaces stripped).
+
+**What gets baked in:**
+- Hidden findings (won't appear in the new file at all)
+- Hidden cards / sections (same)
+- Roadmap lane overrides (the new file shows your manual lanes as the default)
+
+**What's NOT baked in:**
+- Theme / density / text-size choices (those are per-viewer preferences, not part of the report state)
+- The original file on disk is unchanged — Finalize creates a NEW download, doesn't modify the source
+
+**Re-opening a finalized file:** edits persist. You can Finalize-of-a-finalized to bake in further edits (effectively "save" multiple times).
+
+**Regenerating the assessment:** the next `Invoke-M365Assessment` run produces a fresh HTML with no overrides applied (default state). The finalized file you produced is independent of future assessments.
+
+### Power-user note: `REPORT_OVERRIDES`
+
+Inside the finalized HTML, the overrides live in a global JS variable:
+
+```js
+window.REPORT_OVERRIDES = {
+  hiddenFindings:   ['ENTRA-MFA-001', ...],
+  hiddenElements:   ['kpi-secure-score', 'appendix-licenses', ...],
+  roadmapOverrides: { 'EXO-FORWARD-001': 'now', ... }
+};
+```
+
+You can hand-edit this if you want to programmatically share an override set across multiple reports. Stable keys:
+- Finding `checkId` (without sub-numbering — `ENTRA-MFA-001` not `ENTRA-MFA-001.1`)
+- Card `data-hide-key` attributes (visible in browser DevTools — e.g., `kpi-fails`, `appendix-licenses`, `framework-cell-cis-m365`)
+
+---
+
+## Other interactive controls
+
+### Theme toggle
+
+Topbar shows the current theme; click to cycle through:
+
+| Theme | Use case |
+|---|---|
+| **Neon** (dark, default) | Default — high contrast, accent-heavy |
+| **Console** (dark) | Quieter dark theme; closer to standard terminal palette |
+| **Saas** (light) | Light theme for printing / projecting |
+| **High-Contrast** | WCAG AAA-leaning; for accessibility or low-bandwidth visual conditions |
+
+Theme persists per-tenant in localStorage.
+
+### Density toggle
+
+Compact mode reduces vertical padding throughout. Useful when you want more findings on screen at once. Toggle in the topbar; persists per-tenant.
+
+### Text size A− / A+
+
+Two adjacent buttons step the base font size one position each direction. Disable at boundaries. Persists in `m365-text-scale` localStorage.
+
+### Findings table columns
+
+| Action | How |
+|---|---|
+| Sort | Click a header (Status / Finding / Domain / CheckID / Severity) to cycle: none → ascending → descending → none |
+| Resize | Drag the right edge of any header (8px hot zone). Min width 60px |
+
+Sort + resize persist per-tenant in localStorage.
+
+### FilterBar
+
+Multi-select chips above the findings table. Filters apply across the table, KPI tiles, and framework rollups.
+
+| Group | Chips |
+|---|---|
+| **Status** | Pass · Fail · Warning · Review · Info · Skipped |
+| **Severity** | Critical · High · Medium · Low |
+| **Framework** | Per-framework chips (CIS · NIST · ISO · CMMC · ...) |
+| **Domain** | Per-domain chips (Identity · Defender · Exchange · ...) |
+| **Level** | E3-L1 · E3-L2 · E5-L1 · E5-L2 (when a CIS framework is selected) |
+
+Click a chip to add it to the filter; click again to remove. Multiple chips in the same group are OR-combined; chips across groups are AND-combined.
+
+Filter state persists per-tenant; reset via the FilterBar's Clear-all action.
+
+---
+
+## Edge cases
+
+**Hidden finding referenced by a check that no longer exists.** When the registry syncs and a check is removed (rare but possible), an existing override for that `checkId` is silently ignored. No error.
+
+**Re-running the assessment after editing.** A new `Invoke-M365Assessment` run produces a fresh HTML with no overrides. To carry edits forward, either:
+1. Hand-copy the `REPORT_OVERRIDES` block from your finalized HTML into the new one
+2. Or Finalize once at the end of each assessment cycle and store the finalized version separately
+
+**Re-opening a finalized file in a different browser.** Edits persist (they're embedded in the file's JS). Theme / density / text-size are per-browser localStorage and don't transfer.
+
+**Sharing the report via email.** The finalized HTML is a single self-contained file. It runs offline (no CDN dependencies for the data; React + Babel are inlined).
+
+---
+
+## See also
+
+- [`QUICKSTART.md`](QUICKSTART.md) — running the assessment
+- [`RUN.md`](RUN.md) — orchestration details
+- [`REPORT-SCHEMA.md`](REPORT-SCHEMA.md) — the data shape behind the report
+- [`REPORT-FRONTEND.md`](REPORT-FRONTEND.md) — front-end internals (React, build, components)
+- [`SCORING.md`](SCORING.md) — how the headline score is computed and why
+- [`CHECK-STATUS-MODEL.md`](CHECK-STATUS-MODEL.md) — the status taxonomy


### PR DESCRIPTION
## Summary

Closes **#897**. Documents the consultant-facing interactive surface of the HTML report — edit mode, hide-any-card, Finalize, theme toggles, sortable/resizable columns, FilterBar — which had accumulated significantly over the v2.x line without an end-user walkthrough.

## What ships

`docs/REPORT-USER-GUIDE.md` (~180 lines) covering all 5 sections from #897:

1. **What is interactive** — at-a-glance table of every clickable / draggable / sortable surface in the report
2. **Edit mode walkthrough** — entry, EDIT MODE banner, hide-any-card (#712), per-finding hide, roadmap lane reassignment, Reset all
3. **Finalize → fresh HTML** — what gets baked in, file location (downloads folder), `REPORT_OVERRIDES` JS variable schema with example, regeneration interaction
4. **Other interactive controls** — themes (4), density toggle, A− / A+ (#852), findings-table column sort + resize (#846), FilterBar (#847)
5. **Edge cases** — orphaned overrides, sharing the file, browser persistence

## Cross-links added

- `README.md` — under the existing "New to M365 Assess?" note, adds: "Once the assessment runs and you've opened the HTML report, the Report user guide walks through edit mode..."
- `QUICKSTART.md` — after the "Open the HTML report" step in section 5

## What this PR does NOT do

- **No screenshots in v1** — defer until a stable visual reference exists. The doc references `data-hide-key` attributes and topbar control names verbatim, which is enough to navigate.
- **No keyboard shortcuts section** — none documented in the source today.
- **No "in case of accidental Finalize" undo notes** — Finalize is non-destructive (it creates a new file), so there's nothing to undo.

## Test plan

- [x] No code changes — Pester / build / lint not affected
- [x] Markdown renders cleanly (table of contents, code fences, internal cross-links)
- [x] CI green (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)