### PR TITLE
fix(report): NaN posture score card + drop no-op License-Adjusted tab

### DIFF
--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -906,14 +906,6 @@ const computeComplianceReadinessScore = arr => {
   const ready = items.filter(f => f.status === 'Pass' || f.status === 'Review').length;
   return Math.round(ready / items.length * 100);
 };
-const computeLicenseAdjustedScore = arr => {
-  // Strips out NotLicensed entirely from BOTH numerator and denominator. SMBs
-  // without E5 don't get penalised for E5-only controls they cannot enable.
-  const items = (arr || []).filter(f => SCORED_STATUSES.has(f.status) && f.status !== 'NotLicensed');
-  if (items.length === 0) return null;
-  const pass = items.filter(f => f.status === 'Pass').length;
-  return Math.round(pass / items.length * 100);
-};
 // 3 list views (return an array of findings, sorted/filtered for the workflow):
 const getQuickWins = arr => {
   // Fail status × low effort, sorted by severity (critical > high > medium > low > none).
@@ -941,12 +933,6 @@ const SCORING_VIEWS = [{
   kind: 'score',
   compute: computeComplianceReadinessScore,
   blurb: 'Counts Review findings as ready. Auditors usually accept them with written attestation.'
-}, {
-  id: 'license-adjusted',
-  label: 'License-Adjusted',
-  kind: 'score',
-  compute: computeLicenseAdjustedScore,
-  blurb: 'Sets aside checks that require licenses the tenant does not own.'
 }, {
   id: 'quick-wins',
   label: 'Quick Wins',
@@ -1293,8 +1279,10 @@ function Briefing({
 function Posture() {
   const score = parseFloat(SCORE.Percentage);
   const avg = parseFloat(SCORE.AverageComparativeScore);
-  const delta = (score - avg).toFixed(1);
-  const deltaPos = parseFloat(delta) >= 0;
+  const scoreAvailable = Number.isFinite(score);
+  const avgAvailable = Number.isFinite(avg) && avg > 0;
+  const delta = scoreAvailable && avgAvailable ? (score - avg).toFixed(1) : null;
+  const deltaPos = delta !== null && parseFloat(delta) >= 0;
   const fail = FINDINGS.filter(f => f.status === 'Fail').length;
   const warn = FINDINGS.filter(f => f.status === 'Warning').length;
   const pass = FINDINGS.filter(f => f.status === 'Pass').length;
@@ -1308,7 +1296,7 @@ function Posture() {
   }, /*#__PURE__*/React.createElement(HideableBlock, {
     hideKey: "posture-score-card",
     label: "Microsoft Secure Score card"
-  }, /*#__PURE__*/React.createElement("div", {
+  }, scoreAvailable ? /*#__PURE__*/React.createElement("div", {
     className: "score-card"
   }, /*#__PURE__*/React.createElement("div", {
     className: "score-eyebrow"
@@ -1318,17 +1306,17 @@ function Posture() {
     className: "score-num"
   }, score.toFixed(1)), /*#__PURE__*/React.createElement("span", {
     className: "score-denom"
-  }, "/ 100%"), /*#__PURE__*/React.createElement("span", {
+  }, "/ 100%"), delta !== null && /*#__PURE__*/React.createElement("span", {
     className: 'score-delta ' + (deltaPos ? '' : 'neg')
-  }, deltaPos ? '▲' : '▼', " ", Math.abs(delta), " pts vs peers")), /*#__PURE__*/React.createElement("div", {
+  }, deltaPos ? '▲' : '▼', " ", Math.abs(parseFloat(delta)), " pts vs peers")), /*#__PURE__*/React.createElement("div", {
     className: "score-label"
-  }, fmt(SCORE.CurrentScore), " of ", fmt(SCORE.MaxScore), " points achieved. Peer average is ", avg.toFixed(1), "%."), /*#__PURE__*/React.createElement("div", {
+  }, fmt(SCORE.CurrentScore), " of ", fmt(SCORE.MaxScore), " points achieved.", avgAvailable && ` Peer average is ${avg.toFixed(1)}%.`), /*#__PURE__*/React.createElement("div", {
     className: "score-bar"
   }, /*#__PURE__*/React.createElement("span", {
     style: {
       width: score + '%'
     }
-  }), /*#__PURE__*/React.createElement("div", {
+  }), avgAvailable && /*#__PURE__*/React.createElement("div", {
     className: "bench",
     style: {
       left: avg + '%'
@@ -1336,7 +1324,7 @@ function Posture() {
     title: `Peer avg ${avg}%`
   })), /*#__PURE__*/React.createElement("div", {
     className: "score-footnote"
-  }, /*#__PURE__*/React.createElement("span", null, "0"), /*#__PURE__*/React.createElement("span", null, "Peer avg \xB7 ", avg.toFixed(1), "%"), /*#__PURE__*/React.createElement("span", null, "100")), /*#__PURE__*/React.createElement(Sparkline, {
+  }, /*#__PURE__*/React.createElement("span", null, "0"), avgAvailable && /*#__PURE__*/React.createElement("span", null, "Peer avg \xB7 ", avg.toFixed(1), "%"), /*#__PURE__*/React.createElement("span", null, "100")), /*#__PURE__*/React.createElement(Sparkline, {
     scores: D.score,
     avg: avg
   }), SCORE.MicrosoftScore != null && SCORE.CustomerScore != null && SCORE.MicrosoftScore > 0 && /*#__PURE__*/React.createElement("div", {
@@ -1355,7 +1343,13 @@ function Posture() {
     className: "score-split-value"
   }, fmt(SCORE.CustomerScore), " pts"))), /*#__PURE__*/React.createElement("div", {
     className: "score-disclaimer"
-  }, "Microsoft refreshes Secure Score on a delay \u2014 recent configuration changes can take up to 24 hours to reflect. The score above reflects Microsoft's last published value at assessment time, not the live tenant state."))), /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("div", {
+  }, "Microsoft refreshes Secure Score on a delay \u2014 recent configuration changes can take up to 24 hours to reflect. The score above reflects Microsoft's last published value at assessment time, not the live tenant state.")) : /*#__PURE__*/React.createElement("div", {
+    className: "score-card score-card--unavailable"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "score-eyebrow"
+  }, "Microsoft Secure Score"), /*#__PURE__*/React.createElement("div", {
+    className: "score-unavailable"
+  }, "Secure Score unavailable for this run. The SecurityEvents.Read.All permission may not have been granted at collection time."))), /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("div", {
     className: "kpi-strip",
     style: {
       marginBottom: 10

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -529,14 +529,6 @@ const computeComplianceReadinessScore = arr => {
   const ready = items.filter(f => f.status === 'Pass' || f.status === 'Review').length;
   return Math.round((ready / items.length) * 100);
 };
-const computeLicenseAdjustedScore = arr => {
-  // Strips out NotLicensed entirely from BOTH numerator and denominator. SMBs
-  // without E5 don't get penalised for E5-only controls they cannot enable.
-  const items = (arr || []).filter(f => SCORED_STATUSES.has(f.status) && f.status !== 'NotLicensed');
-  if (items.length === 0) return null;
-  const pass = items.filter(f => f.status === 'Pass').length;
-  return Math.round((pass / items.length) * 100);
-};
 // 3 list views (return an array of findings, sorted/filtered for the workflow):
 const getQuickWins = arr => {
   // Fail status × low effort, sorted by severity (critical > high > medium > low > none).
@@ -553,9 +545,7 @@ const SCORING_VIEWS = [
     blurb: 'The strict rule: passes divided by everything that could pass or fail. Matches the headline score.' },
   { id: 'compliance',        label: 'Compliance Readiness',    kind: 'score', compute: computeComplianceReadinessScore,
     blurb: 'Counts Review findings as ready. Auditors usually accept them with written attestation.' },
-  { id: 'license-adjusted',  label: 'License-Adjusted',        kind: 'score', compute: computeLicenseAdjustedScore,
-    blurb: 'Sets aside checks that require licenses the tenant does not own.' },
-  { id: 'quick-wins',        label: 'Quick Wins',              kind: 'list',  collect: getQuickWins,
+{ id: 'quick-wins',        label: 'Quick Wins',              kind: 'list',  collect: getQuickWins,
     blurb: 'Failing checks that take little effort to fix. The fastest score improvements.' },
   { id: 'requires-licensing',label: 'Requires Licensing',      kind: 'list',  collect: getRequiresLicensing,
     blurb: 'Checks that cannot be enabled on current licensing. Input for a license upgrade conversation.' },
@@ -826,8 +816,10 @@ function Briefing({ onViewFinding, onShowCritical, onShowQuickWins }) {
 function Posture() {
   const score = parseFloat(SCORE.Percentage);
   const avg = parseFloat(SCORE.AverageComparativeScore);
-  const delta = (score - avg).toFixed(1);
-  const deltaPos = parseFloat(delta) >= 0;
+  const scoreAvailable = Number.isFinite(score);
+  const avgAvailable = Number.isFinite(avg) && avg > 0;
+  const delta = scoreAvailable && avgAvailable ? (score - avg).toFixed(1) : null;
+  const deltaPos = delta !== null && parseFloat(delta) >= 0;
 
   const fail = FINDINGS.filter(f=>f.status==='Fail').length;
   const warn = FINDINGS.filter(f=>f.status==='Warning').length;
@@ -839,26 +831,29 @@ function Posture() {
     <section className="block" id="posture">
       <div className="posture-grid">
         <HideableBlock hideKey="posture-score-card" label="Microsoft Secure Score card">
+        {scoreAvailable ? (
         <div className="score-card">
           <div className="score-eyebrow">Microsoft Secure Score</div>
           <div className="score-headline">
             <span className="score-num">{score.toFixed(1)}</span>
             <span className="score-denom">/ 100%</span>
-            <span className={'score-delta ' + (deltaPos?'':'neg')}>
-              {deltaPos?'▲':'▼'} {Math.abs(delta)} pts vs peers
-            </span>
+            {delta !== null && (
+              <span className={'score-delta ' + (deltaPos?'':'neg')}>
+                {deltaPos?'▲':'▼'} {Math.abs(parseFloat(delta))} pts vs peers
+              </span>
+            )}
           </div>
           <div className="score-label">
             {fmt(SCORE.CurrentScore)} of {fmt(SCORE.MaxScore)} points achieved.
-            Peer average is {avg.toFixed(1)}%.
+            {avgAvailable && ` Peer average is ${avg.toFixed(1)}%.`}
           </div>
           <div className="score-bar">
             <span style={{width: score + '%'}} />
-            <div className="bench" style={{left: avg + '%'}} title={`Peer avg ${avg}%`} />
+            {avgAvailable && <div className="bench" style={{left: avg + '%'}} title={`Peer avg ${avg}%`} />}
           </div>
           <div className="score-footnote">
             <span>0</span>
-            <span>Peer avg · {avg.toFixed(1)}%</span>
+            {avgAvailable && <span>Peer avg · {avg.toFixed(1)}%</span>}
             <span>100</span>
           </div>
           <Sparkline scores={D.score} avg={avg} />
@@ -878,6 +873,12 @@ function Posture() {
             Microsoft refreshes Secure Score on a delay — recent configuration changes can take up to 24 hours to reflect. The score above reflects Microsoft's last published value at assessment time, not the live tenant state.
           </div>
         </div>
+        ) : (
+        <div className="score-card score-card--unavailable">
+          <div className="score-eyebrow">Microsoft Secure Score</div>
+          <div className="score-unavailable">Secure Score unavailable for this run. The SecurityEvents.Read.All permission may not have been granted at collection time.</div>
+        </div>
+        )}
         </HideableBlock>
 
         <div>

--- a/tests/Behavior/Report-Math.Tests.ps1
+++ b/tests/Behavior/Report-Math.Tests.ps1
@@ -59,3 +59,21 @@ Describe 'Report math denominator (C5 #784, #802 enforcement)' {
         }
     }
 }
+
+Describe 'Report data contract — Secure Score absent (#967)' {
+
+    Context 'when SectionData contains no score rows' {
+        It 'should emit score as an empty array so the React guard can safely skip the card' {
+            # Posture() in report-app.jsx does D.score[0] || {} then parseFloat(SCORE.Percentage).
+            # When score is absent (SecurityEvents.Read.All not granted), the PS layer must
+            # emit score:[] -- an empty array, not null or undefined -- so the JSX
+            # Number.isFinite guard can branch correctly without a runtime error.
+            $json = Build-ReportDataJson -AllFindings @()
+            $stripped = $json -replace '^window\.REPORT_DATA = ', '' -replace ';$', ''
+            $data = $stripped | ConvertFrom-Json
+
+            $data.PSObject.Properties.Name | Should -Contain 'score'
+            @($data.score).Count | Should -Be 0
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Closes #967 — `Posture()` now guards `score` and `avg` with `Number.isFinite` before calling `.toFixed()`. When Secure Score data is absent (`SecurityEvents.Read.All` not granted), the card renders an _'unavailable'_ message instead of raw `NaN` values. Peer-average elements (delta chip, benchmark line, footnote) are individually guarded on `avgAvailable` so a valid score with no comparative data still renders cleanly.
- Closes #966 — `computeLicenseAdjustedScore` was dead code: `SCORED_STATUSES` never contains `NotLicensed`, so the `&& status !== 'NotLicensed'` filter was always a no-op and the tab was identical to Security Risk. The function and tab entry are removed. Redesign tracked in #976.
- Data contract test added to `Report-Math.Tests.ps1`: asserts `Build-ReportDataJson` emits `score` as an empty array (not null) when no Secure Score data is provided.

## Test plan

- [ ] Run `Invoke-Pester -Path './tests/Behavior/Report-Math.Tests.ps1'` — all 3 tests pass
- [ ] Run `npm run build` — clean compile, no diff between `.jsx` intent and `.js` output
- [ ] Manually verify live report: Posture score card renders correctly with data present
- [ ] Verify live report on a tenant where Secure Score data was unavailable: card shows the unavailable message (no NaN)
- [ ] Verify Scoring Views shows 2 score tabs (Security Risk, Compliance Readiness) instead of 3