### PR TITLE
docs: remove 19 stub redirects from #905 — clean root

### DIFF
--- a/docs/CHECK-STATUS-MODEL.md
+++ b/docs/CHECK-STATUS-MODEL.md
@@ -1,3 +1,0 @@
-# CHECK-STATUS-MODEL
-
-> **This document moved.** See [`reference/CHECK-STATUS-MODEL.md`](reference/CHECK-STATUS-MODEL.md). Stub kept for ~6 months to preserve external links; will be deleted in a future cleanup.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,3 +1,0 @@
-# COMPATIBILITY
-
-> **This document moved.** See [`reference/COMPATIBILITY.md`](reference/COMPATIBILITY.md). Stub kept for ~6 months to preserve external links; will be deleted in a future cleanup.

--- a/docs/CheckId-Guide.md
+++ b/docs/CheckId-Guide.md
@@ -1,3 +1,0 @@
-# CheckId-Guide
-
-> **This document moved.** See [`dev/CheckId-Guide.md`](dev/CheckId-Guide.md). Stub kept for ~6 months to preserve external links; will be deleted in a future cleanup.

--- a/docs/DATA-HANDLING.md
+++ b/docs/DATA-HANDLING.md
@@ -1,3 +1,0 @@
-# DATA-HANDLING
-
-> **This document moved.** See [`reference/DATA-HANDLING.md`](reference/DATA-HANDLING.md). Stub kept for ~6 months to preserve external links; will be deleted in a future cleanup.

--- a/docs/EVIDENCE-MODEL.md
+++ b/docs/EVIDENCE-MODEL.md
@@ -1,3 +1,0 @@
-# EVIDENCE-MODEL
-
-> **This document moved.** See [`dev/EVIDENCE-MODEL.md`](dev/EVIDENCE-MODEL.md). Stub kept for ~6 months to preserve external links; will be deleted in a future cleanup.

--- a/docs/EVIDENCE-PACKAGE.md
+++ b/docs/EVIDENCE-PACKAGE.md
@@ -1,3 +1,0 @@
-# EVIDENCE-PACKAGE
-
-> **This document moved.** See [`user/EVIDENCE-PACKAGE.md`](user/EVIDENCE-PACKAGE.md). Stub kept for ~6 months to preserve external links; will be deleted in a future cleanup.

--- a/docs/LEVELS.md
+++ b/docs/LEVELS.md
@@ -1,3 +1,0 @@
-# LEVELS
-
-> **This document moved.** See [`reference/LEVELS.md`](reference/LEVELS.md). Stub kept for ~6 months to preserve external links; will be deleted in a future cleanup.

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -1,3 +1,0 @@
-# PERMISSIONS
-
-> **This document moved.** See [`reference/PERMISSIONS.md`](reference/PERMISSIONS.md). Stub kept for ~6 months to preserve external links; will be deleted in a future cleanup.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,3 +1,0 @@
-# QUICKSTART
-
-> **This document moved.** See [`user/QUICKSTART.md`](user/QUICKSTART.md). Stub kept for ~6 months to preserve external links; will be deleted in a future cleanup.

--- a/docs/RELEASE-PROCESS.md
+++ b/docs/RELEASE-PROCESS.md
@@ -1,3 +1,0 @@
-# RELEASE-PROCESS
-
-> **This document moved.** See [`dev/RELEASE-PROCESS.md`](dev/RELEASE-PROCESS.md). Stub kept for ~6 months to preserve external links; will be deleted in a future cleanup.

--- a/docs/REPORT-FRONTEND.md
+++ b/docs/REPORT-FRONTEND.md
@@ -1,3 +1,0 @@
-# REPORT-FRONTEND
-
-> **This document moved + merged.** Frontend build content now lives in [`dev/REPORT-INTERNALS.md`](dev/REPORT-INTERNALS.md) under "Part 1 — Frontend build". Stub kept for ~6 months to preserve external links; will be deleted in a future cleanup.

--- a/docs/REPORT-SCHEMA.md
+++ b/docs/REPORT-SCHEMA.md
@@ -1,3 +1,0 @@
-# REPORT-SCHEMA
-
-> **This document moved + merged.** Data schema content now lives in [`dev/REPORT-INTERNALS.md`](dev/REPORT-INTERNALS.md) under "Part 2 — Data schema". Stub kept for ~6 months to preserve external links; will be deleted in a future cleanup.

--- a/docs/REPORT-USER-GUIDE.md
+++ b/docs/REPORT-USER-GUIDE.md
@@ -1,3 +1,0 @@
-# REPORT-USER-GUIDE
-
-> **This document moved.** See [`user/REPORT-USER-GUIDE.md`](user/REPORT-USER-GUIDE.md). Stub kept for ~6 months to preserve external links; will be deleted in a future cleanup.

--- a/docs/RUN.md
+++ b/docs/RUN.md
@@ -1,3 +1,0 @@
-# RUN
-
-> **This document moved.** See [`user/RUN.md`](user/RUN.md). Stub kept for ~6 months to preserve external links; will be deleted in a future cleanup.

--- a/docs/SCORING.md
+++ b/docs/SCORING.md
@@ -1,3 +1,0 @@
-# SCORING
-
-> **This document moved.** See [`user/SCORING.md`](user/SCORING.md). Stub kept for ~6 months to preserve external links; will be deleted in a future cleanup.

--- a/docs/SOVEREIGN-CLOUDS.md
+++ b/docs/SOVEREIGN-CLOUDS.md
@@ -1,3 +1,0 @@
-# SOVEREIGN-CLOUDS
-
-> **This document moved.** See [`reference/SOVEREIGN-CLOUDS.md`](reference/SOVEREIGN-CLOUDS.md). Stub kept for ~6 months to preserve external links; will be deleted in a future cleanup.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,3 +1,0 @@
-# TESTING
-
-> **This document moved.** See [`dev/TESTING.md`](dev/TESTING.md). Stub kept for ~6 months to preserve external links; will be deleted in a future cleanup.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,3 +1,0 @@
-# TROUBLESHOOTING
-
-> **This document moved.** See [`user/TROUBLESHOOTING.md`](user/TROUBLESHOOTING.md). Stub kept for ~6 months to preserve external links; will be deleted in a future cleanup.

--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -1,3 +1,0 @@
-# cmdlet-reference
-
-> **This document moved.** See [`dev/cmdlet-reference.md`](dev/cmdlet-reference.md). Stub kept for ~6 months to preserve external links; will be deleted in a future cleanup.


### PR DESCRIPTION
## Summary

Follow-up to **#906** (which closed #905). The 19 stub redirects PR #906 added as a backwards-compat bridge created visible clutter at `docs/` root — exactly the sprawl concern that prompted the consolidation.

## End state

```
docs/
  INDEX.md                  ← only file at the root
  user/    (6 files)
  dev/     (6 files)
  reference/ (6 files)
  research/, design/, architecture/, diagrams/
```

## Trade-off accepted

External references to old paths (`docs/QUICKSTART.md`, `docs/PERMISSIONS.md`, etc.) will 404. Mitigations:
- `INDEX.md` is the canonical wayfinding entry
- `README.md` was updated in #906 to canonical new paths
- This is a small-ish public repo; external link surface is probably tiny
- Fix-by-PR is fast if a real 404 surfaces

## Test plan

- [x] No code changes
- [x] No content changes — pure file deletion
- [x] All canonical paths under `user/`, `dev/`, `reference/` unchanged from #906
- [x] CI green (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)