### PR TITLE
fix(report): PHS card shows N/A on cloud-only tenants (closes #930)

### DIFF
--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -2029,7 +2029,7 @@ function AdHybridPanel() {
       marginTop: 6,
       lineHeight: 1.3
     }
-  }, fmtDate(ad.lastSyncTime))), /*#__PURE__*/React.createElement("div", {
+  }, fmtDate(ad.lastSyncTime))), syncOk ? /*#__PURE__*/React.createElement("div", {
     className: 'spo-stat-card' + (phsOk === false ? ' spo-stat-bad' : '')
   }, /*#__PURE__*/React.createElement("div", {
     className: "kpi-label"
@@ -2050,7 +2050,20 @@ function AdHybridPanel() {
     style: {
       color: 'var(--warn-text)'
     }
-  }, "No PHS timestamp - verify in Microsoft Entra Connect or Entra Cloud Sync")), ad.syncErrorCount > 0 && /*#__PURE__*/React.createElement("div", {
+  }, "No PHS timestamp - verify in Microsoft Entra Connect or Entra Cloud Sync")) : /*#__PURE__*/React.createElement("div", {
+    className: "spo-stat-card"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "kpi-label"
+  }, "Password hash sync"), /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 13,
+      fontWeight: 700,
+      color: 'var(--muted)',
+      marginTop: 6
+    }
+  }, "N/A"), /*#__PURE__*/React.createElement("div", {
+    className: "kpi-hint"
+  }, "Cloud-only tenant \u2014 no on-prem hashes to sync")), ad.syncErrorCount > 0 && /*#__PURE__*/React.createElement("div", {
     className: "spo-stat-card spo-stat-bad"
   }, /*#__PURE__*/React.createElement("div", {
     className: "kpi-label"

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -1267,12 +1267,24 @@ function AdHybridPanel() {
           <div className="kpi-label">Last sync</div>
           <div style={{fontSize:12, fontWeight:600, color:'var(--text-soft)', marginTop:6, lineHeight:1.3}}>{fmtDate(ad.lastSyncTime)}</div>
         </div>
-        <div className={'spo-stat-card' + (phsOk === false ? ' spo-stat-bad' : '')}>
-          <div className="kpi-label">Password hash sync</div>
-          <div style={{fontSize:13, fontWeight:700, color: phsColor, marginTop:6}}>{phsOk ? 'Enabled' : phsUnknown ? 'Verify' : 'Disabled'}</div>
-          {phsOk === false && <div className="kpi-hint" style={{color:'var(--danger-text)'}}>Leaked credential detection and fallback auth may be impacted</div>}
-          {phsUnknown && <div className="kpi-hint" style={{color:'var(--warn-text)'}}>No PHS timestamp - verify in Microsoft Entra Connect or Entra Cloud Sync</div>}
-        </div>
+        {/* #930: PHS only matters on tenants with hybrid Directory sync.
+            On a cloud-only tenant (syncOk === false), render an N/A card
+            with a muted hint instead of a red Disabled warning — there's
+            no on-prem AD to sync hashes from. */}
+        {syncOk ? (
+          <div className={'spo-stat-card' + (phsOk === false ? ' spo-stat-bad' : '')}>
+            <div className="kpi-label">Password hash sync</div>
+            <div style={{fontSize:13, fontWeight:700, color: phsColor, marginTop:6}}>{phsOk ? 'Enabled' : phsUnknown ? 'Verify' : 'Disabled'}</div>
+            {phsOk === false && <div className="kpi-hint" style={{color:'var(--danger-text)'}}>Leaked credential detection and fallback auth may be impacted</div>}
+            {phsUnknown && <div className="kpi-hint" style={{color:'var(--warn-text)'}}>No PHS timestamp - verify in Microsoft Entra Connect or Entra Cloud Sync</div>}
+          </div>
+        ) : (
+          <div className="spo-stat-card">
+            <div className="kpi-label">Password hash sync</div>
+            <div style={{fontSize:13, fontWeight:700, color:'var(--muted)', marginTop:6}}>N/A</div>
+            <div className="kpi-hint">Cloud-only tenant — no on-prem hashes to sync</div>
+          </div>
+        )}
         {ad.syncErrorCount > 0 && (
           <div className="spo-stat-card spo-stat-bad">
             <div className="kpi-label">Sync errors</div>


### PR DESCRIPTION
## Summary

Fixes the Password hash sync card in the Active Directory · Hybrid Posture panel showing a false-positive **Disabled** status with red warning border on cloud-only tenants.

Closes #930.

## Before

On a cloud-only tenant (Directory sync = Disabled):

| Card | Value | Visual |
|---|---|---|
| Directory sync | Disabled — Cloud-only (no hybrid sync) | muted |
| Last sync | Unknown | muted |
| Password hash sync | **Disabled — *Leaked credential detection and fallback auth may be impacted*** | **red warning border** |

The PHS warning was misleading — there's no on-prem AD on a cloud-only tenant, so PHS is structurally not applicable.

## After

On the same cloud-only tenant:

| Card | Value | Visual |
|---|---|---|
| Directory sync | Disabled — Cloud-only (no hybrid sync) | muted |
| Last sync | Unknown | muted |
| Password hash sync | **N/A — Cloud-only tenant — no on-prem hashes to sync** | muted |

On a hybrid tenant (Directory sync = Enabled), all three PHS states (Enabled / Verify / Disabled) render exactly as before — no change to the actionable hybrid case.

## Why N/A instead of hiding the card

Keeping the third card as N/A maintains panel layout symmetry and explicitly tells the reader "we considered this and it doesn't apply." Hiding entirely would risk reading as "did the tool forget about PHS?"

## Files

- \`src/M365-Assess/assets/report-app.jsx\` — \`AdHybridPanel\` component, \`syncOk\` gate added around the PHS card
- \`src/M365-Assess/assets/report-app.js\` — regenerated via \`npm run build\`

## Test plan

- [ ] CI green
- [ ] Live-test on cloud-only tenant — PHS card no longer shows red warning, reads as N/A with the muted hint
- [ ] Live-test on hybrid tenant with PHS Enabled — card renders Enabled (unchanged)
- [ ] Live-test on hybrid tenant with PHS Disabled — card renders red warning (still actionable)
- [ ] All 4 themes (Neon / Console / Saas / High-Contrast) render the N/A state legibly

🤖 Generated with [Claude Code](https://claude.com/claude-code)