### PR TITLE
fix(frameworks): add missing group labels across framework JSON files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to M365 Assess are documented here. This project uses [Conve
 
 ## [Unreleased]
 
+### Fixed
+- **CIS M365 v6 sections rendered as raw numbers in the framework breakdown (#948)** — `cis-m365-v6.json` was missing section labels for `4` (Intune) and `9` (Fabric / Power BI), so checks mapped to those sections displayed the bare section number as the group name. Same fix applied to `cisa-scuba.json`, which was missing the `MS.INTUNE` service label. A new regression test cross-checks every group key derivable from registry controlIds against each framework's group map so a registry sync can no longer reintroduce unlabeled groups silently.
+
 ## [2.11.0] - 2026-05-01
 
 The **Data Quality & Accuracy** milestone — 29 of 30 issues closed (#871 stays blocked on upstream CheckID/SCF). No breaking API changes. Ships several new findings-table capabilities, three research/spec decision artifacts, a misleading-check fix (SSPR semantic mismatch), and the CheckID v3.4.0 registry refresh.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to M365 Assess are documented here. This project uses [Conve
 ## [Unreleased]
 
 ### Fixed
-- **CIS M365 v6 sections rendered as raw numbers in the framework breakdown (#948)** — `cis-m365-v6.json` was missing section labels for `4` (Intune) and `9` (Fabric / Power BI), so checks mapped to those sections displayed the bare section number as the group name. Same fix applied to `cisa-scuba.json`, which was missing the `MS.INTUNE` service label. A new regression test cross-checks every group key derivable from registry controlIds against each framework's group map so a registry sync can no longer reintroduce unlabeled groups silently.
+- **Framework group keys rendered as raw codes in the framework breakdown (#948)** — several framework group maps were missing labels for groups the registry maps checks into, so those groups displayed the bare section number/prefix as the group name: `cis-m365-v6.json` sections `4` (Intune) and `9` (Fabric / Power BI), `cisa-scuba.json` service `MS.INTUNE`, `hipaa.json` the ten Breach Notification + Privacy Rule sections added by the CheckID v3.4.0 sync (#912), and `iso-27002.json` groups `9`/`10` (ISO 27001 management-clause ids that leak in via the upstream 27001/27002 mapping conflation, #871 — labels mirror `iso-27001.json` and can be dropped when upstream diverges the mappings). A new regression test cross-checks every group key derivable from registry controlIds against each framework's group map so a registry sync can no longer reintroduce unlabeled groups silently.
 
 ## [2.11.0] - 2026-05-01
 

--- a/src/M365-Assess/controls/frameworks/cis-m365-v6.json
+++ b/src/M365-Assess/controls/frameworks/cis-m365-v6.json
@@ -69,9 +69,11 @@
     "1": "Identity",
     "2": "Defender",
     "3": "Purview",
+    "4": "Intune",
     "5": "Entra ID",
     "6": "Exchange Online",
     "7": "SharePoint & OneDrive",
-    "8": "Teams"
+    "8": "Teams",
+    "9": "Fabric (Power BI)"
   }
 }

--- a/src/M365-Assess/controls/frameworks/cisa-scuba.json
+++ b/src/M365-Assess/controls/frameworks/cisa-scuba.json
@@ -49,6 +49,7 @@
     "MS.AAD":           "Azure AD / Entra ID",
     "MS.EXO":           "Exchange Online",
     "MS.DEFENDER":      "Microsoft Defender",
+    "MS.INTUNE":        "Intune",
     "MS.POWERPLATFORM": "Power Platform",
     "MS.SHAREPOINT":    "SharePoint",
     "MS.TEAMS":         "Teams"

--- a/src/M365-Assess/controls/frameworks/hipaa.json
+++ b/src/M365-Assess/controls/frameworks/hipaa.json
@@ -112,6 +112,16 @@
     "310": "Physical Safeguards",
     "312": "Technical Safeguards",
     "314": "Organizational Requirements",
-    "316": "Policies, Procedures & Documentation"
+    "316": "Policies, Procedures & Documentation",
+    "404": "Breach Notification to Individuals",
+    "408": "Breach Notification to the Secretary",
+    "412": "Law Enforcement Delay",
+    "506": "Treatment, Payment & Health Care Operations",
+    "508": "Authorization Requirements",
+    "510": "Opportunity to Agree or Object",
+    "512": "Uses & Disclosures Without Authorization",
+    "514": "Other Privacy Requirements",
+    "530": "Privacy Administrative Requirements",
+    "532": "Transition Provisions"
   }
 }

--- a/src/M365-Assess/controls/frameworks/iso-27002.json
+++ b/src/M365-Assess/controls/frameworks/iso-27002.json
@@ -28,6 +28,8 @@
     "5": "Organizational Controls (A.5)",
     "6": "People Controls (A.6)",
     "7": "Physical Controls (A.7)",
-    "8": "Technological Controls (A.8)"
+    "8": "Technological Controls (A.8)",
+    "9": "Performance Evaluation",
+    "10": "Improvement"
   }
 }

--- a/tests/Behavior/Framework-Taxonomy.Tests.ps1
+++ b/tests/Behavior/Framework-Taxonomy.Tests.ps1
@@ -96,19 +96,14 @@ Describe 'Framework group maps cover all registry-mapped groups (#948)' {
             }
         }
 
-        # Pre-existing gaps that predate this test and need content decisions
-        # beyond a label (tracked separately — do NOT grow this list to silence
-        # a failure; add the missing label to the framework JSON instead):
-        #   hipaa     — the CheckID v3.4.0 sync (#912) expanded registry coverage
-        #               to the Breach Notification (404-412) and Privacy Rule
-        #               (506-532) subparts, but hipaa.json's groups map still
-        #               only labels the Security Rule sections.
-        #   iso-27002 — ISO 27002:2022 has no clauses 9/10; registry controlIds
-        #               '9.1', '10.1' look like 2013-edition ids from upstream.
-        $script:knownGroupGaps = @{
-            'hipaa'     = @('404', '408', '412', '506', '508', '510', '512', '514', '530', '532')
-            'iso-27002' = @('9', '10')
-        }
+        # No exceptions: when this fails on a registry sync, add the missing
+        # label to the framework JSON rather than weakening the assertion.
+        # Note: iso-27002.json labels groups 9/10 ("Performance Evaluation",
+        # "Improvement") even though ISO 27002:2022 has no clauses 9/10 — the
+        # registry currently maps iso-27001 and iso-27002 identically (#858 /
+        # #871), so ISO 27001 management-clause ids leak into iso-27002 until
+        # the upstream CheckID/SCF divergence lands. Drop those two labels
+        # when #871 closes.
     }
 
     It 'every group key extracted from registry controlIds has a display name' {
@@ -126,7 +121,6 @@ Describe 'Framework group maps cover all registry-mapped groups (#948)' {
             $known = @($groupsMap.PSObject.Properties.Name)
 
             $registryKey = if ($fw.registryKey) { [string]$fw.registryKey } else { [string]$fw.frameworkId }
-            $allowedGaps = @($script:knownGroupGaps[$registryKey])
 
             $missing = [System.Collections.Generic.SortedSet[string]]::new()
             foreach ($check in $script:registry.checks) {
@@ -136,7 +130,7 @@ Describe 'Framework group maps cover all registry-mapped groups (#948)' {
                     $cid = $cid.Trim()
                     if (-not $cid) { continue }
                     $key = & $extract $cid
-                    if ($key -and $known -notcontains $key -and $allowedGaps -notcontains $key) {
+                    if ($key -and $known -notcontains $key) {
                         $null = $missing.Add($key)
                     }
                 }

--- a/tests/Behavior/Framework-Taxonomy.Tests.ps1
+++ b/tests/Behavior/Framework-Taxonomy.Tests.ps1
@@ -67,3 +67,82 @@ Describe 'Framework taxonomy declarations (#845)' {
         ($native + $fallback) | Should -Be $total
     }
 }
+
+# Issue #948: a groups map can exist yet still be incomplete — cis-m365-v6.json
+# shipped without keys "4" (Intune) and "9" (Fabric) while the registry mapped
+# checks into both sections, so the React FrameworkQuilt rendered the bare
+# numeric code ("4") as the group name (report-app.jsx: groupNames[code] || code).
+# This cross-checks every group key derivable from registry controlIds against
+# the framework's groups map, so a registry sync can never reintroduce an
+# unlabeled group silently.
+Describe 'Framework group maps cover all registry-mapped groups (#948)' {
+    BeforeAll {
+        $script:registry = Get-Content -Raw -Path "$PSScriptRoot/../../src/M365-Assess/controls/registry.json" | ConvertFrom-Json
+
+        # Mirror of GROUP_EXTRACTORS in assets/report-app.jsx — kept in sync by hand.
+        # If a strategy is added there, add it here or the new framework is skipped.
+        $script:groupExtractors = @{
+            'section-prefix'           = { param($cid) if ($cid -match '^(\d+)')        { $Matches[1] } }
+            'family-letter-prefix'     = { param($cid) if ($cid -match '^([A-Z]{2,3})') { $Matches[1] } }
+            'dot-prefix'               = { param($cid) if ($cid -match '^([A-Z]+)\.')   { $Matches[1] } }
+            'iso-clause-prefix'        = { param($cid) if ($cid -match '^(A\.\d+)')     { $Matches[1] } }
+            'hipaa-section'            = { param($cid) if ($cid -match '^164\.(\d+)')   { $Matches[1] } }
+            'essential-eight-practice' = { param($cid) if ($cid -match '-P(\d+)')       { $Matches[1] } }
+            'scuba-service'            = { param($cid) if ($cid -match '^(MS\.[A-Z]+)') { $Matches[1] } }
+            'soc2-tsc-prefix'          = { param($cid)
+                if ($cid.StartsWith('CC')) { 'CC' }
+                elseif ($cid.StartsWith('PI')) { 'PI' }
+                elseif ($cid -match '^([ACP])\d') { $Matches[1] }
+            }
+        }
+
+        # Pre-existing gaps that predate this test and need content decisions
+        # beyond a label (tracked separately — do NOT grow this list to silence
+        # a failure; add the missing label to the framework JSON instead):
+        #   hipaa     — the CheckID v3.4.0 sync (#912) expanded registry coverage
+        #               to the Breach Notification (404-412) and Privacy Rule
+        #               (506-532) subparts, but hipaa.json's groups map still
+        #               only labels the Security Rule sections.
+        #   iso-27002 — ISO 27002:2022 has no clauses 9/10; registry controlIds
+        #               '9.1', '10.1' look like 2013-edition ids from upstream.
+        $script:knownGroupGaps = @{
+            'hipaa'     = @('404', '408', '412', '506', '508', '510', '512', '514', '530', '532')
+            'iso-27002' = @('9', '10')
+        }
+    }
+
+    It 'every group key extracted from registry controlIds has a display name' {
+        foreach ($f in Get-ChildItem -Path $script:frameworksDir -Filter '*.json') {
+            $fw = Get-Content -Raw -Path $f.FullName | ConvertFrom-Json
+            if (-not $fw.PSObject.Properties['groupBy']) { continue }
+            $extract = $script:groupExtractors[[string]$fw.groupBy]
+            if (-not $extract) { continue }
+
+            $groupsMap = $null
+            foreach ($alias in $script:groupsAliases) {
+                if ($fw.PSObject.Properties[$alias]) { $groupsMap = $fw.$alias; break }
+            }
+            if (-not $groupsMap) { continue }
+            $known = @($groupsMap.PSObject.Properties.Name)
+
+            $registryKey = if ($fw.registryKey) { [string]$fw.registryKey } else { [string]$fw.frameworkId }
+            $allowedGaps = @($script:knownGroupGaps[$registryKey])
+
+            $missing = [System.Collections.Generic.SortedSet[string]]::new()
+            foreach ($check in $script:registry.checks) {
+                $mapping = $check.frameworks.PSObject.Properties[$registryKey]
+                if (-not $mapping -or -not $mapping.Value.controlId) { continue }
+                foreach ($cid in ([string]$mapping.Value.controlId -split '[;,]')) {
+                    $cid = $cid.Trim()
+                    if (-not $cid) { continue }
+                    $key = & $extract $cid
+                    if ($key -and $known -notcontains $key -and $allowedGaps -notcontains $key) {
+                        $null = $missing.Add($key)
+                    }
+                }
+            }
+
+            @($missing) | Should -BeNullOrEmpty -Because "$($f.Name) groups map is missing keys [$($missing -join ', ')] referenced by registry '$registryKey' controlIds — these render as raw codes in the report's framework breakdown (issue #948)"
+        }
+    }
+}


### PR DESCRIPTION
Closes #948

## Problem

Framework group maps were missing labels for groups the registry maps checks into, so the report's framework breakdown rendered the raw group code as the group name (`report-app.jsx` falls back to `groupNames[code] || code`). Originally reported for CIS M365 v6 section `4`; a systematic sweep of all 13 `groupBy` frameworks against the registry found the full set:

| File | Missing labels | Affected registry mappings |
|---|---|---|
| `cis-m365-v6.json` | `4`, `9` | `4.1`, `4.2` (Intune), `9.1.1`–`9.1.12` (Fabric / Power BI) |
| `cisa-scuba.json` | `MS.INTUNE` | `MS.INTUNE.1.1v1`–`1.3v1` |
| `hipaa.json` | `404`–`532` (10 sections) | Breach Notification + Privacy Rule mappings added by the CheckID v3.4.0 sync (#912) |
| `iso-27002.json` | `9`, `10` | ISO 27001 management-clause ids that leak in via the upstream 27001/27002 mapping conflation (#858 / #871) |

## Fix

- Add the missing labels to all four framework JSON files. The `iso-27002.json` labels for `9`/`10` mirror `iso-27001.json` ("Performance Evaluation" / "Improvement") and should be dropped once #871's upstream divergence lands — noted in a comment in the guard test.
- New regression test in `tests/Behavior/Framework-Taxonomy.Tests.ps1` cross-checks every group key derivable from registry controlIds against each framework's group map, with no exception list — a registry sync can no longer reintroduce unlabeled groups silently. Verified it fails with a clear message against the unfixed JSON and passes with the fix.

## Verification

- Framework-related suites (`tests/Behavior`, `tests/Consistency`, `tests/controls`, `Import-FrameworkDefinitions`, `Export-FrameworkCatalog`, `Build-ReportData`): 214 passed, 0 failed.
- PSScriptAnalyzer with repo settings: clean on the changed test file and the full `src` tree.
- Data-only change for the report itself — group maps are read at render time from REPORT_DATA, no JS rebuild required.

## Note for the next CheckID sync

`hipaa.json`'s `groups` block is one of the 13 files whose taxonomy keys the auto-sync strips (#914) — the new labels ride on the same manual-restoration stopgap until CheckID#407 lands upstream. `cis-m365-v6.json` and `iso-27002.json` use shapes that survive the sync.