### PR TITLE
docs: backfill ADR-0011 / 0012 / 0013 — frameworks, tenant identity, auth dispatch

### DIFF
--- a/docs/adr/0011-framework-definitions-auto-discovered.md
+++ b/docs/adr/0011-framework-definitions-auto-discovered.md
@@ -1,0 +1,95 @@
+# 0011 — Framework definitions are auto-discovered per-framework JSON files
+
+- **Status:** Accepted
+- **Date:** 2026-05-06
+
+## Context
+
+M365-Assess maps each check to **fifteen** compliance frameworks: CIS Controls v8, CIS M365 v6, CISA SCuBA, CMMC, Essential Eight, FedRAMP, HIPAA, ISO 27001, ISO 27002, MITRE ATT&CK, NIST 800-53 r5, NIST CSF, PCI DSS v4, SOC 2 TSC, STIG. Each framework has its own structure: control IDs, profiles (e.g. CIS L1/L2, CMMC L1/L2/L3), scoring method (control-coverage vs. weighted), display order in the report, filter family for the UI grouping.
+
+We had three reasonable shapes for storing this:
+
+1. **One big monolithic file** with every framework as a sub-object.
+2. **One JSON file per framework**, listed explicitly in code or a manifest.
+3. **One JSON file per framework**, auto-discovered by scanning a directory.
+
+The data is upstream-owned (CheckID syncs the framework files alongside the registry — see [ADR-0001](0001-checkid-sync-vs-fork.md)). When CheckID adds a new framework, M365-Assess should pick it up without code changes. Conversely, when CheckID retires one, the report should silently stop showing it.
+
+We also wanted contributors who add a *local* framework experiment (e.g. NIS2, a customer-specific compliance overlay) to be able to drop one file in `controls/frameworks/` and have it appear in the report. Anything more ceremonious would discourage experimentation.
+
+## Decision
+
+`controls/frameworks/` contains one JSON file per framework. `Import-FrameworkDefinitions.ps1` scans the directory at report-render time, loads every `*.json`, and returns an ordered array of framework hashtables.
+
+Each framework JSON file has a self-describing shape:
+
+```json
+{
+  "frameworkId": "cis-m365-v6",
+  "label": "CIS Microsoft 365 Foundations v6",
+  "description": "...",
+  "displayOrder": 10,
+  "scoring": {
+    "method": "control-coverage",
+    "profiles": {
+      "L1": { "controlCount": 56, "label": "Level 1", "css": "cis-l1" },
+      "L2": { "controlCount": 88, "label": "Level 2", "css": "cis-l2" }
+    }
+  },
+  "controls": [ ... ]
+}
+```
+
+The loader:
+
+- Skips files missing `frameworkId` or `label` with a `Write-Warning`.
+- Skips files that fail JSON parsing with a `Write-Warning` (does not abort).
+- Sorts the resulting array by `displayOrder` so the report's framework tabs come out in a deliberate order regardless of filename / load order.
+- Derives `filterFamily` from the `frameworkId` prefix using a hardcoded prefix→family map (`cis` → `CIS`, `nist` → `NIST`, etc.). Longest prefix wins so `cisa` matches before `cis`.
+
+No explicit framework list anywhere. Adding a framework = drop a file. Removing one = delete a file. CheckID's sync workflow simply overwrites the framework directory.
+
+See: [`src/M365-Assess/Common/Import-FrameworkDefinitions.ps1`](../../src/M365-Assess/Common/Import-FrameworkDefinitions.ps1) and [`src/M365-Assess/controls/frameworks/`](../../src/M365-Assess/controls/frameworks/).
+
+## Consequences
+
+**Positive**
+
+- CheckID syncs add/remove framework support automatically. The first time a v3.5.0 sync ships an `iso-27002.json`, the report grows an ISO 27002 tab without any code change.
+- Contributors can prototype a custom framework overlay by dropping one file. No registration step, no bootstrap code path to update.
+- Bad files fail soft: a malformed `essential-eight.json` doesn't crash the report — it just drops that framework and emits a warning.
+- The directory is the canonical list. No "the code says we have 14 but the directory has 15" drift.
+- Display order is data, not code. Reordering framework tabs is a JSON edit.
+
+**Negative**
+
+- "Auto-discovery" hides which frameworks actually shipped. A reader of the codebase has to look at the directory, not at code, to know what's supported. We mitigate by listing them in CLAUDE.md, but the canonical list is still in the filesystem.
+- The prefix-to-family map IS hardcoded in `Import-FrameworkDefinitions.ps1`. A future framework with a novel prefix (`nis2`, `dora`) would land with `filterFamily = ''` and need a code change to get a UI grouping. That partially undermines the "drop a file and it works" promise.
+- Failure is silent-to-warning. A `Write-Warning` for a malformed JSON file is easy to miss in a long assessment log; a contributor who edits the JSON wrong sees their framework disappear from the report and has to know to look. We've considered upgrading these warnings to ERRORs but kept them WARN to preserve "report still renders if a framework is broken."
+- The `displayOrder` is not validated for collisions. Two frameworks with the same `displayOrder` get a stable-but-arbitrary tie-break. Has not bitten in practice but could.
+- `Get-ChildItem -Filter '*.json'` matches anything ending in `.json`. A stray editor swap file (`framework.json~`) would be skipped only because it doesn't match the filter. A `manifest.json` or `index.json` accidentally placed in the directory would be parsed and probably skipped at the `frameworkId` check, but it's a sharp edge.
+
+**Failure modes and mitigations**
+
+- *Sync overwrites a framework file with broken JSON* → sync PR shows the diff, human review catches it (typically a Unicode encoding issue, fixed by the sync workflow's CP1252→UTF-8 normalization). If it lands anyway, the report renders without that framework with a WARN log entry. Loud-enough failure.
+- *New CheckID framework lands with an unrecognized prefix* → renders without `filterFamily`, UI groups it under an empty bucket. Mitigation: update the prefix map; effectively a manual step on every new-framework CheckID release. Could be improved by reading `filterFamily` directly from each framework JSON.
+- *Two frameworks claim the same `frameworkId`* → second one wins, first is silently shadowed. Mitigation: none currently. Has not happened — CheckID uses unique prefixes by convention.
+- *Performance on large framework counts* → not a concern at 15. The scan + parse runs once per assessment and finishes in milliseconds. We'd revisit if frameworks ever grew to 100+.
+
+## Alternatives considered
+
+- **One monolithic `frameworks.json`.** Rejected: every CheckID sync would touch one giant file, and merge conflicts on local edits become unavoidable. Per-file isolation is much friendlier to upstream sync.
+- **Explicit framework list in code (`$frameworkFiles = @('cis-m365-v6.json', 'nist-csf.json', ...)`).** Rejected: every CheckID upstream change would require a code edit. Defeats the auto-pickup property.
+- **Manifest JSON listing the framework files (`controls/frameworks/index.json`).** Rejected for the same reason: it's an auxiliary file the sync workflow would also have to maintain. The directory listing IS the manifest.
+- **Move `filterFamily` derivation into each framework JSON file (declarative).** Worth doing; not done yet. Currently the prefix map is in code because that's where the existing 12 frameworks expected it. A future PR could move this to data without breaking compatibility — readers would just trust the JSON value if present.
+- **Hard-fail on a malformed framework JSON.** Rejected: we'd rather render the report without one framework than not render it at all. The conservative posture matches the "skip on unavailable service" decision in [ADR-0007](0007-skip-collector-on-unavailable-service.md).
+
+---
+
+## See also
+
+- [`../../src/M365-Assess/Common/Import-FrameworkDefinitions.ps1`](../../src/M365-Assess/Common/Import-FrameworkDefinitions.ps1) — the auto-discovery loader
+- [`../../src/M365-Assess/controls/frameworks/`](../../src/M365-Assess/controls/frameworks/) — the JSON files
+- [`0001-checkid-sync-vs-fork.md`](0001-checkid-sync-vs-fork.md) — upstream sync model (frameworks ride on this)
+- [`0007-skip-collector-on-unavailable-service.md`](0007-skip-collector-on-unavailable-service.md) — sibling "fail soft" posture
+- [`README.md`](README.md) — back to the ADR index

--- a/docs/adr/0012-tenant-identifier-dual-shape.md
+++ b/docs/adr/0012-tenant-identifier-dual-shape.md
@@ -1,0 +1,79 @@
+# 0012 — Tenant identity uses GUID for new artifacts but reads both legacy and GUID folder shapes
+
+- **Status:** Accepted
+- **Date:** 2026-05-06
+
+## Context
+
+Baselines, drift reports, and the trend chart all need a stable per-tenant key — a string that says "this run and that run came from the same tenant" so a comparison is meaningful. Pre-v2.9.0, M365-Assess used the user-supplied `-TenantId` as that key, which produced folder names like `Q1-2026_contoso.com` or `Baseline_contoso.onmicrosoft.com`.
+
+The user-supplied `TenantId` is a **bad canonical key** for several reasons:
+
+1. **It's a free-text input.** The same tenant can be referred to as `contoso.com`, `contoso.onmicrosoft.com`, or `00000000-1111-2222-3333-444444444444`. Each spelling produces a different folder, and trend / drift comparisons silently miss because the keys don't match.
+2. **Domain rebrands break history.** A tenant that renames from `acme.com` to `acme-corp.com` (or sells off a subsidiary keeping `oldname.onmicrosoft.com`) now has its baseline history split across two keys.
+3. **No collision-resistant guarantee.** The `TenantId` value passes through unchanged into the filesystem, sanitized only to remove `[^\w\.\-]`. Two distinct tenants could in principle pick names that sanitize identically.
+
+The right canonical key is the **tenant GUID** from `Get-MgContext.TenantId` after a Graph connect. It's stable across rebrands, immune to spelling variants, and globally unique by definition.
+
+But there's a migration constraint: **users have years of pre-v2.9.0 baselines** sitting in `Baselines/Q1-2026_contoso.com`-shaped folders. Switching the canonical key to GUID would orphan all that history. The user opens the trend chart and sees only post-upgrade data, with the old chart silently gone.
+
+## Decision
+
+C1 #780: dual-shape support, asymmetric between read and write paths.
+
+**Write side (canonical):** all new artifacts use the GUID as the folder-name suffix.
+
+- `Resolve-TenantIdentity` resolves `Guid` from `Get-MgContext.TenantId` (source = `'Graph'`).
+- If Graph isn't connected (pure AD-only run, weird auth state), fall back to a deterministic `SHA256(lowercase(TenantIdInput))` truncated to 32 hex chars, GUID-formatted (source = `'Fallback'`). This gives the same string every time for the same input — same key, just not a real GUID.
+- New baselines are saved to `Baselines/<Label>_<Guid>/`.
+- The baseline manifest stores `{ TenantGuid, DisplayName, PrimaryDomain }` so future readers have all three for matching.
+
+**Read side (compatibility):**
+
+- `Resolve-BaselineFolder` looks up a single named baseline by trying the GUID-keyed path first, then the legacy `TenantId`-keyed path.
+- `Get-BaselineTrend` is more aggressive: it scans the `Baselines/` directory with **both** filters (`*_<sanitized-domain>` and `*_<sanitized-guid>`) and unions the results into a `Dictionary<string, DirectoryInfo>` keyed on full path so duplicates dedupe. Folder names are timestamp-based and unique, so the union doesn't double-count.
+- The trend chart therefore shows pre- and post-v2.9.0 history continuously, even though the underlying folders are keyed differently.
+
+See: [`src/M365-Assess/Common/Resolve-TenantIdentity.ps1`](../../src/M365-Assess/Common/Resolve-TenantIdentity.ps1) (the resolver + folder helper) and [`src/M365-Assess/Common/Get-BaselineTrend.ps1`](../../src/M365-Assess/Common/Get-BaselineTrend.ps1) (the dual-filter scan).
+
+## Consequences
+
+**Positive**
+
+- New baselines are durable across rebrands, vanity-domain swaps, and free-text-spelling variants. Future trend comparisons stay coherent.
+- Existing pre-v2.9.0 baselines remain visible in the trend chart with no manual migration step.
+- The fallback hash means baselines work even in offline / non-Graph runs (e.g. `-SkipConnection` paths) by producing a deterministic per-input key. No silent data loss.
+- The manifest carrying `TenantGuid` + `DisplayName` + `PrimaryDomain` is forward-flexible: future features that want to match by primary domain or display name have the data already in the file.
+
+**Negative**
+
+- The dual-read path is fragile. `Get-BaselineTrend` knows about both shapes; any new code that scans the baselines directory must remember to do the same union or it will silently miss legacy baselines. We have no lint check for this; relies on convention and reviewer attention.
+- The fallback hash *looks like* a GUID (it's GUID-shaped) but isn't one. A reader debugging a baseline folder may confuse a fallback hash for a real tenant GUID and misidentify the tenant. The `Source: 'Fallback'` field on the resolver output is the only signal, and it lives in memory, not on disk.
+- Over time the legacy support becomes pure dead weight — most tenants will eventually have only GUID-keyed baselines, and the legacy filter scan still runs every time. Performance impact is negligible (one extra `Get-ChildItem -Filter`) but the cognitive overhead persists.
+- The user-supplied `-TenantId` is still the human-facing identifier in logs, error messages, and the assessment folder name. The split between "what the user sees" (TenantId) and "what the tool persists" (TenantGuid) is potentially confusing.
+- A tenant that runs assessments against the same M365 tenant from two different cloud environments (commercial vs. GCC) gets the same `TenantGuid` in both. The `Environment` field on the identity object distinguishes them in memory but isn't part of the folder key. Edge case; not yet a real-world problem.
+
+**Failure modes and mitigations**
+
+- *Graph context unavailable when `Resolve-TenantIdentity` runs* → fallback hash kicks in; Source field is `'Fallback'`. Caller can warn. Used baseline file remains usable across runs against the same input.
+- *User changes spelling of `-TenantId` between runs but Graph is connected both times* → `Get-MgContext.TenantId` returns the same GUID regardless of how the user spelled the input. Folder is the GUID-keyed one, history continuous.
+- *User changes `-TenantId` AND Graph is unavailable both times* → fallback hash differs between the two inputs, history splits. Not preventable without Graph; documented in the resolver synopsis.
+- *Sync workflow accidentally re-creates a legacy folder* → harmless, just reads as a duplicate by `Get-BaselineTrend`'s union (deduped by path). Would only be a problem if a write path produced one — and it shouldn't.
+
+## Alternatives considered
+
+- **Migrate all legacy baselines to GUID-keyed folders on first run.** Rejected: requires a Graph connect to know the GUID, requires write permission to the user's baseline directory, and irreversibly mutates user data. The dual-read approach is non-destructive.
+- **Stay on `TenantId` as the canonical key forever.** Rejected: the rebrand-resilience and spelling-variants problems are real, and they manifested in user reports before C1 #780.
+- **Use `PrimaryDomain` as the canonical key.** Rejected: still mutable across tenant lifetime (rebrands), still spelling-sensitive, and not always available (Graph may be reachable but `Get-MgOrganization` may fail on minimal scopes).
+- **Demand a real GUID, refuse to run on the fallback path.** Rejected: kills `-SkipConnection` use cases, breaks AD-only runs, makes the tool brittle for the 5% of edge cases where Graph isn't usable.
+- **Store both keys in the folder name (`<Label>_<Guid>_<TenantId>`).** Rejected: makes the directory listing ugly, doubles the path-length budget on Windows (already tight at 260 chars), and doesn't actually help the dual-shape read problem because legacy folders predate the format.
+
+---
+
+## See also
+
+- [`../../src/M365-Assess/Common/Resolve-TenantIdentity.ps1`](../../src/M365-Assess/Common/Resolve-TenantIdentity.ps1) — `Resolve-TenantIdentity` + `Resolve-BaselineFolder`
+- [`../../src/M365-Assess/Common/Get-BaselineTrend.ps1`](../../src/M365-Assess/Common/Get-BaselineTrend.ps1) — dual-filter scan of legacy + GUID folders
+- [`../../src/M365-Assess/Orchestrator/Export-AssessmentBaseline.ps1`](../../src/M365-Assess/Orchestrator/Export-AssessmentBaseline.ps1) — write path (always GUID-keyed)
+- [`0010-baseline-diff-key-strategy.md`](0010-baseline-diff-key-strategy.md) — diff key strategy that operates inside one baseline (vs. this ADR's choice of how baselines are addressed)
+- [`README.md`](README.md) — back to the ADR index

--- a/docs/adr/0013-unified-cmdlet-with-auth-parameter-sets.md
+++ b/docs/adr/0013-unified-cmdlet-with-auth-parameter-sets.md
@@ -1,0 +1,96 @@
+# 0013 — One cmdlet, five auth modes, dispatched via PowerShell parameter sets
+
+- **Status:** Accepted
+- **Date:** 2026-05-06
+
+## Context
+
+M365-Assess has to authenticate to several Microsoft services (Graph, EXO, SPO, Teams, Defender, Purview) under several different deployment realities:
+
+- **Interactive at the desk.** Consultant clicks through a browser prompt with their own credentials. Fast iteration.
+- **Certificate-based app-only.** Production assessment runs from a scheduled job, no human, app registration with a cert thumbprint.
+- **Device code.** SSH'd into a server, no browser locally; need to authenticate against an external device. Also covers sovereign-cloud edge cases where the standard interactive flow stumbles.
+- **Managed Identity.** Running inside an Azure VM / Function / Automation Runbook with a system-assigned identity. No secret to manage.
+- **Pre-existing connection (`-SkipConnection`).** The user has already called `Connect-MgGraph` / `Connect-ExchangeOnline` themselves, possibly with a custom flow we don't support. Trust them, run the assessment without re-connecting.
+
+A naïve PowerShell module would ship five separate cmdlets:
+
+```powershell
+Invoke-M365AssessmentInteractive -TenantId ...
+Invoke-M365AssessmentCertificate -TenantId ... -ClientId ... -CertificateThumbprint ...
+Invoke-M365AssessmentDeviceCode -TenantId ...
+Invoke-M365AssessmentManagedIdentity ...
+Invoke-M365AssessmentSkipConnection ...
+```
+
+That's the obvious factoring, and it's wrong for this audience. Consultants context-switch between auth modes constantly — same script, different deployment. Five names = five tab-completions to remember = five docs pages = five places to keep parameters in sync as the rest of the tool grows.
+
+We needed mode selection to be a runtime concern, not a cmdlet-name concern, while still getting the per-mode parameter validation that PowerShell users expect (e.g. "Certificate mode requires `-ClientId` AND `-CertificateThumbprint`").
+
+## Decision
+
+A single cmdlet — `Invoke-M365Assessment` — with five PowerShell **parameter sets**, one per auth mode:
+
+| Parameter set | Activated by | Required parameters |
+|---|---|---|
+| `Interactive` (default) | omitting all auth switches | `-TenantId` |
+| `Certificate` | `-CertificateThumbprint` | `-TenantId`, `-ClientId`, `-CertificateThumbprint` |
+| `DeviceCode` | `-UseDeviceCode` switch | `-TenantId`, `-UseDeviceCode` |
+| `ManagedIdentity` | `-ManagedIdentity` switch | `-ManagedIdentity` (TenantId optional) |
+| (implicit) | `-SkipConnection` switch | none — uses the existing session |
+
+PowerShell's `[CmdletBinding(DefaultParameterSetName = 'Interactive')]` plus per-parameter `[Parameter(ParameterSetName = ...)]` attributes do the dispatch:
+
+- Mutually-exclusive switches are enforced at parse time (`-UseDeviceCode` and `-ManagedIdentity` cannot both be supplied — PowerShell errors before the cmdlet runs).
+- Mode-specific required parameters are enforced at parse time (`-CertificateThumbprint` without `-ClientId` errors).
+- Parameters available to multiple modes (`-TenantId` shared across Interactive/DeviceCode/ManagedIdentity) get repeated `[Parameter]` attributes — verbose, but correct.
+
+The cmdlet body inspects `$PSCmdlet.ParameterSetName` (or, in practice, `$PSBoundParameters.ContainsKey(...)`) to dispatch into the right `Connect-RequiredService` flow.
+
+The interactive wizard (`Show-InteractiveWizard`) is a separate path that fires when the user runs `Invoke-M365Assessment` with no parameters at all, bound to the `Interactive` parameter set + `[Environment]::UserInteractive`. The wizard then populates parameters and the cmdlet re-dispatches.
+
+See: [`src/M365-Assess/Invoke-M365Assessment.ps1`](../../src/M365-Assess/Invoke-M365Assessment.ps1) (the parameter block at line ~170 onward).
+
+## Consequences
+
+**Positive**
+
+- One cmdlet to teach, one tab-completion to learn, one help page (`Get-Help Invoke-M365Assessment`) to read.
+- Parameter-set validation is free at parse time. We don't have to write `if ($CertificateThumbprint -and -not $ClientId) { throw }` checks — PowerShell does it before the cmdlet body runs.
+- Profile/preset re-use: a saved profile can carry whichever auth-mode parameters it needs, and replaying it picks the right parameter set automatically.
+- The `-SkipConnection` "trust the user's session" mode is a clean addition: it doesn't fit the parameter-set model directly (it's orthogonal to auth mode), but coexists with the other sets without requiring its own cmdlet.
+- Adding a sixth auth mode (e.g. workload identity federation) adds one parameter set, not a new cmdlet name + new doc + new parameter sync surface.
+
+**Negative**
+
+- Repeated `[Parameter(ParameterSetName = '...')]` attributes on shared parameters get noisy. `-TenantId` has the attribute three times. Refactor temptation is high; the verbosity is the cost of correctness.
+- `Get-Help` output is a wall: every parameter shows in every parameter set. New users skim it and miss the mode separation. `.EXAMPLE` blocks are the actual onboarding surface.
+- The `[Environment]::UserInteractive` wizard branch is a hidden mode-of-operation. Users running in unattended contexts that *happen* to report `UserInteractive = true` (some CI runners) get an unexpected wizard prompt unless they pass `-NonInteractive`. We added the explicit switch for this reason; it's still a footgun.
+- Parameter-set names are public surface. Renaming `DeviceCode` → `BrowserlessAuth` would break every saved profile and every script that reads `$PSCmdlet.ParameterSetName`. Effectively immutable.
+- A user who supplies `-CertificateThumbprint` AND `-UseDeviceCode` gets a "Parameter set cannot be resolved" error from PowerShell that's correct but cryptic. We've considered adding a friendlier preflight check; haven't shipped it.
+
+**Failure modes and mitigations**
+
+- *User in a CI runner with `UserInteractive = true` triggers the wizard* → ships an interactive prompt to a non-interactive context, hangs forever. Mitigation: explicit `-NonInteractive` switch documented and surfaced in the wizard's launch condition.
+- *Parameter set ambiguity (matching multiple sets)* → PowerShell errors at parse time with a generic message. Mitigation: switch parameters (`-UseDeviceCode`, `-ManagedIdentity`) are mutually exclusive by being declared `Mandatory` on different sets. Hard to construct an ambiguous call by accident.
+- *`-SkipConnection` used without an existing session* → assessment runs, every collector fails per-call. The skip-on-unavailable logic from [ADR-0007](0007-skip-collector-on-unavailable-service.md) catches this gracefully (every section reports `Skipped`). Loud failure surface.
+- *Saved profile from v2.6 specifies an auth flag that v3.x renamed* → load fails. Mitigation: profile loader has compatibility shims for known renames; new flags get warning-level "unknown profile field" messages.
+
+## Alternatives considered
+
+- **Five separate cmdlets** (`Invoke-M365AssessmentInteractive`, `...Certificate`, etc). Rejected: see Context. Doubles the surface area, loses parameter-set validation, fragments tab-completion.
+- **Single `-AuthMode` enum parameter (`-AuthMode Interactive | Certificate | DeviceCode | ManagedIdentity`).** Considered, ultimately rejected. PowerShell parameter sets give us mode-specific required-parameter validation for free; an enum forces us to write conditional validation in the cmdlet body. The current approach delegates validation to the language.
+- **Auth-mode object parameter** (`-Authentication ([PSCustomObject]@{Mode='Certificate'; ClientId='...'; Thumbprint='...'})`). Rejected: terrible UX for the common interactive case, and loses tab-completion entirely for the auth fields.
+- **Auto-detect mode from environment** (if `MI_AVAILABLE` env var → Managed Identity; if `CertificateThumbprint` env var → Certificate). Considered for Azure-Function-style use; rejected as default behaviour because it's surprising. We do support env-var-based parameter binding via PowerShell's standard mechanisms, but only on explicit opt-in.
+- **Wrapper script per mode** (`m365-assess-cert.ps1`, `m365-assess-mi.ps1`, ...). Rejected: same problems as separate cmdlets, plus the wrappers go stale.
+
+---
+
+## See also
+
+- [`../../src/M365-Assess/Invoke-M365Assessment.ps1`](../../src/M365-Assess/Invoke-M365Assessment.ps1) — parameter sets + dispatch
+- [`../../src/M365-Assess/Orchestrator/Connect-RequiredService.ps1`](../../src/M365-Assess/Orchestrator/Connect-RequiredService.ps1) — per-mode connect logic the dispatch routes into
+- [`../../src/M365-Assess/Orchestrator/Show-InteractiveWizard.ps1`](../../src/M365-Assess/Orchestrator/Show-InteractiveWizard.ps1) — the no-args interactive path
+- [`../user/AUTHENTICATION.md`](../user/AUTHENTICATION.md) — user-facing per-mode walkthroughs
+- [`0007-skip-collector-on-unavailable-service.md`](0007-skip-collector-on-unavailable-service.md) — what happens if a connection fails
+- [`README.md`](README.md) — back to the ADR index

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,6 +39,9 @@ When a later ADR overrides an earlier one, set the old one's status to `Supersed
 | [0008](0008-self-contained-html-report.md) | HTML report is a single self-contained file with no external runtime dependencies | Accepted | 2026-05-06 |
 | [0009](0009-live-tenant-verification-hard-gate.md) | Live tenant verification is a hard precondition for every release | Accepted | 2026-05-06 |
 | [0010](0010-baseline-diff-key-strategy.md) | Baseline diff keys on the sub-numbered CheckId; cross-version uses intersect-only mode | Accepted | 2026-05-06 |
+| [0011](0011-framework-definitions-auto-discovered.md) | Framework definitions are auto-discovered per-framework JSON files | Accepted | 2026-05-06 |
+| [0012](0012-tenant-identifier-dual-shape.md) | Tenant identity uses GUID for new artifacts but reads both legacy and GUID folder shapes | Accepted | 2026-05-06 |
+| [0013](0013-unified-cmdlet-with-auth-parameter-sets.md) | One cmdlet, five auth modes, dispatched via PowerShell parameter sets | Accepted | 2026-05-06 |
 
 ---
 


### PR DESCRIPTION
## Summary

Fifth batch of ADRs, covering decisions on extensibility and operational identity:

- **0011 — Framework definitions are auto-discovered per-framework JSON files**. Why \`controls/frameworks/\` is a directory of one-file-per-framework, why \`Import-FrameworkDefinitions\` scans rather than uses an explicit list, and the prefix-based filterFamily derivation.
- **0012 — Tenant identity dual-shape**. Why new baselines key on \`TenantGuid\` from \`Get-MgContext\` (C1 #780) but \`Get-BaselineTrend\` reads both legacy \`_<TenantId>\` and new \`_<TenantGuid>\` folders to preserve pre-v2.9.0 history.
- **0013 — One cmdlet with five auth modes via parameter sets**. Why \`Invoke-M365Assessment\` exposes Interactive / Certificate / DeviceCode / ManagedIdentity / SkipConnection as PowerShell parameter sets rather than five separate cmdlets.

Each grounded in code (\`Import-FrameworkDefinitions.ps1\`, \`Resolve-TenantIdentity.ps1\`, \`Invoke-M365Assessment.ps1\` parameter block).

> **Stacked on #936.** Until that merges, this PR's diff includes ADR-0008/0009/0010 too. Once #936 lands I'll rebase.

## Test plan

- [x] N/A — docs only, no code paths touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)