### PR TITLE
docs: fix 5 broken links in README Documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,14 +404,14 @@ M365-Assess/
 
 | Guide | Description |
 |-------|-------------|
-| [Quickstart](docs/QUICKSTART.md) | Step-by-step setup on a fresh Windows machine |
+| [Quickstart](docs/user/QUICKSTART.md) | Step-by-step setup on a fresh Windows machine |
 | [Authentication](AUTHENTICATION.md) | Interactive, certificate, device code, managed identity, and pre-existing connection methods |
-| [Permissions](docs/PERMISSIONS.md) | Generated per-section matrix: delegated Graph scopes, app permissions, EXO RBAC groups, Purview directory roles |
+| [Permissions](docs/reference/PERMISSIONS.md) | Generated per-section matrix: delegated Graph scopes, app permissions, EXO RBAC groups, Purview directory roles |
 | [HTML Report](REPORT.md) | Report features, custom branding, `-NoBranding`, standalone generation |
 | [Compliance](COMPLIANCE.md) | 15 frameworks, XLSX export, CheckId system, control registry |
-| [Compatibility](docs/COMPATIBILITY.md) | Module versions, dependency matrix, known incompatibilities |
-| [Troubleshooting](docs/TROUBLESHOOTING.md) | Common errors, module conflicts, permission issues |
-| [CheckId Guide](docs/CheckId-Guide.md) | CheckId naming convention and mapping reference |
+| [Compatibility](docs/reference/COMPATIBILITY.md) | Module versions, dependency matrix, known incompatibilities |
+| [Troubleshooting](docs/user/TROUBLESHOOTING.md) | Common errors, module conflicts, permission issues |
+| [CheckId Guide](docs/dev/CheckId-Guide.md) | CheckId naming convention and mapping reference |
 | [Changelog](CHANGELOG.md) | Release history and version notes |
 | [Security](SECURITY.md) | Vulnerability reporting and security policy |
 


### PR DESCRIPTION
## Summary

The docs reorg in #905 / #906 / #907 moved files into \`docs/user/\`, \`docs/reference/\`, and \`docs/dev/\` subfolders. The README's Documentation table was not updated and 5 of the 10 entries now point at paths that don't exist.

## Fixed

| Old path | New path |
|---|---|
| \`docs/QUICKSTART.md\` | \`docs/user/QUICKSTART.md\` |
| \`docs/PERMISSIONS.md\` | \`docs/reference/PERMISSIONS.md\` |
| \`docs/COMPATIBILITY.md\` | \`docs/reference/COMPATIBILITY.md\` |
| \`docs/TROUBLESHOOTING.md\` | \`docs/user/TROUBLESHOOTING.md\` |
| \`docs/CheckId-Guide.md\` | \`docs/dev/CheckId-Guide.md\` |

The other 5 entries (AUTHENTICATION.md, REPORT.md, COMPLIANCE.md, CHANGELOG.md, SECURITY.md) remain at the repo root and need no change.

## Verified

\`\`\`
OK  docs/user/QUICKSTART.md
OK  AUTHENTICATION.md
OK  docs/reference/PERMISSIONS.md
OK  REPORT.md
OK  COMPLIANCE.md
OK  docs/reference/COMPATIBILITY.md
OK  docs/user/TROUBLESHOOTING.md
OK  docs/dev/CheckId-Guide.md
OK  CHANGELOG.md
OK  SECURITY.md
\`\`\`

## Test plan

- [x] CI green (Docs Gates / Quality Gates)
- [x] Spot-check the rendered README on GitHub — all 10 links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)