### PR TITLE
docs(diagrams): refresh the 4 architecture diagrams to current code

### DIFF
--- a/docs/diagrams/checkid-data-flow.md
+++ b/docs/diagrams/checkid-data-flow.md
@@ -8,7 +8,7 @@ sequenceDiagram
 
     participant CID as CheckID Repo<br/>(Galvnyz/CheckID)
     participant GHA as GitHub Actions<br/>(sync-checkid.yml)
-    participant CTL as controls/<br/>(registry.json +<br/>14 framework JSONs)
+    participant CTL as controls/<br/>(registry.json +<br/>15 framework JSONs)
     participant ORC as Invoke-M365Assessment
     participant REG as Import-ControlRegistry
     participant FWD as Import-FrameworkDefinitions
@@ -21,14 +21,15 @@ sequenceDiagram
 
     CID->>GHA: Tag push / repository_dispatch /<br/>workflow_dispatch
     GHA->>CTL: curl registry.json from<br/>raw.githubusercontent.com/<tag>
-    GHA->>CTL: curl 14 framework JSONs<br/>(cis-m365-v6, nist-800-53-r5, ...)
+    GHA->>CTL: curl 15 framework JSONs<br/>(cis-m365-v6, nist-800-53-r5, ...)
+    GHA->>GHA: Partition to sync-scope.json<br/>(M365 collectors only; drop WIN-*/AZ-*)<br/>+ preserve local-extensions.json
     GHA->>GHA: Detect drift from local copies
     GHA-->>CTL: Create PR if changes detected
 
     note over ORC,OUT: Assessment Runtime
 
     ORC->>REG: Load controls/registry.json
-    REG->>REG: Build hashtable<br/>(307 entries keyed by CheckId)
+    REG->>REG: Build hashtable<br/>(292 entries keyed by CheckId)
     REG->>REG: Merge risk-severity.json<br/>(Critical/High/Medium/Low)
     REG->>REG: Build __cisReverseLookup<br/>(CIS control ID → CheckId)
     REG-->>ORC: Return progressRegistry
@@ -50,7 +51,7 @@ sequenceDiagram
     ORC->>RPT: Generate report from<br/>assessment folder
 
     RPT->>REG: Reload registry.json
-    RPT->>FWD: Load 14 framework JSONs<br/>(auto-discover from controls/frameworks/)
+    RPT->>FWD: Load 15 framework JSONs<br/>(auto-discover from controls/frameworks/)
     RPT->>CSV: Read all section CSVs
 
     RPT->>RPT: Enrich findings:<br/>CheckId → registry entry →<br/>framework mappings + risk severity

--- a/docs/diagrams/core-pipeline.md
+++ b/docs/diagrams/core-pipeline.md
@@ -71,17 +71,19 @@ graph TD
 
     subgraph P5["Phase 5: Report Generation"]
         direction TB
-        LoadReg["Import-ControlRegistry<br/>(registry.json → 307 checks)"]
-        LoadFw["Import-FrameworkDefinitions<br/>(14 framework JSONs)"]
+        LoadReg["Import-ControlRegistry<br/>(registry.json → 292 checks)"]
+        LoadFw["Import-FrameworkDefinitions<br/>(15 framework JSONs)"]
         GenReport["Export-AssessmentReport<br/>(React 18 inline HTML)"]
         BuildData["Build-ReportData.ps1<br/>(window.REPORT_DATA JSON)"]
         XLSX["Export-ComplianceMatrix<br/>(XLSX workbook)"]
+        Baseline["Auto-Baseline / Drift<br/>(Export-AssessmentBaseline +<br/>Compare-AssessmentBaseline)"]
         Summary["Assessment Summary CSV<br/>+ Issues Log"]
 
         LoadReg --> BuildData
         LoadFw --> BuildData
         BuildData --> GenReport
         GenReport --> XLSX
+        GenReport --> Baseline
         GenReport --> Summary
     end
 
@@ -100,8 +102,8 @@ graph TD
 
     class Wizard,ModCheck,CloudDetect,OutputSetup,LogInit phase1
     class ConnSvc,Graph,DomainResolve,DnsPrefetch,EXO,Purview,PBI phase2
-    class SectionLoop,CollectorLoop,ConnJIT,RunScript,AddSetting,Progress,ExportCsv,ScubaNote,PBINote,SecScore phase3
+    class SectionLoop,CollectorLoop,ConnJIT,RunScript,AddSetting,Progress,ExportCsv,PBINote,SecScore phase3
     class WaitJobs,DnsAuth,DnsSec phase4
-    class LoadReg,LoadFw,GenReport,BuildData,XLSX,Summary phase5
+    class LoadReg,LoadFw,GenReport,BuildData,XLSX,Baseline,Summary phase5
     class Start,Done startEnd
 ```

--- a/docs/diagrams/service-connections.md
+++ b/docs/diagrams/service-connections.md
@@ -39,7 +39,7 @@ graph TD
             CACol["Conditional Access<br/>(CA-*)"]
             EntAppCol["Enterprise Apps<br/>(ENTAPP-*)"]
             IntuneCol["Intune Security Config<br/>(INTUNE-*)"]
-            SPCol["SharePoint Security Config<br/>(SHAREPOINT-*)"]
+            SPCol["SharePoint Security Config<br/>(SPO-*)"]
             TeamsCol["Teams Security Config<br/>(TEAMS-*)"]
         end
 
@@ -82,7 +82,6 @@ graph TD
     classDef purview fill:#e0e7ff,stroke:#6366f1,color:#000
     classDef graph fill:#d1fae5,stroke:#10b981,color:#000
     classDef child fill:#fed7aa,stroke:#ea580c,color:#000
-    classDef legacy fill:#fecaca,stroke:#dc2626,color:#000
     classDef background fill:#e2e8f0,stroke:#64748b,color:#000,stroke-dasharray:5 5
     classDef conflict fill:#fee2e2,stroke:#ef4444,color:#b91c1c
     classDef info fill:#f1f5f9,stroke:#94a3b8,color:#64748b
@@ -93,6 +92,5 @@ graph TD
     class PurviewConn,PurviewCollectors,PurviewNote purview
     class EntraCol,CACol,EntAppCol,IntuneCol,SPCol,TeamsCol graph
     class PBIConn,PBICollector,PBIReason child
-    class ScubaConn,ScubaRun,ScubaReason legacy
     class DnsPrefetch,DnsJobs,DnsRecords,DnsWait background
 ```

--- a/docs/diagrams/upstream-integrations.md
+++ b/docs/diagrams/upstream-integrations.md
@@ -25,8 +25,9 @@ graph LR
 
     subgraph Controls["controls/"]
         direction TB
-        Registry["registry.json<br/>(307 checks)"]
-        Frameworks["frameworks/*.json<br/>(14 frameworks)"]
+        Registry["registry.json<br/>(292 checks)"]
+        Frameworks["frameworks/*.json<br/>(15 frameworks)"]
+        LocalExt["local-extensions.json<br/>(M365-Assess-specific checks,<br/>preserved across sync)"]
         RiskSev["risk-severity.json"]
         MITREMap["mitre-technique-map.json"]
         RoleTiers["role-tiers.json"]
@@ -49,7 +50,7 @@ graph LR
             IntuneColl["Intune<br/>(INTUNE-*)"]
             DefenderColl["Defender<br/>(DEFENDER-*)"]
             ComplianceColl["Compliance<br/>(COMPLIANCE-*)"]
-            SPColl["SharePoint<br/>(SHAREPOINT-*)"]
+            SPColl["SharePoint<br/>(SPO-*)"]
             TeamsColl["Teams<br/>(TEAMS-*)"]
         end
 
@@ -75,6 +76,7 @@ graph LR
     CheckID -->|"weekly sync +<br/>on-demand dispatch"| SyncWorkflow
     SyncWorkflow -->|"curl raw content<br/>by release tag"| Registry
     SyncWorkflow -->|"curl raw content<br/>by release tag"| Frameworks
+    LocalExt -->|"preserved + merged<br/>at sync time"| Registry
 
     %% Static data
     MITRE --> MITREMap
@@ -124,7 +126,7 @@ graph LR
 
     class CheckID,GraphAPI,EXOService,PurviewService,DNS,PSGallery,MITRE,AD external
     class CIWorkflow,SyncWorkflow,ReleaseWorkflow cicd
-    class Registry,Frameworks,RiskSev,MITREMap,RoleTiers controls
+    class Registry,Frameworks,LocalExt,RiskSev,MITREMap,RoleTiers controls
     class Orchestrator,ConnService,ImportReg,ImportFw,EntraColl,CAColl,EntAppColl,EXOColl,DNSColl,IntuneColl,DefenderColl,ComplianceColl,SPColl,TeamsColl,ExportReport,ExportOverview,ExportCatalog,ExportMatrix core
     class HTML,XLSXOut,CatalogHTML,CSVs,SummaryCSV output
     class AuthNote,CloudNote note


### PR DESCRIPTION
## Summary

Closes #918. Walked all four Mermaid diagrams in `docs/diagrams/` against `src/M365-Assess` and corrected the drift since the v2.0.0 baseline. Every change verified against the code.

### Stale facts fixed
| Was | Now | Verified by |
|---|---|---|
| registry "307 checks" (x3) | **292** | `registry.json` has 292 checks |
| "14 framework JSONs" (x5) | **15** | `controls/frameworks/` has 15 files |
| `SHAREPOINT-*` prefix (x2) | **`SPO-*`** | collector emits `SPO-SHARING-*` |
| dead `ScubaNote` / `ScubaConn,ScubaRun,ScubaReason legacy` class refs | **pruned** | nodes no longer exist (ScubaGear removed) |

### Real flows added
- **Auto-Baseline / Drift** (`Export-AssessmentBaseline` + `Compare-AssessmentBaseline`) in `core-pipeline` Phase 5
- **local-extensions.json** preserve + merge at sync time in `checkid-data-flow` and `upstream-integrations` (the #914 preservation path)

### Confirmed accurate (left as-is)
- `role-tiers.json` exists; the **9 scoring methods** count; `docs/diagrams/README.md` describes the right set.

### Follow-up
- The report-app interactivity flow (edit-mode + `REPORT_OVERRIDES` + Finalize) doesn't fit the PS-pipeline diagrams - filed as #986. Owner/Ticket model (#863) is implementation-pending, so deliberately not diagrammed yet.

Doc-only. No undefined Mermaid node references (validated).