### PR TITLE
v2.11.0 close-out: SSPR-001 honest Review + remediation-path rot decision (closes #878 #879)

### DIFF
--- a/docs/research/remediation-path-rot-decision.md
+++ b/docs/research/remediation-path-rot-decision.md
@@ -1,0 +1,99 @@
+# Remediation-path rot — structural decision
+
+Decision artifact for issue #879. The remediation `portal.path` strings shipped in `controls/registry.json` and inline in collector `Add-Setting` calls are silently rotting whenever Microsoft reorganizes an admin-center hub. Two examples surfaced in one v2.10 / v2.11 sprint (#878 ENTRA-SSPR-001 + a CA path during the 2026-04-29 lab session). With ~250 checks and Microsoft's roughly 18-month admin-center reorg cadence, the long-term cost of inline UI breadcrumbs is structural, not incidental.
+
+## The shape of the problem
+
+A remediation string today looks like:
+
+> `Entra admin center > Protection > Authentication methods > Registration campaign > Enable and target All Users.`
+
+The user opens the Entra admin center, looks for "Protection", and finds it doesn't exist (or has been renamed, or its child has moved one hub level up). Two predictable failure modes:
+
+1. **Loss of trust.** A consultant clicking through and not finding the named menu item assumes the report is stale across the board. Hard to recover from.
+2. **Silent skip.** The consultant gives up on remediating the finding because re-discovering the path is more effort than the finding feels worth.
+
+For a tool whose value proposition is hands-off auditor handoff, this is a credibility bug — independent of whether the underlying check is correct.
+
+## Three options on the table (per #879)
+
+| Option | What it changes | Pro | Con |
+|---|---|---|---|
+| **A** Drop verbose paths, link Microsoft Learn instead | Replace breadcrumb strings with MS Learn deep-links Microsoft maintains as canonical | Microsoft owns the rot; URLs are stable across UI reorgs; one source of truth | Loses inline "where to click next" hint; user has to context-switch into a docs page |
+| **B** Render path as "likely-stale, see Learn for canonical" | Keep inline path with "as of v2.X.0" stamp + Learn link as primary fix source | Quick reference preserved; canonical link present; familiar pattern (Wikipedia "[citation needed]") | Still rots; visual chrome added; "as of" stamp ages too |
+| **C** CI step that diff-checks paths against scraped MS Learn deep-links | Automated drift detection on every PR | Catches new rot at PR-time; objective signal | Scraping MS Learn is fragile; MS markup changes; ongoing maintenance cost; doesn't fix the existing rot |
+
+## Decision: Option A
+
+**Replace `remediation.portal.path` rendering with a Microsoft Learn deep-link as the primary remediation surface.** Inline UI breadcrumbs become best-effort secondary content, displayed only when no Learn URL is available.
+
+### Why A wins
+
+- **Microsoft owns the rot.** Learn URLs survive admin-center reorgs because Microsoft updates them in lockstep with the UI changes. We piggyback on Microsoft's documentation pipeline rather than running our own.
+- **Single source of truth.** The Learn page links into the relevant portal config experience anyway. The user gets both the conceptual context and the deep-link in one place.
+- **Already partially populated.** The registry's `remediation.references[].url` field already carries Microsoft Learn URLs for many checks. We're not introducing a new schema concept — we're promoting an existing field to the primary remediation surface.
+- **Low blast radius.** Render-side change, no new collector contract, no breaking change to `Add-Setting`. The breadcrumb path remains in the data; only the visual treatment changes.
+
+### Why not B
+
+The "as-of" stamp still ages, just slower. It adds visual noise (more text per finding, second-class link styling, version stamp) without fixing the underlying issue. We'd be admitting the problem in the UI rather than solving it.
+
+### Why not C
+
+Scraping Microsoft Learn is a fragile maintenance burden — when Microsoft updates the Learn site's markup we're hand-fixing the scraper, which is the same class of problem as the original UI rot. Worse: a CI gate that breaks unrelated PRs because Microsoft renamed an h2 tag is corrosive to development velocity. Defer indefinitely.
+
+## Schema proposal — minimal addition
+
+Existing registry shape (already populated):
+
+```jsonc
+{
+  "remediation": {
+    "portal": {
+      "path": "Microsoft Entra admin center > Protection > ..."
+    },
+    "references": [
+      { "url": "https://learn.microsoft.com/...", "title": "Microsoft Learn — ..." }
+    ]
+  }
+}
+```
+
+No schema change required — the data is already there. The change is in `report-app.jsx` rendering:
+
+1. **Primary surface:** if `remediation.references[]` contains an MS Learn URL (matches `learn.microsoft.com`), render that as the headline remediation link with the title as link text.
+2. **Secondary surface:** display `remediation.portal.path` as fine-print "Approximate menu path (may have moved):" below the link. Visually de-emphasized.
+3. **Fallback:** if no Learn URL exists, render the path as the primary text (current behavior). This handles Group Policy paths (GPMC), PowerShell-only remediations, and other non-portal cases where there's no URL to point at.
+
+Collector-side: `Add-Setting`'s explicit `Remediation` parameter remains a string fallback — no new collector parameter needed. When the registry has a Learn URL the report prefers it; the collector string is only rendered if the registry has no `references`.
+
+## Phased plan
+
+**Phase 1 (this PR is the decision artifact only — implementation is a separate PR):** Render-side change in `report-app.jsx` to prefer `references[].url` over `portal.path`. No data touched. Ship behind no flag — this is purely a visual improvement.
+
+**Phase 2 (data sweep, separate sprint):** Walk the top-30 most-rendered checks (#854's set). For each, verify a `references[].url` entry exists pointing at the canonical Microsoft Learn page. File CheckID upstream issues for any check missing a Learn URL.
+
+**Phase 3 (deferred):** Collector inline `Remediation` strings get a similar audit — promote URL-bearing remediations to use a `learn:` prefix convention or similar (TBD when phase 2 ships and we know what gaps exist).
+
+## Track 3 — upstream coordination
+
+The `remediation.portal.path` field is upstream-controlled (CheckID/SCF data). Local edits get clobbered on next sync. So:
+
+- **Phase 1 (render-side)** lands in M365-Assess only. No upstream coordination required — we're changing how we render existing fields.
+- **Phase 2 (data sweep)** files upstream issues against CheckID for missing Learn URLs. Follows the existing pattern from `feedback_no_local_renames_of_upstream_artifacts.md` — never edit upstream data locally.
+- **The sync workflow** does not need an override layer. Path strings stay upstream-authoritative; we just stop relying on them as the primary user-facing remediation hint.
+
+## Out of scope (deliberately)
+
+- **The Track 1 sweep** (verifying all ~250 paths against current admin-centers) — that's Phase 2, separate sprint. This issue's acceptance criteria explicitly punt the sweep.
+- **Per-cmdlet remediation strings** — PowerShell cmdlet names rot less than admin-center UIs. Lower priority; address opportunistically if a Phase 2 audit surfaces broken cmdlet names.
+- **Replacing `portal.path` in the registry schema** — keep the field; just deprioritize its rendering. Other CheckID consumers may still rely on it.
+- **Rendering a "verified as of vX.Y.Z" stamp on remediation** — Option B's fallback. We rejected it; don't bring it back as a sub-feature.
+
+## Sources
+
+- Issue #879 (this spike resolves)
+- Issue #878 (concrete instance — ENTRA-SSPR-001 stale path)
+- Issue #854 (top-30 most-rendered checks set — used by Phase 2 scope)
+- `feedback_no_local_renames_of_upstream_artifacts.md` (upstream coordination rule)
+- `src/M365-Assess/controls/registry.json` — `remediation.references[].url` field already populated for many checks

--- a/docs/research/review-status-audit.md
+++ b/docs/research/review-status-audit.md
@@ -13,17 +13,17 @@ Get-ChildItem -Path 'src/M365-Assess' -Recurse -Filter '*.ps1' |
 
 | Status | Emissions | What it should mean |
 |---|---|---|
-| `Review` | 68 | Data was collected but a human needs to interpret the result. |
+| `Review` | 69 | Data was collected but a human needs to interpret the result. |
 | `Skipped` | 28 | The check did not run (license-gated, permission-gated, or env-not-applicable). |
 | `Unknown` | 1 | Data could not be collected; this is different from "Skipped". |
-| **Total** | **97** | |
+| **Total** | **98** | |
 
 Per-collector breakdown:
 
 | Collector | Review | Skipped | Unknown |
 |---|---|---|---|
 | `Entra/EntraUserGroupChecks.ps1` | 0 | 22 | 0 |
-| `Entra/EntraPasswordAuthChecks.ps1` | 7 | 0 | 0 |
+| `Entra/EntraPasswordAuthChecks.ps1` | 8 | 0 | 0 |
 | `Entra/EntraAdminRoleChecks.ps1` | 5 | 0 | 1 |
 | `Collaboration/Get-SharePointSecurityConfig.ps1` | 4 | 0 | 0 |
 | `Exchange-Online/Get-DnsSecurityConfig.ps1` | 4 | 0 | 0 |
@@ -55,16 +55,17 @@ For each emission site, the question is one of three things:
 
 - **`EntraUserGroupChecks.ps1` Skipped emissions (22 sites)** — most are conditional on Graph permissions or specific service-plan licensing. Skipped is the correct status for those scenarios.
 - **EXO checks that depend on Connect-ExchangeOnline** — when EXO module isn't connected, checks Skip. Correct.
+- **ENTRA-SSPR-001** (#878, fixed this PR) — the legacy "Self service password reset enabled" toggle (None / Selected / All) lives in the Entra admin center under Password reset > Properties and is **not exposed by Microsoft Graph** as of the 2026-04 audit. The previous collector read `authenticationMethodsRegistrationCampaign` (the MFA Registration Campaign — a different control) and labeled it as SSPR. Now correctly emits Review with a manual-verify instruction.
 
 ### Triage pending (representative — not exhaustive)
 
-- `EntraPasswordAuthChecks.ps1` — 7 Review emissions; some may be the same shape as ENTRA-SSPR-001 (semantic mismatch with upstream registry name) — see #878.
+- `EntraPasswordAuthChecks.ps1` — 8 Review emissions (was 7; ENTRA-SSPR-001 added per #878 fix above).
 - `Exchange-Online/Get-DnsSecurityConfig.ps1` — 4 Review emissions; verify whether they're genuinely manual-validation or if a Graph endpoint would resolve them.
 - `Get-CASecurityConfig.ps1` — 2 Review emissions; given the CA admin-center reorg + #879 path rot, worth confirming the collector's data path.
 
 ## Lock-down regression
 
-`tests/Behavior/Status-Emission-Audit.Tests.ps1` asserts the count of Review / Unknown / Skipped emissions stays at or below the current ceiling (68 / 28 / 1 = 97 total). When a new emission is added the test fails, forcing the contributor to:
+`tests/Behavior/Status-Emission-Audit.Tests.ps1` asserts the count of Review / Unknown / Skipped emissions stays at or below the current ceiling (69 / 28 / 1 = 98 total). When a new emission is added the test fails, forcing the contributor to:
 
 1. Justify the new emission (genuine limitation? collector bug?)
 2. Update this doc to add the new site to the audit catalogue

--- a/src/M365-Assess/Entra/EntraPasswordAuthChecks.ps1
+++ b/src/M365-Assess/Entra/EntraPasswordAuthChecks.ps1
@@ -283,31 +283,26 @@ catch {
 
 # ------------------------------------------------------------------
 # 7c. SSPR Enabled for All Users (CIS 5.2.4.1)
+#
+# The legacy "Self service password reset enabled" (None / Selected /
+# All) toggle lives in the Microsoft Entra admin center under Password
+# reset > Properties and is NOT exposed by Microsoft Graph as of the
+# 2026-04 audit. The previous implementation read
+# /policies/authenticationMethodsPolicy.registrationEnforcement
+# .authenticationMethodsRegistrationCampaign, which is the MFA
+# Registration Campaign feature -- a different control surfaced
+# separately. See #878.
 # ------------------------------------------------------------------
-try {
-    if ($sspr) {
-        $campaign = $sspr['registrationEnforcement']['authenticationMethodsRegistrationCampaign']
-        $campaignState = $campaign['state']
-        $includeTargets = $campaign['includeTargets']
-        $targetsAll = $false
-        if ($includeTargets) {
-            $targetsAll = $includeTargets | Where-Object { $_['id'] -eq 'all_users' -or $_['targetType'] -eq 'group' }
-        }
-        $settingParams = @{
-            Category         = 'Password Management'
-            Setting          = 'SSPR Registration Campaign Targets All Users'
-            CurrentValue     = $(if ($campaignState -eq 'enabled' -and $targetsAll) { 'Enabled for all users' } elseif ($campaignState -eq 'enabled') { 'Enabled (limited scope)' } else { 'Disabled' })
-            RecommendedValue = 'Enabled for all users'
-            Status           = $(if ($campaignState -eq 'enabled' -and $targetsAll) { 'Pass' } elseif ($campaignState -eq 'enabled') { 'Warning' } else { 'Fail' })
-            CheckId          = 'ENTRA-SSPR-001'
-            Remediation      = 'Entra admin center > Protection > Authentication methods > Registration campaign > Enable and target All Users.'
-        }
-        Add-Setting @settingParams
-    }
+$settingParams = @{
+    Category         = 'SSPR'
+    Setting          = "Ensure 'Self service password reset enabled' is set to 'All'"
+    CurrentValue     = 'Not auto-measurable via Microsoft Graph'
+    RecommendedValue = 'Enabled for all users'
+    Status           = 'Review'
+    CheckId          = 'ENTRA-SSPR-001'
+    Remediation      = 'Microsoft Entra admin center > Password reset > Properties > Self service password reset enabled: All. See https://learn.microsoft.com/en-us/entra/identity/authentication/tutorial-enable-sspr for the full enablement walkthrough.'
 }
-catch {
-    Write-Warning "Could not check SSPR targeting: $_"
-}
+Add-Setting @settingParams
 
 # ------------------------------------------------------------------
 # 8. Password Protection (Banned Passwords)

--- a/tests/Behavior/Status-Emission-Audit.Tests.ps1
+++ b/tests/Behavior/Status-Emission-Audit.Tests.ps1
@@ -46,9 +46,9 @@ Describe 'Review/Unknown/Skipped emission count lock-down (#884)' {
     # audit.md classifying the new emission as genuine-limitation vs.
     # collector-bug.
 
-    It "Review emissions stay at or below the audited ceiling (68)" {
+    It "Review emissions stay at or below the audited ceiling (69)" {
         $script:counts.Review |
-            Should -BeLessOrEqual 68 -Because 'a new Review emission was added without updating docs/research/review-status-audit.md — see issue #884'
+            Should -BeLessOrEqual 69 -Because 'a new Review emission was added without updating docs/research/review-status-audit.md — see issue #884'
     }
 
     It "Skipped emissions stay at or below the audited ceiling (28)" {
@@ -62,7 +62,7 @@ Describe 'Review/Unknown/Skipped emission count lock-down (#884)' {
     }
 
     It 'reports current emission counts for visibility (informational)' {
-        Write-Host ("    [INFO] Review:  $($script:counts.Review) / 68")
+        Write-Host ("    [INFO] Review:  $($script:counts.Review) / 69")
         Write-Host ("    [INFO] Skipped: $($script:counts.Skipped) / 28")
         Write-Host ("    [INFO] Unknown: $($script:counts.Unknown) / 1")
         Write-Host ("    [INFO] Total:   $($script:emissions.Count)")


### PR DESCRIPTION
## Summary

Bundle that closes the last two actionable issues in v2.11.0 (#871 stays blocked on upstream CheckID/SCF). After this lands, v2.11.0 milestone is fully closed.

- **#878** — ENTRA-SSPR-001 was measuring the MFA Registration Campaign and labeling it as SSPR enablement. The legacy "Self service password reset enabled" (None / Selected / All) toggle is **not exposed by Microsoft Graph** as of the 2026-04 audit. Collector now emits `Status=Review` with a manual-verify instruction pointing at the current Entra admin center path and the canonical MS Learn enablement walkthrough. Setting name realigned to the upstream registry entry.
- **#879** — Decision artifact (`docs/research/remediation-path-rot-decision.md`) choosing **Option A**: prefer Microsoft Learn URLs as the primary remediation surface; demote hardcoded admin-center breadcrumbs to secondary "approximate path (may have moved)" treatment. Implementation phases punted to follow-up PRs — this is the research-spike artifact only, per the issue's explicit scope.

## What changed

| File | Change |
|---|---|
| `src/M365-Assess/Entra/EntraPasswordAuthChecks.ps1` | Replaced `ENTRA-SSPR-001` block (was reading registration-campaign payload) with a single Review emission + manual-verify remediation. Added a comment explaining why the previous Graph approach was wrong. |
| `tests/Behavior/Status-Emission-Audit.Tests.ps1` | Bumped Review ceiling 68 → 69 to match the new emission. |
| `docs/research/review-status-audit.md` | Classified `ENTRA-SSPR-001` under "Confirmed genuine limitations" with the Graph-not-exposed rationale. Bumped Review row 68 → 69 and total 97 → 98 in the snapshot table. |
| `docs/research/remediation-path-rot-decision.md` (new) | Decision artifact for #879. Option A wins: render-side change, prefer `references[].url` (already populated for many checks); no schema change needed. |

## Verification

- `Invoke-Pester -Path './tests'` → 2307 pass / 0 fail / 3 skip
- `Invoke-ScriptAnalyzer` → no new warnings (one pre-existing BOM warning on the modified file, unchanged)
- Live-test focus: open a generated report on a tenant where SSPR has been historically configured. Confirm `ENTRA-SSPR-001` now renders with `Review` status and the new manual-verify remediation text (current path + MS Learn link). Confirm the `ENTRA-MFA-001` "Auth Method Registration Campaign" check is still rendering correctly with its own Pass/Warning status (it measures the registration campaign, which is the only thing the previous SSPR-001 was actually reading).

## Out of scope (deliberately, per issue acceptance)

- The Track 1 sweep of all ~250 remediation paths against current admin centers — that's #879 Phase 2, separate sprint.
- The render-side change to prefer `references[].url` — Phase 1 of the #879 plan, separate PR.
- A new check measuring the MFA Registration Campaign as a first-class control — `ENTRA-MFA-001` already does this; no new check needed.
- A CheckID upstream issue for the registry's stale `remediation.portal.path` on ENTRA-SSPR-001 — will file separately and cross-link, since the collector's explicit Remediation string overrides the registry value at render time.

## Test plan

- [ ] CI green (Pester 7.4 + 7.6, Quality Gates, CodeQL, Cross-Platform Smoke)
- [ ] Live-tenant assessment with `-AutoBaseline`; confirm `ENTRA-SSPR-001` renders Review + new remediation text in HTML report
- [ ] Confirm `ENTRA-MFA-001` (registration campaign) still renders correctly — that check measures the field the old SSPR-001 was incorrectly reading
- [ ] Spot-check the new decision doc reads cleanly

## Closes

- closes #878
- closes #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)