### PR TITLE
fix(gcchigh): Teams beta-endpoint gaps emit Skipped instead of silent omit

### DIFF
--- a/docs/research/review-status-audit.md
+++ b/docs/research/review-status-audit.md
@@ -14,7 +14,7 @@ Get-ChildItem -Path 'src/M365-Assess' -Recurse -Filter '*.ps1' |
 | Status | Emissions | What it should mean |
 |---|---|---|
 | `Review` | 69 | Data was collected but a human needs to interpret the result. |
-| `Skipped` | 29 | The check did not run (license-gated, permission-gated, or env-not-applicable). |
+| `Skipped` | 31 | The check did not run (license-gated, permission-gated, or env-not-applicable). |
 | `Unknown` | 1 | Data could not be collected; this is different from "Skipped". |
 | **Total** | **98** | |
 
@@ -57,6 +57,7 @@ For each emission site, the question is one of three things:
 - **EXO checks that depend on Connect-ExchangeOnline** — when EXO module isn't connected, checks Skip. Correct.
 - **ENTRA-SSPR-001** (#878, fixed this PR) — the legacy "Self service password reset enabled" toggle (None / Selected / All) lives in the Entra admin center under Password reset > Properties and is **not exposed by Microsoft Graph** as of the 2026-04 audit. The previous collector read `authenticationMethodsRegistrationCampaign` (the MFA Registration Campaign — a different control) and labeled it as SSPR. Now correctly emits Review with a manual-verify instruction.
 - **FORMS-CONFIG-001 Skipped emission** (#941, ceiling 28 -> 29) — the `/beta/admin/forms/settings` Graph endpoint that the Forms collector reads is beta-only (no v1.0 endpoint exists) and is not served in GCC High / sovereign clouds, where it returns BadRequest. The collector now emits Skipped naming the cloud, surfaced in the report's not-assessed group. Genuine limitation: there is no correct call to substitute on these tenants.
+- **Teams client-config + meeting-policy Skipped emissions** (#940, ceiling 29 -> 31) — `/beta/teamwork/teamsClientConfiguration` (6 checks: TEAMS-EXTACCESS-001/002/003/004, TEAMS-CLIENT-001/002) and `/beta/teamwork/teamsMeetingPolicy` (9 checks: TEAMS-MEETING-001..009) are beta-only with no v1.0 equivalent (confirmed against Microsoft's Graph v1.0 Teams API reference) and 400 in sovereign clouds. The collector now emits Skipped for the 15 dependent checks via two data-driven loops (so +2 static emissions, not +15) instead of WARN-and-omit. Genuine limitation; the underlying data is only reachable via the MicrosoftTeams PS module (Get-CsTeamsClientConfiguration / Get-CsTeamsMeetingPolicy), a separate dependency out of scope here.
 
 ### Triage pending (representative — not exhaustive)
 
@@ -66,7 +67,7 @@ For each emission site, the question is one of three things:
 
 ## Lock-down regression
 
-`tests/Behavior/Status-Emission-Audit.Tests.ps1` asserts the count of Review / Unknown / Skipped emissions stays at or below the current ceiling (69 / 29 / 1 = 99 total). When a new emission is added the test fails, forcing the contributor to:
+`tests/Behavior/Status-Emission-Audit.Tests.ps1` asserts the count of Review / Unknown / Skipped emissions stays at or below the current ceiling (69 / 31 / 1 = 101 total). When a new emission is added the test fails, forcing the contributor to:
 
 1. Justify the new emission (genuine limitation? collector bug?)
 2. Update this doc to add the new site to the audit catalogue

--- a/src/M365-Assess/Collaboration/Get-TeamsSecurityConfig.ps1
+++ b/src/M365-Assess/Collaboration/Get-TeamsSecurityConfig.ps1
@@ -239,6 +239,30 @@ try {
 }
 catch {
     Write-Warning "Teams client configuration endpoint unavailable: $($_.Exception.Message)"
+    # The /beta/teamwork/teamsClientConfiguration endpoint is beta-only with no v1.0
+    # equivalent and is not served in sovereign clouds (GCC High/DoD), where it 400s.
+    # Emit Skipped for the dependent checks so they surface in the report's
+    # not-assessed group instead of silently vanishing (#940).
+    $clientConfigGapChecks = @(
+        @{ CheckId = 'TEAMS-EXTACCESS-001'; Category = 'External Access';      Setting = 'Communication with Unmanaged Teams Users' }
+        @{ CheckId = 'TEAMS-EXTACCESS-002'; Category = 'External Access';      Setting = 'External Unmanaged Users Can Initiate Conversations' }
+        @{ CheckId = 'TEAMS-CLIENT-001';    Category = 'Client Configuration'; Setting = 'Third-Party Cloud Storage' }
+        @{ CheckId = 'TEAMS-CLIENT-002';    Category = 'Client Configuration'; Setting = 'Email Into Channel' }
+        @{ CheckId = 'TEAMS-EXTACCESS-003'; Category = 'External Access';      Setting = 'External Domain Access' }
+        @{ CheckId = 'TEAMS-EXTACCESS-004'; Category = 'External Access';      Setting = 'Skype for Business/Consumer Interop' }
+    )
+    foreach ($gap in $clientConfigGapChecks) {
+        $skipParams = @{
+            Category         = $gap.Category
+            Setting          = $gap.Setting
+            CurrentValue     = 'Not assessed'
+            RecommendedValue = 'n/a'
+            Status           = 'Skipped'
+            CheckId          = $gap.CheckId
+            Remediation      = 'The Teams client configuration endpoint (/beta/teamwork/teamsClientConfiguration) is not available in this cloud environment. Sovereign clouds (GCC High/DoD) do not serve it and there is no v1.0 equivalent. Verify manually in Teams admin center > Users > External access.'
+        }
+        Add-Setting @skipParams
+    }
 }
 
 # ------------------------------------------------------------------
@@ -376,6 +400,32 @@ try {
 }
 catch {
     Write-Warning "Teams meeting policy endpoint unavailable: $($_.Exception.Message)"
+    # /beta/teamwork/teamsMeetingPolicy is beta-only with no v1.0 equivalent and is
+    # not served in sovereign clouds (GCC High/DoD), where it 400s. Emit Skipped for
+    # the dependent checks so they surface in the report's not-assessed group (#940).
+    $meetingPolicyGapChecks = @(
+        @{ CheckId = 'TEAMS-MEETING-001'; Setting = 'Anonymous Users Can Join Meeting' }
+        @{ CheckId = 'TEAMS-MEETING-002'; Setting = 'Anonymous Users Can Start Meeting' }
+        @{ CheckId = 'TEAMS-MEETING-003'; Setting = 'Auto-Admitted Users (Lobby Bypass)' }
+        @{ CheckId = 'TEAMS-MEETING-004'; Setting = 'Dial-in Users Bypass Lobby' }
+        @{ CheckId = 'TEAMS-MEETING-005'; Setting = 'External Participants Can Give/Request Control' }
+        @{ CheckId = 'TEAMS-MEETING-006'; Setting = 'Meeting Chat for Anonymous Users' }
+        @{ CheckId = 'TEAMS-MEETING-007'; Setting = 'Default Presenter Role' }
+        @{ CheckId = 'TEAMS-MEETING-008'; Setting = 'External Meeting Chat (Non-Trusted)' }
+        @{ CheckId = 'TEAMS-MEETING-009'; Setting = 'Cloud Recording' }
+    )
+    foreach ($gap in $meetingPolicyGapChecks) {
+        $skipParams = @{
+            Category         = 'Meeting Policy'
+            Setting          = $gap.Setting
+            CurrentValue     = 'Not assessed'
+            RecommendedValue = 'n/a'
+            Status           = 'Skipped'
+            CheckId          = $gap.CheckId
+            Remediation      = 'The Teams meeting policy endpoint (/beta/teamwork/teamsMeetingPolicy) is not available in this cloud environment. Sovereign clouds (GCC High/DoD) do not serve it and there is no v1.0 equivalent. Verify manually in Teams admin center > Meetings > Meeting policies.'
+        }
+        Add-Setting @skipParams
+    }
 }
 
 # ------------------------------------------------------------------

--- a/tests/Behavior/Status-Emission-Audit.Tests.ps1
+++ b/tests/Behavior/Status-Emission-Audit.Tests.ps1
@@ -51,9 +51,9 @@ Describe 'Review/Unknown/Skipped emission count lock-down (#884)' {
             Should -BeLessOrEqual 69 -Because 'a new Review emission was added without updating docs/research/review-status-audit.md — see issue #884'
     }
 
-    It "Skipped emissions stay at or below the audited ceiling (29)" {
+    It "Skipped emissions stay at or below the audited ceiling (31)" {
         $script:counts.Skipped |
-            Should -BeLessOrEqual 29 -Because 'a new Skipped emission was added without updating docs/research/review-status-audit.md — see issue #884'
+            Should -BeLessOrEqual 31 -Because 'a new Skipped emission was added without updating docs/research/review-status-audit.md — see issue #884'
     }
 
     It "Unknown emissions stay at or below the audited ceiling (1)" {
@@ -63,7 +63,7 @@ Describe 'Review/Unknown/Skipped emission count lock-down (#884)' {
 
     It 'reports current emission counts for visibility (informational)' {
         Write-Host ("    [INFO] Review:  $($script:counts.Review) / 69")
-        Write-Host ("    [INFO] Skipped: $($script:counts.Skipped) / 29")
+        Write-Host ("    [INFO] Skipped: $($script:counts.Skipped) / 31")
         Write-Host ("    [INFO] Unknown: $($script:counts.Unknown) / 1")
         Write-Host ("    [INFO] Total:   $($script:emissions.Count)")
         $script:emissions.Count | Should -BeGreaterThan 0

--- a/tests/Collaboration/Get-TeamsSecurityConfig.Tests.ps1
+++ b/tests/Collaboration/Get-TeamsSecurityConfig.Tests.ps1
@@ -184,6 +184,73 @@ Describe 'Get-TeamsSecurityConfig' {
     }
 }
 
+Describe 'Get-TeamsSecurityConfig - sovereign-cloud endpoint gaps emit Skipped (#940)' {
+    # In GCC High the beta /teamwork/teamsClientConfiguration and
+    # /teamwork/teamsMeetingPolicy endpoints return 400 (no v1.0 equivalent exists,
+    # confirmed against Microsoft's Graph v1.0 Teams API reference). Rather than
+    # WARN-and-omit, the dependent checks must emit Skipped so they appear in the
+    # report's not-assessed group. The v1.0 endpoints (teamsAppSettings, teamwork)
+    # still return data and their checks must still run.
+    BeforeAll {
+        function global:Update-CheckProgress {
+            param($CheckId, $Setting, $Status)
+        }
+        function global:Get-MgContext {
+            return @{ TenantId = 'test-tenant-id'; AuthType = 'Delegated'; Account = 'admin@contoso.com' }
+        }
+        function global:Get-MgSubscribedSku {
+            return @(
+                @{
+                    SkuPartNumber = 'SPE_E5_USGOV_GCCHIGH'
+                    ConsumedUnits = 5
+                    ServicePlans  = @(
+                        @{ ServicePlanId = '9953b155-8aef-4c56-92f3-72b0487fce41'; ProvisioningStatus = 'Success' }
+                    )
+                }
+            )
+        }
+        Mock Invoke-MgGraphRequest {
+            param($Method, $Uri)
+            switch -Wildcard ($Uri) {
+                '*teamsClientConfiguration*' { throw 'Response status code does not indicate success: BadRequest (Bad Request).' }
+                '*teamsMeetingPolicy*'       { throw 'Response status code does not indicate success: BadRequest (Bad Request).' }
+                '*/v1.0/teamwork/teamsAppSettings' { return @{ isChatResourceSpecificConsentEnabled = $false } }
+                '*/v1.0/teamwork'                  { return @{ id = 'teamwork' } }
+                default                            { return @{ value = @() } }
+            }
+        }
+
+        . "$PSScriptRoot/../../src/M365-Assess/Orchestrator/AssessmentHelpers.ps1"
+        . "$PSScriptRoot/../../src/M365-Assess/Collaboration/Get-TeamsSecurityConfig.ps1"
+    }
+
+    It 'emits Skipped for every meeting-policy check when the endpoint 400s' {
+        $meeting = $settings | Where-Object { $_.CheckId -like 'TEAMS-MEETING-*' }
+        $meeting | Should -Not -BeNullOrEmpty
+        ($meeting | Where-Object { $_.Status -ne 'Skipped' }) | Should -BeNullOrEmpty
+    }
+
+    It 'emits Skipped for every client-configuration check when the endpoint 400s' {
+        $clientChecks = $settings | Where-Object {
+            $_.CheckId -like 'TEAMS-EXTACCESS-*' -or $_.CheckId -like 'TEAMS-CLIENT-*'
+        }
+        $clientChecks | Should -Not -BeNullOrEmpty
+        ($clientChecks | Where-Object { $_.Status -ne 'Skipped' }) | Should -BeNullOrEmpty
+    }
+
+    It 'still runs checks from v1.0 endpoints that work (teamsAppSettings -> Pass)' {
+        $apps = $settings | Where-Object { $_.CheckId -like 'TEAMS-APPS-001*' }
+        $apps | Should -Not -BeNullOrEmpty
+        $apps.Status | Should -Be 'Pass'
+    }
+
+    AfterAll {
+        Remove-Item Function:\Update-CheckProgress -ErrorAction SilentlyContinue
+        Remove-Item Function:\Get-MgContext -ErrorAction SilentlyContinue
+        Remove-Item Function:\Get-MgSubscribedSku -ErrorAction SilentlyContinue
+    }
+}
+
 Describe 'Get-TeamsSecurityConfig - App-Only Auth Early Exit' {
     BeforeAll {
         function global:Update-CheckProgress {


### PR DESCRIPTION
## Summary

Closes #940. In GCC High, `/beta/teamwork/teamsClientConfiguration` and `/beta/teamwork/teamsMeetingPolicy` return 400. Verified against Microsoft's [Graph v1.0 Teams API reference](https://learn.microsoft.com/en-us/graph/api/resources/teams-api-overview?view=graph-rest-1.0) that **neither has a v1.0 equivalent**, and the recently announced Teams-admin Graph APIs are commercial-only beta — so unlike PIM (#978), there's no correct call to substitute. This is a genuine sovereign gap, same class as Forms (#941).

## Behaviour change

Previously both catch blocks just `Write-Warning`, so the **15 dependent checks silently vanished** from the report in sovereign clouds:
- client-config (6): `TEAMS-EXTACCESS-001/002/003/004`, `TEAMS-CLIENT-001/002`
- meeting-policy (9): `TEAMS-MEETING-001..009`

Per the issue's stated expected behaviour, they now emit **`Skipped`** with a clear "not available in this cloud environment" message, so they appear in the report's not-assessed group. v1.0 checks (`teamsAppSettings`, `teamwork`) still run normally — so commercial tenants are unaffected (those endpoints return data, the catch never fires).

Implementation uses **data-driven loops**, so this is only **+2 static `Skipped` emissions** (not +15) for the #884 ceiling.

## Tests
- New Pester context mocks both beta endpoints to 400 and asserts every meeting + client-config check emits `Skipped`, while `teamsAppSettings` still produces `Pass`. (RED before, GREEN after.)
- Raised the #884 Skipped ceiling 29 → 31, documented both emissions in `review-status-audit.md` as genuine limitations.
- Full suite: **2077 pass, 0 fail**.

## Live verification
Already observed live on GCC High (2026-06-12): the two endpoints 400 and the collector degrades. After this change those 15 checks will render as Skipped rather than being absent — worth a confirming glance at the not-assessed group on the next GCC High run, but no functional risk to commercial.