### PR TITLE
docs: backfill ADR-0005 / 0006 / 0007 — status, evidence, skip semantics

### DIFF
--- a/docs/adr/0005-nine-status-taxonomy.md
+++ b/docs/adr/0005-nine-status-taxonomy.md
@@ -1,0 +1,73 @@
+# 0005 — 9-value status taxonomy instead of binary Pass/Fail
+
+- **Status:** Accepted
+- **Date:** 2026-05-06
+
+## Context
+
+A security assessment tool's most-load-bearing primitive is the **status** it puts on each finding. It drives the headline score, the report colour scheme, the framework-mapping math, the baseline-diff rules, the XLSX colouring, and what shows up in the executive summary. Once that primitive's value-set is fixed, every consumer in the pipeline depends on it.
+
+The naïve choice is `Pass`/`Fail`. It's also wrong for this domain — security assessments hit several states that are categorically not Pass and not Fail:
+
+- *We couldn't collect the data* (permission denied, throttled, transient API failure). Reporting `Fail` here lies — we don't know.
+- *The user opted this out* (`-Section Identity` excludes Defender; running Defender's checks would be wrong).
+- *The tenant doesn't license the feature being checked* (E5-only check on an E3 tenant). Reporting `Fail` blames the customer for not paying for a SKU they may not need.
+- *The data is collected but the answer is judgmental* (privileged role list — listing is mechanical, deciding "is this assignment appropriate?" is human).
+- *The check is informational* (count of admin role assignments — context, not a posture claim).
+- *The configuration is fine but contextually concerning* (Security Defaults instead of Conditional Access — works, but blocks finer controls).
+
+For a tool consultants use to brief boards on tenant posture, **false confidence is worse than missing data**. The taxonomy needed to be wide enough that collectors don't have to lie when reality is more nuanced.
+
+## Decision
+
+`Add-SecuritySetting`'s `[ValidateSet]` (in `Common/SecurityConfigHelper.ps1`) accepts exactly nine values:
+
+```
+Pass, Fail, Warning, Review, Info, Skipped, Unknown, NotApplicable, NotLicensed
+```
+
+Each value has a defined meaning, a fixed colour in the report, and a fixed role in the score math. Three statuses (`Pass`, `Fail`, `Warning`) participate in the Pass% denominator; the other six (`Review`, `Info`, `Skipped`, `Unknown`, `NotApplicable`, `NotLicensed`) are excluded from both numerator and denominator so a tenant doesn't get punished for missing license tiers or permission gaps.
+
+The full meaning, decision tree, and per-status colour mapping live in [`docs/reference/CHECK-STATUS-MODEL.md`](../reference/CHECK-STATUS-MODEL.md), which is the source-of-truth doc. This ADR captures *why* the set is nine values (not four, not twelve), not the per-status semantics.
+
+The taxonomy is versioned (current schema version `1.0`, declared at the top of CHECK-STATUS-MODEL.md). Bumping requires updating the `ValidateSet`, every rendering surface (HTML, XLSX, executive summary, framework totals), and the `schemaVersion` field in `window.REPORT_DATA`.
+
+## Consequences
+
+**Positive**
+
+- Collectors don't have to lie: a 403 from Graph emits `Unknown`, not `Fail`, so the score isn't poisoned by permission gaps.
+- The Pass% denominator is honest — `Pass / (Pass + Fail + Warning)`. A tenant with 30% `Unknown` checks isn't dragged below a tenant with full permissions and 30% `Fail`s.
+- `NotLicensed` enables a license-adjusted scoring view (D2 #786) without re-engineering the score path.
+- Each status has a defined report colour, so users learn the visual language fast.
+- `Skipped` (user-driven absence) and `Unknown` (tool-driven absence) are differentiated, which is critical for "why is this section blank?" diagnosis.
+
+**Negative**
+
+- Nine values is a lot of cognitive load for collectors. New contributors reach for `Fail` when they should be using `Unknown` or `Review`. CHECK-STATUS-MODEL.md has a decision tree to mitigate, but it's still drift-prone.
+- Every rendering surface must handle every status, or the inconsistent paths become bugs. Issue B8 #779 audits each surface; without that audit, statuses get rendered as raw strings or fall back to a default colour.
+- `Warning` and `Review` are the most-confused pair. The line — "concerning but verified" vs "data is good but human judgment needed" — is real but easy to blur. Collector authors trip on this.
+- Schema bumps are expensive: `ValidateSet` + doc + 4-5 rendering surfaces + `window.REPORT_DATA.schemaVersion`. We accept that cost because the alternative (silent semantic drift) is worse.
+
+**Failure modes and mitigations**
+
+- *Collector emits `Fail` for a permission-denied case* → score is wrong; downstream remediation guidance points the user at a non-existent setting. Mitigation: code review + `.claude/rules/powershell.md` reminder; we've considered a runtime check that emits a WARN log when `Fail` is recorded with no `EvidenceSource`, but haven't shipped it.
+- *Rendering surface forgets to handle a status* → status renders as raw string or grey. Mitigation: B8 #779 audit; React report has a fallback colour rather than crashing.
+- *Status added without bumping the schema version* → downstream React/M365-Remediate consumers break silently. Mitigation: the bump-checklist in CHECK-STATUS-MODEL.md (5 steps); enforced by code review, not lint.
+
+## Alternatives considered
+
+- **Binary Pass/Fail.** Rejected: see Context — produces false confidence on uncollected data, false failures on unlicensed checks. Tested briefly in v0.x prototypes; abandoned within weeks.
+- **Pass / Fail / Warning / Skipped (4 values).** Rejected: collapses `Unknown` into either `Fail` (poisoning the score) or `Skipped` (which means user-driven absence and confuses the WARN-level "you may need more permissions" guidance). Also can't represent `NotLicensed` honestly without a separate field.
+- **Severity-based scale (Low/Medium/High/Critical).** Rejected: severity is an orthogonal dimension to status — a `Fail` is a Fail regardless of severity, and an `Unknown` doesn't have a severity. We carry severity separately in `risk-severity.json`, keyed on CheckId.
+- **Free-form string status.** Rejected: every consumer would have to handle the long tail. The `ValidateSet` is the contract; the contract is the value.
+- **More-than-9 values (e.g. separate `Throttled` and `PermissionDenied` for what is currently `Unknown`).** Rejected: reaching for resolution we don't actually use. The `Limitations` evidence field carries the sub-cause; `Unknown` is enough resolution at the status level.
+
+---
+
+## See also
+
+- [`../reference/CHECK-STATUS-MODEL.md`](../reference/CHECK-STATUS-MODEL.md) — the per-status semantics, decision tree, and denominator rules
+- [`../../src/M365-Assess/Common/SecurityConfigHelper.ps1`](../../src/M365-Assess/Common/SecurityConfigHelper.ps1) — `Add-SecuritySetting` `ValidateSet` (the contract)
+- [`0006-optional-structured-evidence-fields.md`](0006-optional-structured-evidence-fields.md) — sibling decision on how findings carry their provenance
+- [`README.md`](README.md) — back to the ADR index

--- a/docs/adr/0006-optional-structured-evidence-fields.md
+++ b/docs/adr/0006-optional-structured-evidence-fields.md
@@ -1,0 +1,92 @@
+# 0006 — Extend the finding contract with optional structured evidence fields
+
+- **Status:** Accepted
+- **Date:** 2026-05-06
+
+## Context
+
+Every finding M365-Assess emits answers two questions implicitly:
+
+- *What was checked?* (`Setting` + `CheckId`)
+- *What was found?* (`Status` + `CurrentValue`)
+
+For a long time, that was the whole contract. The single `Evidence` parameter on `Add-SecuritySetting` was a free-form `PSCustomObject` — anything could go in, JSON-serialised at the report-render boundary. That worked for collectors but broke down for the audience the tool is actually serving:
+
+- **Auditors** asked "how do you know?" and got a nameless object with whatever fields the collector author happened to choose.
+- **Consultants** preparing remediation evidence couldn't filter findings by "show me everything that came from `Get-AdminAuditLogConfig`" because the source was buried inside an unstructured blob.
+- **Future M365-Assess versions** wanting to surface confidence, permission paths, or collection methods had no contract to extend — only a free-form bag.
+
+The conservative move was to add new typed fields. The hard part was *how* to add them without:
+
+1. Forcing a sweeping rewrite of every existing collector to populate the new fields.
+2. Breaking the existing `Evidence` parameter that some collectors had organically built rich blobs around.
+3. Making the report ugly for findings that didn't (yet) carry the new fields.
+
+## Decision
+
+Issue D1 #785 added eight optional, typed fields to `Add-SecuritySetting`:
+
+| Field | Purpose |
+|---|---|
+| `ObservedValue` | Machine-readable raw value from the tenant |
+| `ExpectedValue` | Machine-readable benchmark value |
+| `EvidenceSource` | Graph endpoint / EXO cmdlet / DNS query that produced the data |
+| `EvidenceTimestamp` | UTC ISO-8601 collection time (only when the upstream API gives a real one) |
+| `CollectionMethod` | `Direct` / `Derived` / `Inferred` / `''` |
+| `PermissionRequired` | The Graph scope or RBAC role the data depended on |
+| `Confidence` | `0.0`-`1.0` (nullable) — distinguishes "definitely Pass" from "best-effort given missing scopes" |
+| `Limitations` | Free-text caveat (the sub-cause for `Unknown`, the explanation for non-1.0 `Confidence`) |
+
+All eight are **optional**. The free-form `Evidence` parameter is preserved for backward compatibility. New collectors should prefer the typed fields; old collectors keep working unchanged.
+
+The pipeline is "drop empty at every stage":
+
+- Empty fields produce empty CSV cells.
+- `Build-ReportData` emits an `evidence` object on each finding only when at least one field is populated; if every field is empty, `evidence` is `null` (not an empty object).
+- The XLSX "Evidence Details" sheet only includes rows where at least one field is populated.
+- The React Appendix `EvidenceBlock` only renders a row per non-empty field.
+
+This means a collector that hasn't migrated produces no visible evidence section in the report rather than a section full of empty rows.
+
+See: [`docs/dev/EVIDENCE-MODEL.md`](../dev/EVIDENCE-MODEL.md) (the migration cookbook), [`src/M365-Assess/Common/SecurityConfigHelper.ps1`](../../src/M365-Assess/Common/SecurityConfigHelper.ps1) (the contract).
+
+## Consequences
+
+**Positive**
+
+- Auditors can answer "how do you know?" with structured per-field rows instead of a JSON dump.
+- Findings filterable by `EvidenceSource` (which API produced this?) and `PermissionRequired` (was the scope I had enough?).
+- `Confidence` lets the tool say "I'm 60% sure" out loud, instead of false-confident `Pass`. Pairs with `Unknown` from [ADR-0005](0005-nine-status-taxonomy.md): some checks land at `Pass` with low confidence rather than `Unknown`, which is more accurate when the data is partially there.
+- Migration is incremental. Each collector that adopts the new fields adds value immediately; we don't have to convert all 250+ checks before any of them improve.
+- The "drop empty" rule means the report doesn't pay a UX cost for half-migrated state.
+
+**Negative**
+
+- Two evidence paths exist now: free-form `Evidence` and typed fields. Code reviewers must catch collectors that mix them inconsistently. The doc says "prefer typed fields for new code", but enforcement is by review, not lint.
+- The optional nature means evidence quality is collector-by-collector. A consultant comparing two findings can find one with full provenance and one with none. Until coverage is uniform, the absence of fields doesn't mean the data wasn't gathered — it might just mean the collector hasn't migrated.
+- `EvidenceTimestamp` is the most-misused field. The doc explicitly says "don't synthesize `Get-Date` at the helper" because it would drift for late-stage `Add-Setting` calls; collector authors keep being tempted to fill it in anyway.
+- `Confidence` numbers without calibration are theatre. The `feedback_no_fake_statistical_credibility` rule applies: `0.6` should mean "I had partial data and inferred from it", not "I felt 60% sure". Without explicit examples in the doc, this drifts.
+
+**Failure modes and mitigations**
+
+- *Collector populates `EvidenceTimestamp` with `Get-Date` at write-time, not collection-time* → audit trails become useless because every finding shares a timestamp. Mitigation: doc warning + code review.
+- *Collector mixes free-form `Evidence` with typed fields and the report renders both* → noise. Mitigation: report layer renders typed fields when present, free-form `Evidence` only as a fallback.
+- *Confidence is set without a corresponding `Limitations` explaining why it's < 1.0* → unverifiable claim. Mitigation: doc says "populate `Limitations` whenever Confidence < 1.0"; review-enforced.
+- *D1 schema bumps required by adding a new field* → must update `EVIDENCE-MODEL.md`, the helper, the CSV column list, `Build-ReportData`, the React `EvidenceBlock`, and the XLSX sheet. Five-step bump checklist; same shape as the [ADR-0005](0005-nine-status-taxonomy.md) status-schema bump.
+
+## Alternatives considered
+
+- **Mandatory new fields.** Rejected: would force 250+ collector audit before any improvement shipped. Migration risk too high; we'd never ship D1.
+- **Replace the free-form `Evidence` parameter outright.** Rejected: collectors had built useful per-section blobs (CA policy condition trees, DKIM record dumps) that don't fit the typed fields. Removing it would lose information.
+- **Sidecar evidence file (separate JSON keyed by CheckId).** Rejected: doubles the I/O paths, breaks the single-CSV-per-collector contract that the rest of the orchestrator depends on, makes baseline diff harder.
+- **Embed evidence as nested objects inside the existing `Evidence` blob with a known schema.** Rejected: still unstructured at the type level — no `[ValidateSet]` for `CollectionMethod`, no `[double]` range check for `Confidence`. The flat-typed-fields approach gives PowerShell's parameter validation for free.
+- **Use one big "Provenance" hashtable parameter.** Considered. Rejected because hashtable parameters lose tab-completion and parameter validation in PowerShell. The eight separate parameters are uglier to type but catch errors at parse time.
+
+---
+
+## See also
+
+- [`../dev/EVIDENCE-MODEL.md`](../dev/EVIDENCE-MODEL.md) — full schema, flow, migration cookbook
+- [`../../src/M365-Assess/Common/SecurityConfigHelper.ps1`](../../src/M365-Assess/Common/SecurityConfigHelper.ps1) — `Add-SecuritySetting` (the contract)
+- [`0005-nine-status-taxonomy.md`](0005-nine-status-taxonomy.md) — status taxonomy this evidence model complements
+- [`README.md`](README.md) — back to the ADR index

--- a/docs/adr/0007-skip-collector-on-unavailable-service.md
+++ b/docs/adr/0007-skip-collector-on-unavailable-service.md
@@ -1,0 +1,89 @@
+# 0007 — Skip individual collectors when their services are unavailable; never abort the run
+
+- **Status:** Accepted
+- **Date:** 2026-05-06
+
+## Context
+
+M365-Assess depends on six-plus separate Microsoft service connections: Microsoft Graph (multiple submodules), Exchange Online, SharePoint Online, Microsoft Teams, Microsoft Defender, Purview. Each is a separate OAuth flow, a separate session lifetime, a separate set of throttling rules, and a separate failure mode.
+
+A real-world assessment can start successfully, get most of the way through, and then hit a partial-failure state:
+
+- The user authenticated with permissions enough for Identity but not Defender.
+- An EXO connection that was healthy at start-of-run timed out 30 minutes in.
+- Network blip during the SharePoint connect step left SPO unreachable while everything else is fine.
+- The tenant's Defender for Office isn't licensed, so the connect itself succeeds but every check returns 403.
+
+The naïve responses both fail the user:
+
+- **Abort the entire run on first failure.** Punishes a 90%-successful assessment because of one section. Consultants lose 25 minutes of accumulated data because Purview happened to be down.
+- **Plough on regardless.** Section after section logs cryptic exceptions, the report renders with mystery blanks, and the user has no idea which findings are real vs. ghosts.
+
+We needed a middle path: keep going wherever we can, but be **loud about what we skipped and why**.
+
+## Decision
+
+The orchestrator (`Invoke-M365Assessment.ps1`) maintains a `$failedServices` set populated by `Connect-RequiredService` whenever a service connection fails. Then, at two granularities:
+
+**Section-level skip** — if **all** of a section's required services are in `$failedServices`, the entire section is skipped:
+
+- Each collector in that section emits a `Skipped` row to the summary with `Error = "<services> not connected"`.
+- Each is logged at WARN level: `Skipped: <Collector> — <services> not connected`.
+- The DNS deferred phase is also skipped if the Email section's services failed (since DNS depends on Email's domain prefetch — see [ADR-0003](0003-dns-section-runs-last-with-prefetch.md)).
+- The orchestrator `continue`s to the next section.
+
+**Collector-level skip (just-in-time)** — if a collector declares `RequiredServices` (per-collector hashtable key) and any of those are in `$failedServices`:
+
+- Just that collector emits a `Skipped` row + WARN log.
+- Sibling collectors in the same section keep running.
+- This handles the mixed case where, say, an Identity collector needs only Graph and another needs Graph + EXO.
+
+Both paths produce structured `Skipped` summary rows that flow into:
+
+- The orchestrator's run summary table (visible at console).
+- The `_PermissionDeficits.json` artifact ([`Test-GraphPermissions.ps1`](../../src/M365-Assess/Orchestrator/Test-GraphPermissions.ps1)) that the HTML report's Permissions panel and the evidence package consume.
+- The HTML report's Permissions panel, where each missing scope is mapped back to the section(s) it would have unlocked.
+
+See: [`src/M365-Assess/Invoke-M365Assessment.ps1`](../../src/M365-Assess/Invoke-M365Assessment.ps1) (around the `allSectionServicesFailed` and per-collector `RequiredServices` blocks) and [`Connect-RequiredService.ps1`](../../src/M365-Assess/Orchestrator/Connect-RequiredService.ps1).
+
+## Consequences
+
+**Positive**
+
+- Partial-permission tenants get a partial-but-honest report instead of either a crash or a misleading "Pass" against unverified data.
+- The `Skipped` status (see [ADR-0005](0005-nine-status-taxonomy.md)) is a first-class output, not an exception. It's excluded from the Pass% denominator, so a 403-heavy run doesn't poison the score.
+- The Permissions panel + `_PermissionDeficits.json` give the user a clear "you'd unlock these checks if you granted scope X" remediation path.
+- The orchestrator never aborts. A 30-minute run produces *something* even if half the services failed — useful for triage.
+- `Skipped` (services unavailable) is differentiated from `Skipped` (user opted out via `-Section`) by the WARN-level log + summary row. Same status value, different evidence.
+
+**Negative**
+
+- Reports from partial runs *look* like full runs to a casual viewer. A consultant skimming the HTML can miss the "30% of sections were Skipped" reality unless they read the Permissions panel. We've added warnings to the executive summary for this reason, but it's still possible to misread the headline.
+- The Pass% denominator excludes `Skipped`, which is right (don't punish for missing data) but creates a perverse incentive: a tenant with poor permissions sees a high Pass% because only the easy checks ran. The CHECK-STATUS-MODEL.md doc and the report's per-section coverage indicators address this, but it's a real gotcha.
+- Per-collector `RequiredServices` is opt-in metadata. Collectors that don't declare it inherit section-level skip behaviour, which can be too coarse: an Identity collector that only needs Graph won't skip when only EXO failed, but if some sibling Identity collectors also need EXO, the orchestrator currently runs the section anyway and the EXO-needing collectors fail individually.
+- Mixed sections (some collectors with `RequiredServices`, some without) trigger an explicit "connect section-level services upfront so un-annotated collectors are never dispatched without a connection" path. Adds branch complexity to the orchestrator.
+
+**Failure modes and mitigations**
+
+- *Service connect appears to succeed but the actual data calls 403* → connect-time check passes, individual collector calls fail. Each collector catches and emits `Unknown` per-finding (not `Skipped`), so the report still distinguishes "could not connect at all" from "connected but no data". `Test-GraphPermissions` runs the per-section scope deficit warning before any collector executes, so most of these are surfaced at start-of-run.
+- *`$failedServices` is mutated mid-section by a per-collector connect attempt* → subsequent collectors in the same section observe the new failure and skip. Behaviour is correct but order-dependent; collectors are dispatched in registry order.
+- *Network flake: service fails on first attempt, would have worked on retry* → currently we don't retry. Connect failures are sticky for the run. Considered worth adding bounded retry to `Connect-RequiredService`, but no concrete issue yet.
+
+## Alternatives considered
+
+- **Abort the assessment on first connect failure.** Rejected: see Context — fail-fast is hostile to partial-permission tenants and wastes accumulated data.
+- **Continue silently; let collectors throw exceptions per-call.** Rejected: report quality collapses (the "mystery blanks" problem). Also makes baseline diff useless because each run has a different shape of "checks present".
+- **Mark all checks in the failed section as `Unknown` instead of `Skipped`.** Considered. Rejected because `Unknown` implies "we tried to collect and the attempt failed at the data layer", whereas `Skipped` means "we didn't attempt this collector at all". The distinction matters for re-run guidance: `Unknown` says "fix permissions and rerun"; `Skipped` says "the connect itself failed, fix that first".
+- **Auto-retry the failed connection N times before giving up.** Deferred. Worth doing for transient flakes but adds complexity (per-service retry policies, session-token refresh, throttling-aware backoff). Not blocking the current decision.
+- **Per-check `RequiredServices` (finer-grained than per-collector).** Rejected. Per-collector is the right abstraction — a collector that needs Graph + EXO needs both for *every* check it emits; splitting per-check would be over-engineered.
+
+---
+
+## See also
+
+- [`../../src/M365-Assess/Invoke-M365Assessment.ps1`](../../src/M365-Assess/Invoke-M365Assessment.ps1) — section + collector skip logic
+- [`../../src/M365-Assess/Orchestrator/Connect-RequiredService.ps1`](../../src/M365-Assess/Orchestrator/Connect-RequiredService.ps1) — populates `$failedServices`
+- [`../../src/M365-Assess/Orchestrator/Test-GraphPermissions.ps1`](../../src/M365-Assess/Orchestrator/Test-GraphPermissions.ps1) — pre-flight scope deficit warnings + `_PermissionDeficits.json`
+- [`0003-dns-section-runs-last-with-prefetch.md`](0003-dns-section-runs-last-with-prefetch.md) — DNS-deferred logic that interacts with section skip
+- [`0005-nine-status-taxonomy.md`](0005-nine-status-taxonomy.md) — `Skipped` vs `Unknown` semantics that this decision relies on
+- [`README.md`](README.md) — back to the ADR index

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -33,6 +33,9 @@ When a later ADR overrides an earlier one, set the old one's status to `Supersed
 | [0002](0002-sub-numbered-check-ids.md) | Auto sub-number CheckIds at the setting level | Accepted | 2026-05-06 |
 | [0003](0003-dns-section-runs-last-with-prefetch.md) | DNS section runs last, fed by a connect-time prefetch | Accepted | 2026-05-06 |
 | [0004](0004-licensing-overlay-separate-from-registry.md) | Keep the licensing overlay separate from the upstream registry | Accepted | 2026-05-06 |
+| [0005](0005-nine-status-taxonomy.md) | 9-value status taxonomy instead of binary Pass/Fail | Accepted | 2026-05-06 |
+| [0006](0006-optional-structured-evidence-fields.md) | Extend the finding contract with optional structured evidence fields | Accepted | 2026-05-06 |
+| [0007](0007-skip-collector-on-unavailable-service.md) | Skip individual collectors when their services are unavailable; never abort the run | Accepted | 2026-05-06 |
 
 ---
 


### PR DESCRIPTION
## Summary

Third batch of ADRs, covering decisions on the finding contract itself:

- **0005 — 9-value status taxonomy** instead of binary Pass/Fail. Why we have 9 statuses (`Pass`/`Fail`/`Warning`/`Review`/`Info`/`Skipped`/`Unknown`/`NotApplicable`/`NotLicensed`), what each enables, and what's excluded from the Pass% denominator.
- **0006 — Optional structured evidence fields**. Why D1 #785 added 8 typed optional fields rather than replacing the free-form `Evidence` parameter, and the "drop empty at every stage" rendering rule.
- **0007 — Skip on unavailable service, never abort**. Why the orchestrator emits `Skipped` rows + WARN logs at section and collector granularity rather than aborting on connect failure.

Each grounded in code (`SecurityConfigHelper.ps1` ValidateSet, `Invoke-M365Assessment.ps1` skip blocks, `EVIDENCE-MODEL.md`) and cross-linked to sibling ADRs where decisions interact (DNS-defer ↔ Email skip, status taxonomy ↔ evidence schema, skip ↔ status `Skipped` vs `Unknown`).

> **Stacked on #934.** Until that merges, this PR's diff includes ADR-0002/0003/0004 too. Once #934 lands I'll rebase to clean it up.

## Test plan

- [x] N/A — docs only, no code paths touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)