### PR TITLE
docs: backfill ADR-0008 / 0009 / 0010 — report packaging, release gate, baseline diff

### DIFF
--- a/docs/adr/0008-self-contained-html-report.md
+++ b/docs/adr/0008-self-contained-html-report.md
@@ -1,0 +1,78 @@
+# 0008 — HTML report is a single self-contained file with no external runtime dependencies
+
+- **Status:** Accepted
+- **Date:** 2026-05-06
+
+## Context
+
+The HTML report is the artifact most M365-Assess users actually look at. Consultants email it to clients, auditors archive it as evidence, customers attach it to ticket trails. The audience matters because it dictates the runtime environment we cannot control:
+
+- **Air-gapped tenants.** Government / classified / regulated environments that physically cannot reach a CDN.
+- **Stale archives.** A report opened in 2030 that referenced `cdn.example.com/react@18` would fail to render the moment the CDN URL changed, was repurposed, or stopped serving the right version.
+- **Email attachments.** Outlook strips link previews, blocks external image fetches by default, and corporate proxies often block CDN traffic outright.
+- **USB / file-share handoffs.** Field engineers run the assessment from a laptop, copy the report to a USB stick, walk it to a customer site, and open it on a machine that has never seen the internet.
+
+Any external runtime dependency (CDN-hosted React, Google Fonts, telemetry beacons, sidecar JSON files) breaks at least one of those paths. We also wanted the report to be *one file* — not a folder of HTML + JS + CSS + JSON the user has to keep together. Folders get unzipped wrong, get individual files lost, and lose all relative-path resolution when emailed.
+
+This is uncommon for "modern" web reports. The default React/Vite pipeline ships a `dist/` folder with hashed asset filenames and an `index.html` that references them. That output is excellent for a hosted SPA and useless as a portable artifact.
+
+## Decision
+
+The report is a single HTML file with **everything inlined**:
+
+- `react.production.min.js` — bundled into a `<script>` tag
+- `react-dom.production.min.js` — bundled into a `<script>` tag
+- `report-app.js` (Babel-compiled from `report-app.jsx`) — bundled into a `<script>` tag
+- `report-themes.css` and `report-shell.css` — bundled into `<style>` tags
+- The findings + framework + section + permissions data — emitted as `window.REPORT_DATA = { ... }` in a `<script>` block
+- An anti-FOUC bootstrap script that reads `localStorage` for theme/mode/density preferences synchronously before first paint
+
+`Get-ReportTemplate.ps1` is the assembler. It reads each asset file from `assets/` and `Append`s into a `[StringBuilder]::new(2097152)` (2 MB initial capacity, since reports routinely cross 1.5 MB). Asset content is read with `Get-Content -Raw` and never PowerShell-interpolated — only `.NET` string append — so `$` and backtick characters in the JS pass through unmolested. All `</script>` and `</style>` substrings inside the inlined JS/CSS are pre-escaped to `<\/script>` / `<\/style>` so they don't terminate the surrounding tag.
+
+The build pipeline is two-stage: Babel transpiles `report-app.jsx` → `report-app.js` once at build time (committed to repo), then `Get-ReportTemplate` does the inlining at run time per assessment.
+
+See: [`src/M365-Assess/Common/Get-ReportTemplate.ps1`](../../src/M365-Assess/Common/Get-ReportTemplate.ps1) and [`src/M365-Assess/Common/Export-AssessmentReport.ps1`](../../src/M365-Assess/Common/Export-AssessmentReport.ps1).
+
+## Consequences
+
+**Positive**
+
+- Report opens and renders identically in 2030 as it did in 2026. No CDN drift, no version pinning bugs, no external service dependency.
+- Air-gapped, USB-handoff, and email-attachment workflows all work first-try.
+- One file = one mental model. Users don't lose pieces.
+- The report can be rebuilt offline from the assessment folder's CSVs alone (the data input pipeline is fully local). This unlocks "rerun with a different theme without re-collecting" workflows.
+- Asset content is never PowerShell-interpolated → no risk of `$variable` lookalikes in minified JS being silently corrupted.
+
+**Negative**
+
+- Reports are **big**. Typical output is 2-3 MB; large tenants with thousands of findings push 5 MB+. Email attachment limits (10 MB Outlook default, 25 MB Gmail) sometimes catch people out.
+- React 18 + react-dom is ~140 KB even minified, and we ship that bundled into every report. A consultant who runs 50 assessments a year accumulates 100+ MB of reports that all contain the same React.
+- The two-stage build (Babel offline → PowerShell at runtime) means JSX changes require a manual rebuild step. We've shipped JSX-and-not-rebuilt-JS bugs more than once.
+- We can't lazy-load. The whole React tree, all sections, all findings, all framework data parse on first open. A 100 MB report (which we've seen on enterprise tenants) takes 5+ seconds to render and pegs the browser tab's memory.
+- The "data inlined as `window.REPORT_DATA`" contract makes the report read-only by default — there's no easy "fetch updates from a server" path. Edit Mode and Finalize features had to be implemented client-side with localStorage, which has its own constraints.
+
+**Failure modes and mitigations**
+
+- *`</script>` substring inside inlined JS terminates the wrapping `<script>` tag* → mitigation: pre-escape `</script>`/`</style>` before append. Tested in `Get-ReportTemplate.Tests.ps1`.
+- *PowerShell interpolation corrupts the JS at template-assembly time* → mitigation: `[StringBuilder].Append`, never `"$jsContent"`. Bug class fixed by structural choice, not a runtime check.
+- *Anti-FOUC script runs synchronously and blocks first paint* → accepted: it's microseconds; preventing the white-flash-on-load is worth it for reports opened against a dark theme.
+- *Large reports (50+ MB) crash older browsers* → no current mitigation. Long-term we may pre-aggregate non-rendered data into a separate sidecar that's loaded on demand, but that breaks the "one file" property and we've avoided it.
+
+## Alternatives considered
+
+- **Reference React from a CDN (`unpkg.com/react@18` etc.).** Rejected: breaks every offline / air-gapped / archived-report case. Saves ~140 KB per report at the cost of reliability we depend on.
+- **Sidecar JSON with `<script src="report-data.json">` (or fetch on load).** Rejected: requires a web server (browsers block `file://` cross-origin fetches by default), which kills the email/USB workflow.
+- **Multi-file output: `report.html` + `report.js` + `report.css` + `data.json` in a folder.** Rejected: users lose pieces, lose relative-path resolution when emailed, and lose the "send my client one file" property.
+- **Server-side rendered static HTML with no JS.** Rejected: kills interactivity (filters, sortable tables, drill-downs, edit mode, theme switcher). Most of the report's value is the interactive UI, not the static content.
+- **Single-page-app served from a separate hosting service.** Rejected: requires us to operate infrastructure, run a backend, and pay forever. Customers also can't share assessment data with non-authenticated viewers without rolling token-protected URLs. The on-disk file is a much simpler distribution model.
+- **PDF as primary output.** Rejected for the same interactivity reasons. We do support a print stylesheet and PDF export from-the-browser as a secondary distribution channel.
+
+---
+
+## See also
+
+- [`../../src/M365-Assess/Common/Get-ReportTemplate.ps1`](../../src/M365-Assess/Common/Get-ReportTemplate.ps1) — the assembler
+- [`../../src/M365-Assess/Common/Export-AssessmentReport.ps1`](../../src/M365-Assess/Common/Export-AssessmentReport.ps1) — the orchestrator that calls it
+- [`../../src/M365-Assess/assets/`](../../src/M365-Assess/assets/) — the inlined assets (React build, CSS, compiled `report-app.js`)
+- [`../dev/REPORT-INTERNALS.md`](../dev/REPORT-INTERNALS.md) — frontend build pipeline + `window.REPORT_DATA` schema
+- [`README.md`](README.md) — back to the ADR index

--- a/docs/adr/0009-live-tenant-verification-hard-gate.md
+++ b/docs/adr/0009-live-tenant-verification-hard-gate.md
@@ -1,0 +1,84 @@
+# 0009 — Live tenant verification is a hard precondition for every release
+
+- **Status:** Accepted
+- **Date:** 2026-05-06
+
+## Context
+
+M365-Assess publishes to PSGallery. A bad release reaches every consumer of the module on `Update-Module`. Unlike a SaaS, we can't hot-fix a regression in production — once a version is on the gallery, anyone who installed it is stuck with it until they explicitly upgrade. Yanking a version is technically possible but practically catastrophic for users mid-engagement.
+
+We had a healthy CI pipeline: PSScriptAnalyzer lint, Pester tests at 65% coverage, fixture-based collector tests, schema validation on registry/framework JSON. CI was green. Releases looked safe.
+
+**v2.9.0 broke the assumption that green CI = ready to ship.** Two distinct bugs shipped to PSGallery, both of which destroyed the HTML report:
+
+1. A PowerShell parser-binding bug in `Get-BaselineTrend` that silently dropped the HTML when `-AutoBaseline` was supplied. The `[System.Collections.Generic.Dictionary[string, System.IO.DirectoryInfo]]` type literal was being parsed as an array argument to `New-Object -TypeName`, throwing `Cannot convert Object[] to System.String`. Caught only when running `-AutoBaseline` end-to-end.
+2. A `ConvertTo-Json` array-shape mismatch in the `PermissionsPanel` data path. PowerShell's `ConvertTo-Json` unwraps single-element arrays into objects, breaking the React component that expected `[{...}]` and got `{...}`. This manifested as a black screen — the entire React app unmounted on render error, leaving an empty body.
+
+Neither was caught by CI because:
+
+- CI runs against synthetic fixtures, not real Microsoft Graph / EXO / SharePoint responses. The PermissionsPanel bug fired only when the deficit-detection upstream emitted a one-element array, which happened reliably against real tenants and ~never against the test fixtures.
+- The `-AutoBaseline` code path was tested in isolation; the orchestrator's `try/catch` around HTML generation swallowed the parser bug and logged at WARN. The assessment "succeeded" — just without the HTML, which the test harness didn't notice.
+- Both failures were in code paths that were structurally hard to fixture-test (real tenant data shapes, real downstream-component error boundaries).
+
+The lesson: **CI is necessary but not sufficient for this product.** The class of bugs we care about — runtime React errors, PowerShell parser ambiguity against real type literals, downstream component failures triggered by real data shapes — only fires against a real tenant.
+
+## Decision
+
+Every release, regardless of size, requires an end-to-end live tenant verification by a human before tagging or publishing. No exceptions.
+
+The full process (codified in [`.claude/rules/releases.md`](../../.claude/rules/releases.md)):
+
+1. The version-bump PR is opened.
+2. CI runs and must be green.
+3. **The user (not the agent) runs `Invoke-M365Assessment -TenantId <tenant>` against a real tenant**, with the parameter set that exercises the new feature. For releases that touch baseline / drift / report code, `-AutoBaseline` is mandatory — that's the path that hides the v2.9.0 class of bugs.
+4. The user opens the HTML report in a browser, clicks through changed sections, watches for black/blank screens (= runtime React error).
+5. The user inspects the `_Assessment-Log_*.txt` for WARN-level entries (silent failures hide there because the orchestrator catches and logs rather than aborts).
+6. The user explicitly confirms the live test passed. "Looks good after running it" / "live test passed" / equivalent.
+7. **Only then** does the version-bump PR get merged.
+8. **Only then** does `gh release create vX.Y.Z` run, which triggers the PSGallery publish workflow.
+
+The agent does not have credentials for a live tenant. The agent waits.
+
+A "looks good" on the version-bump PR alone does **not** authorize release — only the live-test confirmation does. This distinction is preserved in the rule because users (reasonably) sometimes review code without running it; the agent must not interpret a code-review approval as a tested-in-anger approval.
+
+## Consequences
+
+**Positive**
+
+- Catches the runtime-React-error class of bugs that CI structurally cannot.
+- Catches the parser-binding-against-real-types class of bugs that CI structurally cannot.
+- Catches silent-failure-with-WARN-log bugs because the human is told to read the log.
+- Forces the release process to slow down to "wait for a human" — which has caught dependency upgrades that pass CI but break against real Graph responses.
+- The version-bump PR sitting visibly unmerged is a readable status: "we're between code-complete and verified".
+
+**Negative**
+
+- Releases are slow. Bumping a patch version takes an hour minimum (run the assessment, inspect the artifacts, eyeball the log). Several hours if the live test surfaces something that needs a follow-up bug-fix PR.
+- Cannot fully automate publish. PSGallery deploys are tag-triggered, but the tag itself is gated on a human signal. We accept this — the alternative is more v2.9.0s.
+- The user is doing real work in the verification step, which means they have to *want to release* enough to spend that time. Some patches sit unreleased for weeks because no one wants to do the verification.
+- Verification quality is variable — a hurried user may click through fewer sections than a careful one. The checklist mitigates but doesn't eliminate.
+- Agent flow is awkward: agent does the work, opens the PR, then has to *wait* for an offline human action. The "agent doesn't have tenant credentials" rule is structural, not preferential — granting credentials would create a new liability surface.
+
+**Failure modes and mitigations**
+
+- *Agent interprets a code-review approval as live-test approval and tags prematurely* → catastrophic (yank from gallery, hot-fix). Mitigation: explicit rule in `releases.md` that "looks good" on the PR alone is approval to **discuss** merging, not to tag. Repeated phrasing makes the boundary clear.
+- *User runs the assessment but skips the log inspection* → silent failures (the v2.9.0-A class) slip through. Mitigation: the verification checklist explicitly names "Read the `_Assessment-Log_*.txt` for any WARN-level entries". No further enforcement; relies on user discipline.
+- *Live test passes against the user's primary tenant but fails on tenant types we don't test* (gov cloud, complex licensing, lots of CA policies) → mitigation: at-times we ask multiple users to run on different tenants for major releases. Not codified.
+- *User reports "live test passed" prematurely (e.g. opened the HTML, didn't notice the section that broke)* → no mitigation. The decision accepts that the human is in the loop and that humans miss things. Acceptable because the previous baseline (no human in the loop) was demonstrably worse.
+
+## Alternatives considered
+
+- **Trust CI fully — let `gh release create` run automatically on version-bump PR merge.** Rejected: this is exactly what shipped v2.9.0. CI structurally can't catch the bug classes we care about.
+- **Add CI tests against a real tenant.** Rejected (for now): requires committing tenant credentials to GitHub Actions, which is a security disaster. Even with OIDC federation, the tenant becomes a CI dependency that flakes destroy releases. We've discussed running CI against a low-stakes lab tenant; nothing has shipped yet.
+- **Canary release: tag, publish to PSGallery as `-preview`, wait for a real user to install it, then promote.** Considered. The PSGallery preview channel is real and we use it for major changes. But it doesn't eliminate the human-runs-it step, and the preview-vs-stable promotion adds its own gate. Net: the live-test gate is simpler.
+- **More fixture coverage to catch the v2.9.0 bug classes.** Tried (we added fixtures specifically modelling the array-shape bug). Helps for the *exact* bug; doesn't generalize. The bug class is "the thing CI can't reach" — adding fixtures expands what CI can reach but doesn't change the structural ceiling.
+- **Skip the live test for "trivial" releases (docs, comments, etc).** Rejected for now. The cost of the rule's universality is occasional friction on tiny releases; the cost of carving out exceptions is that "trivial" creep until we ship another v2.9.0.
+
+---
+
+## See also
+
+- [`../../.claude/rules/releases.md`](../../.claude/rules/releases.md) — the codified rule (this ADR explains the *why*; the rule is the *how*)
+- [`../../src/M365-Assess/Common/Get-BaselineTrend.ps1`](../../src/M365-Assess/Common/Get-BaselineTrend.ps1) — the v2.9.0-A bug location (line ~71, the `::new()` fix)
+- [`../dev/RELEASE-PROCESS.md`](../dev/RELEASE-PROCESS.md) — the user-facing release walkthrough
+- [`README.md`](README.md) — back to the ADR index

--- a/docs/adr/0010-baseline-diff-key-strategy.md
+++ b/docs/adr/0010-baseline-diff-key-strategy.md
@@ -1,0 +1,81 @@
+# 0010 — Baseline diff keys on the sub-numbered CheckId; cross-version comparisons use intersect-only mode
+
+- **Status:** Accepted
+- **Date:** 2026-05-06
+
+## Context
+
+Baseline comparison is the "did anything regress?" feature: a saved baseline from a previous run is compared against the current run, and each check is classified as `Regressed` / `Improved` / `Modified` / `New` / `Removed` (or `Unchanged`, which is dropped from the output). For the feature to be useful, a check in run A must be matched up to its counterpart in run B.
+
+The matching is harder than it looks because of two properties of M365-Assess:
+
+1. **CheckIds are sub-numbered per-setting at the helper level.** [ADR-0002](0002-sub-numbered-check-ids.md) describes this: a single upstream `CA-REPORTONLY-001` becomes `CA-REPORTONLY-001.1`, `.2`, `.3` ... — one row per CA policy evaluated. The sub-number is *order-dependent* within a run. If Graph happens to return CA policies in a different order tomorrow than it did today, `CA-REPORTONLY-001.1` refers to a different policy on each run, and a naïve diff would scream "everything changed."
+2. **The control registry is upstream-synced** ([ADR-0001](0001-checkid-sync-vs-fork.md)). When CheckID ships a new version, checks get added, renamed, retired. A run from before the sync compared to a run from after the sync sees those upstream changes as "drift" — but they're not posture changes, they're schema changes.
+
+We needed a join key that:
+
+- Is stable across runs against the same tenant (so the diff matches on real changes).
+- Survives upstream registry version bumps without producing pages of bogus drift entries.
+- Doesn't require the user to manually align check IDs after each upstream sync.
+
+## Decision
+
+Two pieces:
+
+**1. Diff keys on `row.CheckId` directly — the sub-numbered form.**
+
+`Compare-AssessmentBaseline` builds two lookup tables (`baselineMap` and `currentMap`), both keyed on the CheckId field as it appears in the saved JSON / current CSV. That field is always the sub-numbered string (`CA-REPORTONLY-001.1`).
+
+The pragmatic justification: *Microsoft Graph is order-stable in practice*. Repeated calls to the same endpoint with the same parameters return objects in the same order, run after run, against the same tenant. The sub-numbering is therefore stable in observed behaviour even though it's not stable in theory. We accept the brittleness in exchange for not having to compute a per-collector "natural identifier" (policy name, role definition ID, sharing-link target, etc.) for every check.
+
+**2. Cross-version comparisons switch to intersect-only mode.**
+
+The baseline manifest stores `RegistryVersion` (the `dataVersion` from `controls/registry.json` at the time the baseline was captured). At diff time, `Compare-AssessmentBaseline` compares this against the current registry version. If they differ:
+
+- The diff is computed only over the **intersection** of CheckIds present in both snapshots.
+- New CheckIds in the current run (that didn't exist in the baseline) are *not* reported as `New`.
+- Removed CheckIds (that existed in the baseline but not the current run) are *not* reported as `Removed`.
+
+The reasoning: when registry versions differ, `New`/`Removed` are dominated by upstream schema churn, not policy drift. Reporting them is noise. A user comparing v3.2 against v3.4 of the registry doesn't want to see "37 new findings" if 35 of those are checks the upstream just added.
+
+See: [`src/M365-Assess/Orchestrator/Compare-AssessmentBaseline.ps1`](../../src/M365-Assess/Orchestrator/Compare-AssessmentBaseline.ps1).
+
+## Consequences
+
+**Positive**
+
+- Implementation is cheap: dictionary lookup by CheckId, no per-collector identifier extraction logic.
+- Cross-version mode keeps the diff signal-to-noise ratio sane after every CheckID sync. A registry bump adds 5-10 checks routinely; without intersect mode, every drift report after a sync would be unreadable.
+- The baseline manifest carrying `RegistryVersion` makes the cross-version detection automatic — the user doesn't have to opt in.
+- Same-version comparisons (the common case) get the full `New` / `Removed` classification, which is genuinely useful for "we expanded coverage in this section" narratives.
+
+**Negative**
+
+- *Theoretical* bug: if Graph ever returns CA policies in a different order between runs, `CA-REPORTONLY-001.1` would point at a different policy and the diff would lie. We have not seen this in practice, but we don't have a regression test for it either. [ADR-0002](0002-sub-numbered-check-ids.md) flags the risk; [ADR-0010](0010-baseline-diff-key-strategy.md) (this one) accepts it as the tradeoff for implementation simplicity.
+- Cross-version intersect mode hides a real signal: "you upgraded and now have 35 new checks" is information a consultant might want. The current report doesn't surface this — it just quietly drops them. We accept that this is the right default for the diff-as-drift-detection use case but acknowledge it might want a separate "schema-change report" mode.
+- The choice is collector-class-dependent without surfacing the dependency. Collectors that emit one row per registry CheckId (no sub-numbering — e.g. tenant-wide settings) are fine. Collectors that emit many sub-numbered rows are exposed to the order-stability assumption. The line between the two isn't visible in the diff output.
+- A registry-version field error (e.g. baseline manifest written without the field) silently falls back to same-version mode, which can produce noisy diffs after a sync. The fallback is "if either version is empty, treat as same-version" — that's the wrong default for safety, but right for backward compatibility with old baselines.
+
+**Failure modes and mitigations**
+
+- *Graph response order shuffles between two runs against the same tenant* → diff reports phantom Regressed/Improved entries. No current mitigation. Would surface as "drift entries that don't make sense when the user spot-checks the named policies." If we ever see this in the wild, the fix is per-collector natural-key derivation.
+- *Baseline file lacks `RegistryVersion` (saved by an old M365-Assess)* → cross-version detection silently disables; old baselines compared against new runs report all upstream-added checks as `New`. Mitigation: documented in `Compare-AssessmentBaseline` synopsis; users see the noise and ask, at which point the answer is "save a fresh baseline post-upgrade."
+- *Sub-numbered CheckIds collide between two collectors* (would require both collectors to use the same upstream CheckId base — currently impossible by registry shape, but not enforced) → mitigation: the registry has unique `checkId` per check at v2.0.0 schema, so this can't happen unless the registry itself breaks invariants.
+
+## Alternatives considered
+
+- **Key on `(Setting, Category)` tuple instead of CheckId.** Considered. Rejected because `Setting` is a free-text human-readable string set by the collector author; renaming a setting in the source code would break every existing baseline overnight. CheckId is more durable.
+- **Compute a "natural key" per collector (e.g. policy displayName for CA, role definition ID for PIM).** Rejected for now: would require every collector to emit a stable identifier alongside its findings, which is 250+ touchpoints. The pragmatic choice is to live with the sub-numbered key until we have evidence the order-stability assumption is breaking.
+- **Treat schema changes as drift in cross-version mode.** Rejected: see Consequences. The `New`/`Removed` from a registry sync would dominate the report. The user wants drift-as-policy-change, not drift-as-tool-version.
+- **Refuse to compare across versions; force the user to save a fresh baseline post-upgrade.** Rejected: most upgrades are minor (a handful of new checks) and the user wants to see continuity. Forcing a fresh baseline throws away weeks of trend data.
+- **Surface the schema-change set as a separate panel in the report ("12 new checks were added since your last baseline").** Worth doing eventually. Currently not implemented; cross-version intersect just silently drops them. Would be a non-breaking enhancement.
+
+---
+
+## See also
+
+- [`../../src/M365-Assess/Orchestrator/Compare-AssessmentBaseline.ps1`](../../src/M365-Assess/Orchestrator/Compare-AssessmentBaseline.ps1) — the diff implementation
+- [`../../src/M365-Assess/Common/Get-BaselineTrend.ps1`](../../src/M365-Assess/Common/Get-BaselineTrend.ps1) — sibling code, aggregates per-status counts across snapshots (uses tenant-folder matching, not CheckId join)
+- [`0002-sub-numbered-check-ids.md`](0002-sub-numbered-check-ids.md) — the sub-numbering scheme this diff strategy depends on
+- [`0001-checkid-sync-vs-fork.md`](0001-checkid-sync-vs-fork.md) — the upstream-sync model that motivates cross-version mode
+- [`README.md`](README.md) — back to the ADR index

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,6 +36,9 @@ When a later ADR overrides an earlier one, set the old one's status to `Supersed
 | [0005](0005-nine-status-taxonomy.md) | 9-value status taxonomy instead of binary Pass/Fail | Accepted | 2026-05-06 |
 | [0006](0006-optional-structured-evidence-fields.md) | Extend the finding contract with optional structured evidence fields | Accepted | 2026-05-06 |
 | [0007](0007-skip-collector-on-unavailable-service.md) | Skip individual collectors when their services are unavailable; never abort the run | Accepted | 2026-05-06 |
+| [0008](0008-self-contained-html-report.md) | HTML report is a single self-contained file with no external runtime dependencies | Accepted | 2026-05-06 |
+| [0009](0009-live-tenant-verification-hard-gate.md) | Live tenant verification is a hard precondition for every release | Accepted | 2026-05-06 |
+| [0010](0010-baseline-diff-key-strategy.md) | Baseline diff keys on the sub-numbered CheckId; cross-version uses intersect-only mode | Accepted | 2026-05-06 |
 
 ---
 


### PR DESCRIPTION
## Summary

Fourth batch of ADRs, covering how the tool ships its output and verifies state across runs:

- **0008 — Self-contained HTML report**. Why React, CSS, app JS, and `window.REPORT_DATA` are all inlined into one HTML file (no CDN, no sidecar JSON, no folder of files). Driven by air-gapped tenants, email attachments, and stale-archive use cases.
- **0009 — Live tenant verification is a hard release gate**. Why every version bump waits for a human to run an end-to-end assessment before tagging. Captures the v2.9.0 incident (Get-BaselineTrend parser bug, PermissionsPanel array-shape mismatch) that drove the rule.
- **0010 — Baseline diff key strategy**. Why `Compare-AssessmentBaseline` joins on the sub-numbered CheckId directly, why cross-version comparisons drop to intersect-only mode, and the order-stability assumption we accept.

Each grounded in code (`Get-ReportTemplate.ps1`, `Compare-AssessmentBaseline.ps1`, `.claude/rules/releases.md`) and cross-linked to sibling ADRs (0008 ↔ REPORT-INTERNALS, 0010 ↔ ADR-0001 / ADR-0002).

## Test plan

- [x] N/A — docs only, no code paths touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)