### PR TITLE
docs: backfill ADR-0002 / 0003 / 0004 for load-bearing decisions

### DIFF
--- a/docs/adr/0002-sub-numbered-check-ids.md
+++ b/docs/adr/0002-sub-numbered-check-ids.md
@@ -1,0 +1,63 @@
+# 0002 — Auto sub-number CheckIds at the setting level
+
+- **Status:** Accepted
+- **Date:** 2026-05-06
+
+## Context
+
+CheckID upstream gives one identifier per *check* — a control-level concept (e.g. `CA-REPORTONLY-001` for "Conditional Access policies are not stuck in report-only mode"). But what M365-Assess actually emits to the report is a stream of *settings* — individual evaluations against a single tenant artifact. A single CheckID upstream check often expands to many setting-level findings: the report-only check runs once per CA policy, the PIM eligibility check runs once per privileged role, the SPO sharing check runs once per top-level setting.
+
+We needed each setting-level finding to be:
+
+- Distinguishable in the HTML/XLSX reports (so a user can point at "this exact row").
+- Traceable back to its parent CheckID upstream control (for framework mapping, remediation guidance, registry licensing rules).
+- Stable across runs against the same tenant (so a baseline diff isn't dominated by spurious ID churn).
+
+We also wanted to do this **without forking the upstream registry** — adding 50+ synthetic IDs per check upstream to cover every possible setting permutation would be impossible to maintain and would diverge wildly from CheckID's control-centric model.
+
+## Decision
+
+`Add-SecuritySetting` (in `Common/SecurityConfigHelper.ps1`) auto-suffixes the upstream `CheckId` with a `.N` counter, where `N` increments each time the same base CheckId is recorded within a single assessment run. The counter lives on a `CheckIdCounter` hashtable owned by the collector context.
+
+Example: a single `CA-REPORTONLY-001` upstream check becomes `CA-REPORTONLY-001.1`, `CA-REPORTONLY-001.2`, ... in the emitted report — one sub-numbered row per CA policy evaluated.
+
+The base ID before the dot is what the registry, framework matrix, licensing overlay, and remediation lookups all key on. The full sub-numbered ID is what shows up in the report, the adoption-signals hashtable, and the progress tracker.
+
+See: [`src/M365-Assess/Common/SecurityConfigHelper.ps1`](../../src/M365-Assess/Common/SecurityConfigHelper.ps1) (function `Add-SecuritySetting`).
+
+## Consequences
+
+**Positive**
+
+- One CheckID upstream control can fan out to N setting-level findings without touching the registry.
+- Reports show distinct rows users can click into, while the "Group by CheckId base" view still rolls them up correctly.
+- Registry lookups (frameworks, severity, remediation, licensing) work on the base ID — no duplication needed.
+- Counter state is per-collector-context (not global), so collectors don't cross-contaminate.
+
+**Negative**
+
+- Sub-numbering is **order-dependent** within a run — `CA-REPORTONLY-001.1` is "the first CA policy the collector saw", not a stable property of any specific policy. Two runs against the same tenant can shuffle if the upstream Graph response order changes. Baseline diffing has to key on the underlying object (policy displayName, role definition ID, etc.), not on the sub-numbered CheckId.
+- Test code has to filter by `$_.Setting` (human-readable name) NOT by `$_.CheckId`, since the stored CheckId is the sub-numbered form. This footgun has burned us; CLAUDE.md and `.claude/rules/pester.md` both warn against it.
+- Anyone reading raw CSV output sees `.1`/`.2`/`.3` suffixes that aren't documented in the upstream CheckID schema. The report layer hides this; CSV consumers see it.
+
+**Failure modes and mitigations**
+
+- *Test filters by sub-numbered CheckId* → tests pass on first add, fail when a second is added. Caught by `.claude/rules/pester.md` rule and reinforced in CLAUDE.md.
+- *Adoption-signal lookup uses base ID instead of sub-numbered ID* → returns null silently; mitigated by keying adoption signals on the sub-numbered ID and consumers iterating instead of point-looking-up.
+- *Order shuffle between runs* → handled by baseline diff keying on stable identifiers (object name/ID), not on the sub-numbered CheckId.
+
+## Alternatives considered
+
+- **One row per upstream CheckId, with all settings concatenated into a single Evidence field.** Rejected: makes the report illegible and breaks per-finding remediation, status, and framework mapping.
+- **Mint bespoke local CheckIds for every setting permutation.** Rejected: combinatorial explosion (CIS lists *one* check for "MFA enforced for admins"; in practice we evaluate 6 admin roles × 4 policy types). Local IDs would also drift from upstream and make framework mapping a nightmare.
+- **Push the sub-numbered IDs upstream into CheckID.** Rejected: the upstream model is deliberately control-centric; sub-numbering is an artifact of how we *evaluate* a control, not a property of the control itself. CheckID stays clean if this transformation lives downstream.
+- **Use a separate ID column (e.g. `FindingId`) alongside the unmodified `CheckId`.** Considered. Rejected for now because every existing consumer (report templates, baseline diff, adoption signals, progress tracker) already keys on the suffixed CheckId; a parallel column would double the write paths without removing the old one. Worth revisiting if we ever break the report contract for v3.
+
+---
+
+## See also
+
+- [`../../src/M365-Assess/Common/SecurityConfigHelper.ps1`](../../src/M365-Assess/Common/SecurityConfigHelper.ps1) — `Add-SecuritySetting` (the sub-numbering logic)
+- [`../../.claude/rules/pester.md`](../../.claude/rules/pester.md) — the test-filtering rule this decision implies
+- [`../dev/CheckId-Guide.md`](../dev/CheckId-Guide.md) — naming + numbering conventions
+- [`README.md`](README.md) — back to the ADR index

--- a/docs/adr/0003-dns-section-runs-last-with-prefetch.md
+++ b/docs/adr/0003-dns-section-runs-last-with-prefetch.md
@@ -1,0 +1,64 @@
+# 0003 — DNS section runs last, fed by a connect-time prefetch
+
+- **Status:** Accepted
+- **Date:** 2026-05-06
+
+## Context
+
+DNS Authentication checks (SPF, DKIM, DMARC, MTA-STS, the DNS Security Config collector) need two inputs that don't come from DNS:
+
+1. The list of accepted/verified domains for the tenant — produced by Microsoft Graph (`/organization`) or EXO `Get-AcceptedDomain`.
+2. DKIM signing configurations — produced by EXO `Get-DkimSigningConfig`.
+
+Both come from sections that run earlier in the assessment pipeline. EXO sessions, though, are not reliable across the full assessment lifetime — long-running runs hit token expiry / session timeout, and EXO cmdlets after that point throw cryptic errors. We've been bitten by this multiple times when DNS used to run inline with the Email section: the EXO session that produced `AcceptedDomain` 5 minutes earlier was already gone by the time DNS resolution finished its serial round-trips.
+
+The DNS section is also the slowest section by wall-clock — DNS resolution is network-bound and serialized per-domain. Running it inline with other sections wastes the elapsed time of every section that follows.
+
+## Decision
+
+Defer the entire DNS section to **after all other sections complete**, and feed it from caches populated earlier:
+
+1. **At Graph connect time** (in `Connect-RequiredService.ps1`), if `Email` is in the requested sections, kick off `Start-ThreadJob`-based DNS prefetch for every verified domain in parallel. This runs *concurrently with* the rest of the assessment.
+2. **During the Email section**, snapshot `Get-AcceptedDomain` and `Get-DkimSigningConfig` into `$script:cachedAcceptedDomains` and `$script:cachedDkimConfigs` while the EXO session is known to be valid.
+3. **At the end of the orchestrator**, after all other sections have run, `Invoke-DnsAuthentication` consumes the cached domains, the cached DKIM data, and the now-completed prefetch job results.
+4. **Filter `.onmicrosoft.com` domains at source** before any DNS resolution — Microsoft-managed domains can't have customer-published records by design.
+
+See: [`src/M365-Assess/Orchestrator/Invoke-DnsAuthentication.ps1`](../../src/M365-Assess/Orchestrator/Invoke-DnsAuthentication.ps1) and the prefetch in [`src/M365-Assess/Orchestrator/Connect-RequiredService.ps1`](../../src/M365-Assess/Orchestrator/Connect-RequiredService.ps1) (around the `dnsPrefetchJobs` setup).
+
+## Consequences
+
+**Positive**
+
+- DNS resolution happens concurrently with the slow EXO/SharePoint/Defender sections — no idle wall-clock time.
+- EXO-derived inputs are captured while the session is still alive, then handed to DNS as plain data; the DNS phase never re-touches EXO.
+- `.onmicrosoft.com` filter at source means we don't waste resolution attempts on domains where the result is mathematically impossible.
+- DNS failures are isolated: a network blip during DNS doesn't taint Email/Defender/SPO findings, since those have already completed.
+
+**Negative**
+
+- DNS findings appear at the bottom of the report and get the latest assessment timestamp, which can confuse users into thinking DNS was "checked latest" when in fact the prefetch ran much earlier. The evidence-timestamp field per finding is the source of truth, not section order.
+- The cache is held in `$script:` scope, which couples the DNS phase to the orchestrator's specific module load. If the orchestrator ever moves to a separate runspace per section, this contract breaks.
+- If the user runs `-Section DNS` alone (without Email), there's no cached domain list. The current code falls back to a fresh `Get-AcceptedDomain` call, which means a fresh EXO connection is required for that path.
+- Prefetch runs before the user has explicitly opted into DNS — if `Email` is in the section list, we're querying public DNS for every verified domain regardless of whether the DNS section ultimately runs. Today this is fine (DNS queries to public resolvers are not sensitive), but it's worth flagging if we ever add internal-resolver checks.
+
+**Failure modes and mitigations**
+
+- *EXO session times out before Email section captures domain list* → the cache is empty and `Invoke-DnsAuthentication` re-tries `Get-AcceptedDomain`, logging WARN and skipping if that also fails.
+- *Prefetch jobs fail mid-run (DNS resolver flake)* → individual domain results come back with empty record sets; the per-finding evidence shows "no record found" rather than crashing the section.
+- *Section order changes (e.g. user runs `-Section DNS,Email`)* → defer logic still triggers because it's keyed on `$script:runDnsAuthentication`, not on requested section order.
+
+## Alternatives considered
+
+- **Run DNS inline at the end of the Email section.** Rejected (this is what we used to do): EXO session timeout caused intermittent failures on large tenants where Email finished early but the assessment kept running for another 20 minutes.
+- **Run DNS as the first section, before EXO.** Rejected: no domain list available until Graph or EXO has been queried, so DNS would need its own copy of that lookup logic — duplicating the connect-side code.
+- **Lazy DNS: resolve per-domain only when the report renders.** Rejected: pushes network calls into report generation, which is supposed to be a pure transformation. Also breaks the offline-report-rebuild use case.
+- **Spawn a separate runspace per DNS check, fan-out at end.** Considered, deferred. The current `Start-ThreadJob` prefetch already gives us the parallelism we need; full per-check runspacing adds complexity without a clear win.
+
+---
+
+## See also
+
+- [`../../src/M365-Assess/Orchestrator/Invoke-DnsAuthentication.ps1`](../../src/M365-Assess/Orchestrator/Invoke-DnsAuthentication.ps1) — the deferred DNS phase
+- [`../../src/M365-Assess/Orchestrator/Connect-RequiredService.ps1`](../../src/M365-Assess/Orchestrator/Connect-RequiredService.ps1) — connect-time DNS prefetch via `Start-ThreadJob`
+- [`../../src/M365-Assess/Exchange-Online/Get-DnsSecurityConfig.ps1`](../../src/M365-Assess/Exchange-Online/Get-DnsSecurityConfig.ps1) — DNS Security Config collector that consumes `-AcceptedDomains`
+- [`README.md`](README.md) — back to the ADR index

--- a/docs/adr/0004-licensing-overlay-separate-from-registry.md
+++ b/docs/adr/0004-licensing-overlay-separate-from-registry.md
@@ -1,0 +1,87 @@
+# 0004 — Keep the licensing overlay separate from the upstream registry
+
+- **Status:** Accepted
+- **Date:** 2026-05-06
+
+## Context
+
+CheckID v2.0.0 carries license-tier information at a deliberately coarse granularity: each check declares `licensing.minimum` as `"E3"` or `"E5"` (or omits it entirely). That's the right level of abstraction for CheckID — it's a vendor-agnostic compliance project, and "this check requires E5" is enough for most consumers.
+
+M365-Assess needs more precision than that. To decide whether to *run* a check on a given tenant, we need to know which **exact Microsoft service plan IDs** it depends on:
+
+- "PIM eligibility" requires `AAD_PREMIUM_P2` specifically — Entra ID P2, not just any E5 SKU.
+- "Defender Safe Attachments" requires `ATP_ENTERPRISE` — Defender for Office Plan 2, which can ship with E5 *or* be purchased standalone.
+- "Customer Lockbox" requires `LOCKBOX_ENTERPRISE` — bundled into E5 but not the only path to having it.
+
+A coarse "E5" gate would either:
+- Skip checks on tenants that have the right add-on but no full E5 (false negative — we miss findings the customer wanted).
+- Run checks on tenants with E5 but missing the specific add-on (false positive — checks throw "Forbidden" or return empty data we mis-interpret as `Pass`).
+
+We could fix this by adding `requiredServicePlans` arrays to the upstream registry. We deliberately don't, because:
+
+1. CheckID is a public project with non-Microsoft consumers; pushing M365-specific service plan IDs into upstream entries is a layering violation.
+2. The mapping changes faster than the underlying check — Microsoft renames service plans, splits them, retires them. Decoupling lets us update overlay precision without re-syncing CheckID.
+3. We sync from CheckID **tagged releases** (see [ADR-0001](0001-checkid-sync-vs-fork.md)). A registry edit to add service plan IDs would be either lost on next sync (if applied locally) or require maintaining a fork (which 0001 explicitly rejected).
+
+## Decision
+
+Maintain `controls/licensing-overlay.json` as a separate file, owned by M365-Assess, never touched by the CheckID sync workflow. Its shape:
+
+```json
+{
+  "checks": {
+    "ENTRA-PIM-001": ["AAD_PREMIUM_P2"],
+    "DEFENDER-SAFEATTACH-001": ["ATP_ENTERPRISE"],
+    "...": ["..."]
+  }
+}
+```
+
+Resolution semantics (in `Common/Import-ControlRegistry.ps1`):
+
+1. Load `registry.json` (synced from CheckID).
+2. Load `licensing-overlay.json` (local).
+3. For each check, if the overlay has an entry → use those service plan IDs. Else if the upstream check has v1.x-style `requiredServicePlans` → use that. Else → empty array (runs on all tenants).
+4. The runtime gating logic only consults the merged result; it never sees `licensing.minimum`.
+
+Checks **omitted from the overlay** run on all tenants regardless of license. This is the conservative default: we'd rather emit a finding the user can ignore than silently skip a check.
+
+See: [`src/M365-Assess/controls/licensing-overlay.json`](../../src/M365-Assess/controls/licensing-overlay.json) and the merge logic in [`src/M365-Assess/Common/Import-ControlRegistry.ps1`](../../src/M365-Assess/Common/Import-ControlRegistry.ps1).
+
+## Consequences
+
+**Positive**
+
+- CheckID sync is one-directional and doesn't trample license data. Sync PRs are diff-readable because they only ever change upstream-owned files.
+- We can refine service plan IDs (add a new SKU mapping, fix a wrong plan ID) with a single-file PR, no CheckID release dependency.
+- `NotLicensed` status is meaningful: it's keyed on a specific service plan we know we depend on, not on a coarse tier guess.
+- New checks default to "runs everywhere" rather than "skipped because no overlay entry" — fail-open posture matches the conservative-assessment goal.
+
+**Negative**
+
+- Two files to maintain instead of one. When CheckID adds a new E5 check, someone has to remember to add the overlay entry — there's no schema-level enforcement that "every E5-tier upstream check has an overlay row".
+- The split makes it harder for a contributor reading `registry.json` to understand "what does this check actually need?" — they have to cross-reference the overlay file.
+- Service plan IDs are not human-readable (`AAD_PREMIUM_P2`, `ATP_ENTERPRISE` etc.). Without a comment column in the JSON, the overlay file is opaque to non-Microsoft-internal readers.
+- We lose CheckID's `licensing.minimum` signal entirely in the runtime path — if a future check arrives upstream with `minimum: "E5"` but no overlay row, we'll happily run it against an E1 tenant, which may produce noise.
+
+**Failure modes and mitigations**
+
+- *Upstream adds a new E5 check; we forget the overlay row* → check runs on E1 tenants, returns "Forbidden" or empty data, lands as `Fail`/`Unknown`. Mitigation: a sync-PR review step where a human eyeballs new check IDs against the overlay (currently manual; could be automated by diffing `registry.json` for new IDs and warning if they have `minimum: "E5"` and no overlay entry).
+- *Service plan ID renamed by Microsoft* → overlay entry stops matching tenant licenses, check runs on tenants that shouldn't run it (or skips on tenants that should). Mitigation: covered by integration test fixtures in `tests/Common/Test-ServicePlanResolution`, plus the sku-feature-map sync from CheckID.
+- *Overlay file gets deleted or fails to parse* → `Import-ControlRegistry` falls through to upstream `requiredServicePlans` (which v2.0.0 doesn't have) → empty array → all checks run on all tenants. Loud failure: noisy output, easy to spot in QA.
+
+## Alternatives considered
+
+- **Push service plan IDs upstream into CheckID.** Rejected: layering violation. CheckID's audience is wider than M365-Assess and shouldn't carry vendor SKU metadata.
+- **Patch `registry.json` post-sync to splice service plan IDs in.** Rejected: makes diffs noisy on every sync, and any merge conflict reverts the overlay silently. The whole point of [ADR-0001](0001-checkid-sync-vs-fork.md) is that `registry.json` is upstream-owned and immutable downstream.
+- **Embed service plan IDs in `local-extensions.json`.** Rejected: that file is for *new* checks not yet upstream, not for *additional metadata on existing upstream checks*. Mixing the two roles makes the file's contract incoherent.
+- **Use the coarse `licensing.minimum` directly and accept the false-positive/false-negative tradeoff.** Rejected: the false-positive case (running an E5-only check against E3) was the most-frequent v2.6 user complaint. Fixing it was the motivating force behind the overlay.
+
+---
+
+## See also
+
+- [`../../src/M365-Assess/controls/licensing-overlay.json`](../../src/M365-Assess/controls/licensing-overlay.json) — the file this ADR is about
+- [`../../src/M365-Assess/Common/Import-ControlRegistry.ps1`](../../src/M365-Assess/Common/Import-ControlRegistry.ps1) — overlay merge at registry-load time
+- [`0001-checkid-sync-vs-fork.md`](0001-checkid-sync-vs-fork.md) — why we don't patch `registry.json` directly
+- [`README.md`](README.md) — back to the ADR index

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,6 +30,9 @@ When a later ADR overrides an earlier one, set the old one's status to `Supersed
 | # | Title | Status | Date |
 |---|---|---|---|
 | [0001](0001-checkid-sync-vs-fork.md) | Consume CheckID via tagged-release sync, not a fork | Accepted | 2026-05-06 |
+| [0002](0002-sub-numbered-check-ids.md) | Auto sub-number CheckIds at the setting level | Accepted | 2026-05-06 |
+| [0003](0003-dns-section-runs-last-with-prefetch.md) | DNS section runs last, fed by a connect-time prefetch | Accepted | 2026-05-06 |
+| [0004](0004-licensing-overlay-separate-from-registry.md) | Keep the licensing overlay separate from the upstream registry | Accepted | 2026-05-06 |
 
 ---
 


### PR DESCRIPTION
## Summary

Three more ADRs covering decisions that today live only in CLAUDE.md, code comments, or tribal knowledge:

- **0002 — CheckId sub-numbering** at the setting level. Why `Add-SecuritySetting` auto-suffixes `.N`, what fans out, and the test-filter footgun this implies.
- **0003 — DNS section runs last, fed by a connect-time prefetch**. Why we defer DNS, where the cache comes from, and the EXO-session-timeout story that drove the decision.
- **0004 — licensing-overlay.json separate from the upstream registry**. Why we don't patch `registry.json` to add service plan IDs, and how the overlay merges at registry-load time.

Each ADR follows the 5-field template from #933: Context / Decision / Consequences / Alternatives, with code path links so a reader can verify the claim against the current source.

Index in `docs/adr/README.md` updated to list all four ADRs.

## Test plan

- [x] N/A — docs only, no code paths touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)