### PR TITLE
docs: 3 new user-facing docs — SCOPE / GLOSSARY / UNDERSTANDING-RESULTS (closes #920 #921 #922)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,14 +12,17 @@ For consultants running assessments and consuming the report.
 
 | Doc | What's in it |
 |---|---|
+| [`user/SCOPE.md`](user/SCOPE.md) | One-page answer to "what does this tool actually do?" — in scope, opt-in, out of scope |
 | [`user/QUICKSTART.md`](user/QUICKSTART.md) | Step-by-step setup on a fresh Windows machine — install module, prereqs, first run |
 | [`user/RUN.md`](user/RUN.md) | Orchestration details — section selection, auth methods, output folders |
 | [`user/AUTHENTICATION.md`](user/AUTHENTICATION.md) | Interactive, certificate, device code, managed identity, and pre-existing connection methods |
 | [`user/REPORT-USER-GUIDE.md`](user/REPORT-USER-GUIDE.md) | Interactive features in the HTML report — edit mode, finalize, themes, sortable/resizable columns |
-| [`user/COMPLIANCE.md`](user/COMPLIANCE.md) | 15 frameworks, XLSX export, CheckId system, control registry |
+| [`user/UNDERSTANDING-RESULTS.md`](user/UNDERSTANDING-RESULTS.md) | What each status (Pass / Fail / Review / Warning / Skipped / etc.) means and what to do |
 | [`user/SCORING.md`](user/SCORING.md) | How the headline score is computed; the 6 scoring views; per-audience rationale |
+| [`user/COMPLIANCE.md`](user/COMPLIANCE.md) | 15 frameworks, XLSX export, CheckId system, control registry |
 | [`user/EVIDENCE-PACKAGE.md`](user/EVIDENCE-PACKAGE.md) | Sanitized evidence bundle for auditor handoff (`-EvidencePackage` switch) |
 | [`user/TROUBLESHOOTING.md`](user/TROUBLESHOOTING.md) | Common errors and resolutions |
+| [`user/GLOSSARY.md`](user/GLOSSARY.md) | Glossary — Lane / Sequence / Section / Collector / Check / Control / Framework / Profile / Level / Status |
 
 ## Implementer / developer audience
 

--- a/docs/user/GLOSSARY.md
+++ b/docs/user/GLOSSARY.md
@@ -1,0 +1,84 @@
+# Glossary
+
+Terms used in the M365-Assess HTML report, the registry, and these docs. One short definition per term, alphabetical, with a pointer to the canonical doc when one exists.
+
+---
+
+### Baseline
+
+A snapshot of an assessment, captured automatically (`-AutoBaseline`) or on demand. Used to compare two runs and surface drift (newly-failing checks, newly-passing checks, status flips). Lives under `M365-Assessment/Baselines/`.
+
+### Check
+
+One observation produced by a collector — e.g., "MFA is enabled on all admin accounts." Each check has a unique **CheckId** (e.g., `ENTRA-ADMIN-001`), a **status** (Pass / Fail / Review / etc.), and a **finding** (the human-readable result).
+
+Compare to **Control** below — a Check is what M365-Assess runs; a Control is what a framework expects.
+
+### CheckId
+
+The stable identifier for a check (e.g., `ENTRA-ADMIN-001`). Defined upstream in CheckID and synced into M365-Assess's registry. CheckIds are sub-numbered when a single check produces multiple findings (e.g., `ENTRA-ADMIN-001.1`, `ENTRA-ADMIN-001.2`).
+
+See [`dev/CheckId-Guide.md`](../dev/CheckId-Guide.md) for the naming convention.
+
+### Collector
+
+A PowerShell script that connects to a Microsoft 365 service and produces checks. Lives under `src/M365-Assess/<domain>/Get-*.ps1`. Multiple collectors compose a [Section](#section).
+
+### Control
+
+A requirement defined by a compliance framework (e.g., CIS M365 1.1.1, NIST 800-53 IA-2). M365-Assess [Checks](#check) map to one or more Controls via the registry's `frameworks` field.
+
+### Finding
+
+The user-visible outcome of a check — title, status, current value, recommended value, remediation. Renders as one row in the findings table.
+
+### Framework
+
+A compliance standard or benchmark M365-Assess maps findings to. There are 15: CIS Controls v8, CIS M365 v6, NIST 800-53 r5, NIST CSF, CMMC, ISO 27001, ISO 27002, SOC 2, PCI-DSS v4, HIPAA, FedRAMP, MITRE ATT&CK, STIG, CISA SCUBA, Essential Eight.
+
+### Lane
+
+The remediation horizon assigned to a Fail finding: **Now** (immediate), **Next** (within sprint), **Later** (backlog), or **Done** (Pass — no remediation needed). Computed by `Get-RemediationLane.ps1` based on severity, license tier, and effort.
+
+Synonym in the report: **Sequence** (see below).
+
+### Level
+
+A maturity classification within a framework. CIS uses **L1 / L2 / L3** (basic / intermediate / advanced); CMMC uses the same; CIS Controls v8 uses **IG1 / IG2 / IG3** (Implementation Group 1 through 3). The FilterBar's profile chips slice findings by level.
+
+### Profile
+
+In some frameworks (CIS Controls v8, CMMC), Profile is the formal name for what the report calls Level. Treat them as synonyms.
+
+### Registry
+
+The canonical catalog of all checks M365-Assess can run, including each check's framework mappings, severity, license requirements, and remediation guidance. Lives at `src/M365-Assess/controls/registry.json` and is synced from upstream CheckID weekly.
+
+### Section
+
+A grouping of related collectors run together — e.g., **Identity**, **Email**, **Security**. The report's home view surfaces sections as the top-level navigation. Configurable via `-Section` on `Invoke-M365Assessment`.
+
+See [`SCOPE.md`](SCOPE.md) for the full section catalog.
+
+### Sequence
+
+The user-facing label for a finding's [Lane](#lane). Renders as a colour-coded pill in the findings table: **Now** (red) / **Next** (amber) / **Later** (blue) / **Done** (green).
+
+### Severity
+
+The risk level of a Fail finding: **Critical / High / Medium / Low / Info**. Set per-check in `risk-severity.json`. Drives the order findings appear in default-sorted views and influences the [Lane](#lane) computation.
+
+### Status
+
+The outcome category of a check: **Pass**, **Fail**, **Warning**, **Review**, **Info**, **Skipped**, **Unknown**, **NotApplicable**, **NotLicensed**.
+
+Pass / Fail / Warning count toward the Pass% denominator; the others don't. See [`UNDERSTANDING-RESULTS.md`](UNDERSTANDING-RESULTS.md) for the user-facing explanation and [`reference/CHECK-STATUS-MODEL.md`](../reference/CHECK-STATUS-MODEL.md) for the implementer detail.
+
+---
+
+## See also
+
+- [`UNDERSTANDING-RESULTS.md`](UNDERSTANDING-RESULTS.md) — what each status means for you
+- [`SCOPE.md`](SCOPE.md) — section catalog and what's in / out of scope
+- [`REPORT-USER-GUIDE.md`](REPORT-USER-GUIDE.md) — using the HTML report
+- [`INDEX.md`](../INDEX.md) — back to the docs index

--- a/docs/user/SCOPE.md
+++ b/docs/user/SCOPE.md
@@ -1,0 +1,72 @@
+# What M365-Assess covers (and what it doesn't)
+
+A one-page answer to "what does this tool actually do?" for procurement reviews, customer briefings, and onboarding.
+
+For the full per-section detail, see [`RUN.md`](RUN.md). For the report features, see [`REPORT-USER-GUIDE.md`](REPORT-USER-GUIDE.md).
+
+---
+
+## In scope (default)
+
+These sections run on every assessment unless explicitly excluded with `-Section`:
+
+| Section | What it covers |
+|---|---|
+| **Tenant** | Organization profile, verified domains, security defaults |
+| **Identity** | Users, MFA, admin roles, Conditional Access, app registrations, password policy, Entra security config |
+| **Licensing** | SKU allocation, assigned vs. consumed seats |
+| **Email** | Mailbox config, mail flow, anti-spam / anti-phishing, modern auth, DNS authentication (SPF / DKIM / DMARC), audit settings |
+| **Intune** | Managed devices, compliance policies, configuration profiles, CMMC L2 controls (encryption, port storage, app control, FIPS, removable media) |
+| **Security** | Microsoft Secure Score, Defender for Office 365, DLP policies, incident readiness (stale admins, CA exclusions, break-glass, device wipe audit) |
+| **Collaboration** | SharePoint / OneDrive sharing, Teams meeting policies, Forms data sharing, third-party app restrictions |
+| **PowerBI** | 11 CIS 9.1.x tenant settings: guest access, external sharing, publish-to-web, sensitivity labels |
+| **Hybrid** | Azure AD Connect / Cloud Sync configuration, drift between on-prem and cloud directory state |
+
+---
+
+## Opt-in (run with `-Section`)
+
+These cost extra time, require additional permissions, or only apply in specific environments:
+
+| Section | When to add it | Notes |
+|---|---|---|
+| **ActiveDirectory** | On-premises AD environment | Requires RSAT or domain-controller access; produces dcdiag, replication, AD Security reports |
+| **SOC2** | SOC 2 Trust Services audit prep | Pulls 30 days of audit-log evidence; produces a readiness checklist for non-automatable criteria |
+| **Inventory** | Snapshot of mailboxes / groups / Teams / SPO / OneDrive | Counts only — useful for sizing, not posture |
+| **ValueOpportunity** | License utilization + feature adoption | Identifies SKUs paid for but not used |
+| **Networking** | Port-connectivity tests to M365 endpoints | Useful when troubleshooting connection failures |
+| **Windows** | Local installed-software inventory | Endpoint-side; assumes you're running against a managed device |
+
+---
+
+## Out of scope
+
+If you need any of the below, M365-Assess is the wrong tool:
+
+| Not covered | Why | What to use instead |
+|---|---|---|
+| **Third-party SaaS** (Salesforce, Workday, ServiceNow, etc.) | M365-Assess connects only to Microsoft 365 APIs | A SaaS posture management (SSPM) platform |
+| **Network controls** (firewalls, IDS / IPS, NAC) | Network surface lives outside M365 | A network security posture tool |
+| **Endpoint detection content** (EDR rules, SIEM detections) | Detection-content tuning is operational, not configuration audit | Microsoft Sentinel / Defender XDR portals |
+| **Custom application configuration** (in-tenant LOB apps) | Custom apps' security posture is org-specific and not standardised | App-specific review |
+| **M365 service health** (incidents, advisories) | M365-Assess audits *your* configuration, not Microsoft's service state | Microsoft 365 admin center → Service health |
+| **Tenant cost optimization** (license audit beyond utilization) | The ValueOpportunity section flags unused features but is not a procurement tool | Microsoft Cost Management |
+| **On-prem Exchange / SharePoint** (non-hybrid) | Tool is cloud-first; only the Hybrid section touches on-prem config | Standalone on-prem tooling |
+| **GDPR / HIPAA / PCI compliance verdict** | M365-Assess maps controls to frameworks but doesn't certify compliance | An accredited auditor signs off; M365-Assess feeds the evidence |
+
+---
+
+## A note on framework coverage
+
+M365-Assess maps each finding to **15 compliance frameworks** (CIS Controls v8, CIS M365 v6, NIST 800-53, NIST CSF, CMMC, ISO 27001, ISO 27002, SOC 2, PCI-DSS, HIPAA, FedRAMP, MITRE ATT&CK, STIG, CISA SCUBA, Essential Eight). This **mapping is informational** — useful for evidence packages and audit prep, not a substitute for an auditor's judgement.
+
+A tenant scoring 95% on CIS M365 has not been "CIS-certified"; it has 95% of the controls M365-Assess maps to CIS verified as Pass. Real certification still requires an accredited assessor.
+
+---
+
+## See also
+
+- [`RUN.md`](RUN.md) — full per-section detail with the cmdlets each one runs
+- [`REPORT-USER-GUIDE.md`](REPORT-USER-GUIDE.md) — what to do with the output
+- [`COMPLIANCE.md`](COMPLIANCE.md) — framework mapping detail
+- [`INDEX.md`](../INDEX.md) — back to the docs index

--- a/docs/user/UNDERSTANDING-RESULTS.md
+++ b/docs/user/UNDERSTANDING-RESULTS.md
@@ -1,0 +1,127 @@
+# Understanding your results
+
+A user-facing answer to "I'm reading this report — what do these statuses mean and what should I do?"
+
+For the implementation rules (when collectors emit each status, denominator math, schema versioning), see [`reference/CHECK-STATUS-MODEL.md`](../reference/CHECK-STATUS-MODEL.md).
+
+---
+
+## The 9 statuses, in priority order
+
+### 🔴 Fail
+
+**The control is not in place. Action required.**
+
+The check observed your tenant data and the configuration is insecure or the recommended setting is missing entirely. Open the finding's detail panel and follow the remediation steps.
+
+Counts toward your Pass% score (drags it down).
+
+### 🟠 Warning
+
+**The control is partially in place. Review whether to harden.**
+
+The check is configured but in a way that's contextually concerning — e.g., MFA is enabled but only for some users, or DLP rules exist but are in audit-only mode. Often the right call is to harden; sometimes it's an intentional design decision worth documenting.
+
+Counts toward your Pass% score (drags it down).
+
+### 🔵 Review
+
+**Manual interpretation needed.**
+
+The check pulled data but a human has to decide whether it's good or bad — e.g., a list of admin accounts where you need to know which ones are intentional vs. legacy. Open the finding, read the **Current value**, and decide based on your tenant's context.
+
+**Doesn't count** toward your Pass% score. The score reflects only checks where M365-Assess can give a clear Pass / Fail / Warning verdict.
+
+### 🟢 Pass
+
+**The control is in place. Nothing to do.**
+
+The check observed your tenant data and the configuration matches the recommended setting.
+
+Counts toward your Pass% score (lifts it up).
+
+### ⚪ Info
+
+**Informational. No action implied.**
+
+A signal worth showing in the report but not a posture verdict — e.g., "this tenant has X licensed users", "P2 features are available". Useful context; not something you fix or ignore.
+
+**Doesn't count** toward your Pass% score.
+
+### ⚫ Skipped
+
+**The check didn't run.**
+
+Three reasons this happens, and the right response depends on which:
+
+| Sub-reason | What it means | Should you worry? |
+|---|---|---|
+| **License-gated** | The control requires a license tier you don't have (e.g., a P2-only feature on a P1 tenant) | No — it's correctly skipped |
+| **Permission-gated** | The assessment didn't have the Graph scope or RBAC role needed | Maybe — re-run with the right permissions if the check matters to you. See [`AUTHENTICATION.md`](AUTHENTICATION.md) |
+| **Environment-not-applicable** | The control doesn't apply to this tenant (e.g., a Hybrid check on a cloud-only tenant) | No |
+
+**Doesn't count** toward your Pass% score.
+
+### 🟡 Unknown
+
+**The assessment tried but couldn't get the data.**
+
+Different from Skipped — this is "the API returned an error or unexpected shape." Check the assessment log (`_Assessment-Log_*.txt`) for the underlying error. Common causes: transient API failure (re-run usually fixes), a Graph endpoint returning new shape (file an issue), or a tenant with non-standard config that confuses the collector.
+
+**Doesn't count** toward your Pass% score.
+
+### ⚪ NotApplicable
+
+**The control isn't relevant to this tenant.**
+
+E.g., an Azure AD B2B check on a tenant that doesn't use B2B. The check is correctly inert; there's nothing to fix.
+
+**Doesn't count** toward your Pass% score.
+
+### ⚫ NotLicensed
+
+**The tenant lacks the license tier this control requires.**
+
+E.g., a Defender for Identity check on a tenant without Defender for Identity. The right response is usually no action — this is just M365-Assess being honest that it can't verify a control you don't pay for. If the control matters to your security posture, the action is "buy the license"; otherwise ignore.
+
+**Doesn't count** toward your Pass% score.
+
+---
+
+## What counts toward the score?
+
+Only **Pass / Fail / Warning** count. Everything else is "we couldn't or shouldn't decide" and is excluded from the denominator.
+
+Practical example: a tenant with 200 checks where 150 Pass, 20 Fail, 10 Warning, 15 Review, and 5 Skipped scores **(150) / (150 + 20 + 10) = 83%**. The 20 unscored checks (Review + Skipped) don't pull the score up or down — they're set aside.
+
+For the math detail and how the report breaks the score across views, see [`SCORING.md`](SCORING.md).
+
+---
+
+## Common questions
+
+**Why did my Secure Score drop after I fixed something?**
+
+You're looking at a different score. The Microsoft Secure Score panel reflects Microsoft's value (delayed up to 24 hours; see the disclaimer in that panel). The Pass% in the M365-Assess KPIs is computed from this assessment's findings and updates immediately when you re-run.
+
+**A finding shows Review — do I have to do something?**
+
+Only if the **Current value** in the finding detail tells you something needs attention. Review means "M365-Assess pulled the data but can't decide for you." Read the value, decide, move on. If it's truly Pass-worthy, leave it. If it's a Fail in disguise, treat it as a Fail and remediate.
+
+**My tenant has lots of Skipped checks — is the assessment broken?**
+
+Probably not. Most Skipped checks are license-gated — your tenant doesn't pay for the feature being checked. Open the assessment log (`_Assessment-Log_*.txt`) and look for "Skipping" entries to see why each section was skipped. If you see permission errors instead of license messages, re-run with the right permissions per [`AUTHENTICATION.md`](AUTHENTICATION.md).
+
+**Why is my score lower than my client's despite our tenants looking similar?**
+
+Pass% denominators differ. Two tenants with identical configurations can score differently if they have different licenses (more licensed features = more checks counted), different sections selected, or different permission scopes (fewer permissions = more Skipped, smaller denominator).
+
+---
+
+## See also
+
+- [`SCORING.md`](SCORING.md) — how the score is computed across the 6 scoring views
+- [`reference/CHECK-STATUS-MODEL.md`](../reference/CHECK-STATUS-MODEL.md) — implementer-oriented status reference (when collectors emit each)
+- [`GLOSSARY.md`](GLOSSARY.md) — terminology used in the report
+- [`REPORT-USER-GUIDE.md`](REPORT-USER-GUIDE.md) — using the HTML report
+- [`INDEX.md`](../INDEX.md) — back to the docs index


### PR DESCRIPTION
## Summary

Three small new docs landing the highest-leverage gaps from the v2.12.0 backlog. All live at \`docs/user/\` and target the milestone's stated goal: \"clear communication to humans about the solution.\"

Closes #920, #921, #922.

## What's in each

| Doc | Lines | Closes | What it does |
|---|---|---|---|
| \`docs/user/SCOPE.md\` | 72 | #922 | One-page \"what does this tool actually do?\" — In-scope / Opt-in / Out-of-scope tables for procurement reviews and customer briefings, plus a framework-coverage caveat (\"95% on CIS M365\" ≠ \"CIS-certified\") |
| \`docs/user/GLOSSARY.md\` | 84 | #920 | Alphabetical glossary: Baseline · Check · CheckId · Collector · Control · Finding · Framework · Lane · Level · Profile · Registry · Section · Sequence · Severity · Status. One short entry per term with a pointer to the canonical doc |
| \`docs/user/UNDERSTANDING-RESULTS.md\` | 127 | #921 | User-facing companion to \`reference/CHECK-STATUS-MODEL.md\`. Walks each of the 9 statuses from a \"what should I do?\" angle. Includes worked Pass% example and a Common Questions section addressing predictable friction (\"why did my Secure Score drop?\", \"why is Review unscored?\", \"lots of Skipped checks\") |

## INDEX.md update

User-doc table reorganized:
- **SCOPE** moves to the top (highest-leverage onboarding doc)
- **GLOSSARY** at the bottom (reference, not sequential-read)
- **UNDERSTANDING-RESULTS** sits between REPORT-USER-GUIDE and SCORING — where readers naturally hit status questions

## Notes

- All three docs cross-link to existing docs (CHECK-STATUS-MODEL, SCORING, REPORT-USER-GUIDE, AUTHENTICATION) but don't duplicate content; each links out for detail.
- No code changes; CI should be quick (Quality Gates + Pester + Cross-Platform Smoke).
- Future content batches will tackle #919 (worked-example walkthrough), #908 (REPORT-USER-GUIDE Phase 2 update), and the structural reorgs (#923 README trim, #924 REPORT consolidation).

## Test plan

- [ ] CI green
- [ ] Spot-check on GitHub: all internal links resolve, tables render
- [ ] Tone reads as user-facing (not implementer-facing) — flag if tone drift in any doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)