### PR TITLE
refactor(common): centralize Add-Setting across all collectors

### DIFF
--- a/src/M365-Assess/Collaboration/Get-FormsSecurityConfig.ps1
+++ b/src/M365-Assess/Collaboration/Get-FormsSecurityConfig.ps1
@@ -46,29 +46,10 @@ $graphEnvironment = try { (Get-MgContext).Environment } catch { $null }
 $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocation.MyCommand.Path } else { $PSScriptRoot }
 . (Join-Path -Path $_scriptDir -ChildPath '..\Common\SecurityConfigHelper.ps1')
 
+# Initialize-SecurityConfig records the active context; the shared Add-Setting from
+# SecurityConfigHelper.ps1 reads it, so no local wrapper is needed (#958).
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
-
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = ''
-    )
-    $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-    }
-    Add-SecuritySetting @p
-}
 
 # ------------------------------------------------------------------
 # 1. Microsoft Forms Admin Settings (CIS 3.6.x)

--- a/src/M365-Assess/Collaboration/Get-SharePointSecurityConfig.ps1
+++ b/src/M365-Assess/Collaboration/Get-SharePointSecurityConfig.ps1
@@ -41,31 +41,10 @@ if (-not (Assert-GraphConnection)) { return }
 $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocation.MyCommand.Path } else { $PSScriptRoot }
 . (Join-Path -Path $_scriptDir -ChildPath '..\Common\SecurityConfigHelper.ps1')
 
+# Initialize-SecurityConfig records the active context; the shared Add-Setting from
+# SecurityConfigHelper.ps1 reads it, so no local wrapper is needed (#958).
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
-
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = '',
-        [PSCustomObject]$Evidence = $null
-    )
-    $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-        Evidence         = $Evidence
-    }
-    Add-SecuritySetting @p
-}
 
 # ------------------------------------------------------------------
 # Retrieve SharePoint tenant settings

--- a/src/M365-Assess/Collaboration/Get-TeamsSecurityConfig.ps1
+++ b/src/M365-Assess/Collaboration/Get-TeamsSecurityConfig.ps1
@@ -85,29 +85,10 @@ catch {
 $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocation.MyCommand.Path } else { $PSScriptRoot }
 . (Join-Path -Path $_scriptDir -ChildPath '..\Common\SecurityConfigHelper.ps1')
 
+# Initialize-SecurityConfig records the active context; the shared Add-Setting from
+# SecurityConfigHelper.ps1 reads it, so no local wrapper is needed (#958).
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
-
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = ''
-    )
-    $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-    }
-    Add-SecuritySetting @p
-}
 
 # ------------------------------------------------------------------
 # 1. Teams Client Configuration (external access)

--- a/src/M365-Assess/Common/SecurityConfigHelper.ps1
+++ b/src/M365-Assess/Common/SecurityConfigHelper.ps1
@@ -30,10 +30,92 @@ function Initialize-SecurityConfig {
     param()
 
     if (-not $global:AdoptionSignals) { $global:AdoptionSignals = @{} }
-    @{
+    $ctx = @{
         Settings       = [System.Collections.Generic.List[PSCustomObject]]::new()
         CheckIdCounter = @{}
     }
+    # #958 -- record the active context so the shared Add-Setting wrapper can find
+    # Settings + CheckIdCounter without each collector redefining a local wrapper.
+    # Dot-sourced per collector, so $script: is the collector's own scope and each
+    # Initialize-SecurityConfig call resets it; sequential collectors stay isolated.
+    $script:ActiveSecurityConfig = $ctx
+    $ctx
+}
+
+function Add-Setting {
+    <#
+    .SYNOPSIS
+        Adds a finding to the active collector context (#958).
+    .DESCRIPTION
+        Canonical replacement for the ~60 per-collector local Add-Setting wrappers.
+        Pulls Settings + CheckIdCounter from the script-scoped active context that
+        Initialize-SecurityConfig records, then forwards every other argument to
+        Add-SecuritySetting. Call Initialize-SecurityConfig first.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Category,
+
+        [Parameter(Mandatory)]
+        [string]$Setting,
+
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$CurrentValue,
+
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$RecommendedValue,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('Pass', 'Fail', 'Warning', 'Review', 'Info', 'Skipped', 'Unknown', 'NotApplicable', 'NotLicensed')]
+        [string]$Status,
+
+        [Parameter()]
+        [string]$CheckId = '',
+
+        [Parameter()]
+        [string]$Remediation = '',
+
+        [Parameter()]
+        [switch]$IntentDesign,
+
+        [Parameter()]
+        [PSCustomObject]$Evidence = $null,
+
+        [Parameter()]
+        [string]$ObservedValue = '',
+
+        [Parameter()]
+        [string]$ExpectedValue = '',
+
+        [Parameter()]
+        [string]$EvidenceSource = '',
+
+        [Parameter()]
+        [string]$EvidenceTimestamp = '',
+
+        [Parameter()]
+        [ValidateSet('', 'Direct', 'Derived', 'Inferred')]
+        [string]$CollectionMethod = '',
+
+        [Parameter()]
+        [string]$PermissionRequired = '',
+
+        [Parameter()]
+        [Nullable[double]]$Confidence = $null,
+
+        [Parameter()]
+        [string]$Limitations = ''
+    )
+
+    if (-not $script:ActiveSecurityConfig) {
+        throw "Add-Setting was called before Initialize-SecurityConfig. Each collector must call Initialize-SecurityConfig before adding settings."
+    }
+
+    Add-SecuritySetting -Settings $script:ActiveSecurityConfig.Settings `
+        -CheckIdCounter $script:ActiveSecurityConfig.CheckIdCounter @PSBoundParameters
 }
 
 function Add-SecuritySetting {

--- a/src/M365-Assess/Entra/Get-CASecurityConfig.ps1
+++ b/src/M365-Assess/Entra/Get-CASecurityConfig.ps1
@@ -39,47 +39,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = '',
-        [PSCustomObject]$Evidence = $null,
-        # D1 #785 -- structured evidence schema
-        [string]$ObservedValue = '',
-        [string]$ExpectedValue = '',
-        [string]$EvidenceSource = '',
-        [string]$EvidenceTimestamp = '',
-        [ValidateSet('', 'Direct', 'Derived', 'Inferred')]
-        [string]$CollectionMethod = '',
-        [string]$PermissionRequired = '',
-        [Nullable[double]]$Confidence = $null,
-        [string]$Limitations = ''
-    )
-    $p = @{
-        Settings           = $settings
-        CheckIdCounter     = $checkIdCounter
-        Category           = $Category
-        Setting            = $Setting
-        CurrentValue       = $CurrentValue
-        RecommendedValue   = $RecommendedValue
-        Status             = $Status
-        CheckId            = $CheckId
-        Remediation        = $Remediation
-        Evidence           = $Evidence
-        ObservedValue      = $ObservedValue
-        ExpectedValue      = $ExpectedValue
-        EvidenceSource     = $EvidenceSource
-        EvidenceTimestamp  = $EvidenceTimestamp
-        CollectionMethod   = $CollectionMethod
-        PermissionRequired = $PermissionRequired
-        Confidence         = $Confidence
-        Limitations        = $Limitations
-    }
-    Add-SecuritySetting @p
-}
 
 # ------------------------------------------------------------------
 # Check Security Defaults status

--- a/src/M365-Assess/Entra/Get-EntAppSecurityConfig.ps1
+++ b/src/M365-Assess/Entra/Get-EntAppSecurityConfig.ps1
@@ -46,29 +46,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = '',
-        [PSCustomObject]$Evidence = $null
-    )
-    $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-        Evidence         = $Evidence
-    }
-    Add-SecuritySetting @p
-}
 
 # ------------------------------------------------------------------
 # Dangerous permissions -- loaded from tiered classification file

--- a/src/M365-Assess/Entra/Get-EntraAdminRoleSeparationConfig.ps1
+++ b/src/M365-Assess/Entra/Get-EntraAdminRoleSeparationConfig.ps1
@@ -40,27 +40,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = ''
-    )
-    $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-    }
-    Add-SecuritySetting @p
-}
 
 # ------------------------------------------------------------------
 # Well-known role template IDs for high-privilege roles

--- a/src/M365-Assess/Entra/Get-EntraCaRemoteDevicePolicy.ps1
+++ b/src/M365-Assess/Entra/Get-EntraCaRemoteDevicePolicy.ps1
@@ -38,27 +38,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = ''
-    )
-    $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-    }
-    Add-SecuritySetting @p
-}
 
 # ------------------------------------------------------------------
 # 1. Check CA policies for compliant device enforcement on remote access

--- a/src/M365-Assess/Entra/Get-EntraPrivRemoteConfig.ps1
+++ b/src/M365-Assess/Entra/Get-EntraPrivRemoteConfig.ps1
@@ -40,27 +40,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = ''
-    )
-    $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-    }
-    Add-SecuritySetting @p
-}
 
 # ------------------------------------------------------------------
 # Well-known role template IDs for critical roles

--- a/src/M365-Assess/Entra/Get-EntraSecurityConfig.ps1
+++ b/src/M365-Assess/Entra/Get-EntraSecurityConfig.ps1
@@ -50,31 +50,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue,
-        [ValidateSet('Pass', 'Fail', 'Warning', 'Review', 'Info', 'Skipped', 'Unknown')]
-        [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = '',
-        [PSCustomObject]$Evidence = $null
-    )
-    $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-        Evidence         = $Evidence
-    }
-    Add-SecuritySetting @p
-}
 
 # ------------------------------------------------------------------
 # Shared data queries used by multiple helper files

--- a/src/M365-Assess/Entra/Get-EntraSoDConfig.ps1
+++ b/src/M365-Assess/Entra/Get-EntraSoDConfig.ps1
@@ -38,27 +38,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = ''
-    )
-    $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-    }
-    Add-SecuritySetting @p
-}
 
 # ------------------------------------------------------------------
 # Well-known role template IDs

--- a/src/M365-Assess/Entra/Get-EntraTouConfig.ps1
+++ b/src/M365-Assess/Entra/Get-EntraTouConfig.ps1
@@ -36,27 +36,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = ''
-    )
-    $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-    }
-    Add-SecuritySetting @p
-}
 
 # ------------------------------------------------------------------
 # 1. Check for Terms of Use agreements

--- a/src/M365-Assess/Exchange-Online/Get-DnsSecurityConfig.ps1
+++ b/src/M365-Assess/Exchange-Online/Get-DnsSecurityConfig.ps1
@@ -55,27 +55,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = ''
-    )
-    $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-    }
-    Add-SecuritySetting @p
-}
 
 # ------------------------------------------------------------------
 # Fetch authoritative domains

--- a/src/M365-Assess/Exchange-Online/Get-ExoSecurityConfig.ps1
+++ b/src/M365-Assess/Exchange-Online/Get-ExoSecurityConfig.ps1
@@ -36,49 +36,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue,
-        [ValidateSet('Pass', 'Fail', 'Warning', 'Review', 'Info', 'Skipped', 'Unknown')]
-        [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = '',
-        [PSCustomObject]$Evidence = $null,
-        # D1 #785 -- structured evidence schema
-        [string]$ObservedValue = '',
-        [string]$ExpectedValue = '',
-        [string]$EvidenceSource = '',
-        [string]$EvidenceTimestamp = '',
-        [ValidateSet('', 'Direct', 'Derived', 'Inferred')]
-        [string]$CollectionMethod = '',
-        [string]$PermissionRequired = '',
-        [Nullable[double]]$Confidence = $null,
-        [string]$Limitations = ''
-    )
-    $p = @{
-        Settings           = $settings
-        CheckIdCounter     = $checkIdCounter
-        Category           = $Category
-        Setting            = $Setting
-        CurrentValue       = $CurrentValue
-        RecommendedValue   = $RecommendedValue
-        Status             = $Status
-        CheckId            = $CheckId
-        Remediation        = $Remediation
-        Evidence           = $Evidence
-        ObservedValue      = $ObservedValue
-        ExpectedValue      = $ExpectedValue
-        EvidenceSource     = $EvidenceSource
-        EvidenceTimestamp  = $EvidenceTimestamp
-        CollectionMethod   = $CollectionMethod
-        PermissionRequired = $PermissionRequired
-        Confidence         = $Confidence
-        Limitations        = $Limitations
-    }
-    Add-SecuritySetting @p
-}
 
 # ------------------------------------------------------------------
 # 1. Organization Config (modern auth, audit, customer lockbox)

--- a/src/M365-Assess/Intune/Get-IntuneAlwaysOnVpnConfig.ps1
+++ b/src/M365-Assess/Intune/Get-IntuneAlwaysOnVpnConfig.ps1
@@ -39,27 +39,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = ''
-    )
-    $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-    }
-    Add-SecuritySetting @p
-}
 
 # ------------------------------------------------------------------
 # 1. Check VPN device configuration profiles for always-on full tunnel

--- a/src/M365-Assess/Intune/Get-IntuneAppControlConfig.ps1
+++ b/src/M365-Assess/Intune/Get-IntuneAppControlConfig.ps1
@@ -40,27 +40,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = ''
-    )
-    $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-    }
-    Add-SecuritySetting @p
-}
 
 $remediationText = 'Intune admin center > Devices > Configuration > Create profile > Endpoint protection > Windows Defender Application Control. Alternatively, deploy WDAC via custom OMA-URI.'
 

--- a/src/M365-Assess/Intune/Get-IntuneAutoDiscConfig.ps1
+++ b/src/M365-Assess/Intune/Get-IntuneAutoDiscConfig.ps1
@@ -39,27 +39,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = ''
-    )
-    $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-    }
-    Add-SecuritySetting @p
-}
 
 $remediationText = 'Configure Intune automatic enrollment: Entra admin center > Mobility (MDM and WIP) > Microsoft Intune > MDM user scope: All or Some. Consider configuring Windows Autopilot for zero-touch provisioning.'
 

--- a/src/M365-Assess/Intune/Get-IntuneFipsConfig.ps1
+++ b/src/M365-Assess/Intune/Get-IntuneFipsConfig.ps1
@@ -41,27 +41,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = ''
-    )
-    $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-    }
-    Add-SecuritySetting @p
-}
 
 $remediationText = 'Intune admin center > Devices > Configuration > Create profile > Custom OMA-URI > Add setting: ./Device/Vendor/MSFT/Policy/Config/Cryptography/AllowFipsAlgorithmPolicy = 1.'
 

--- a/src/M365-Assess/Intune/Get-IntuneInventoryConfig.ps1
+++ b/src/M365-Assess/Intune/Get-IntuneInventoryConfig.ps1
@@ -38,27 +38,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = ''
-    )
-    $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-    }
-    Add-SecuritySetting @p
-}
 
 # ------------------------------------------------------------------
 # 1. Check managed device overview and device categories

--- a/src/M365-Assess/Intune/Get-IntuneMobileEncryptConfig.ps1
+++ b/src/M365-Assess/Intune/Get-IntuneMobileEncryptConfig.ps1
@@ -39,27 +39,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = ''
-    )
-    $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-    }
-    Add-SecuritySetting @p
-}
 
 $remediationText = 'Intune admin center > Devices > Compliance > Create/edit iOS and Android compliance policies > Require device encryption.'
 

--- a/src/M365-Assess/Intune/Get-IntunePortStorageConfig.ps1
+++ b/src/M365-Assess/Intune/Get-IntunePortStorageConfig.ps1
@@ -40,27 +40,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = ''
-    )
-    $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-    }
-    Add-SecuritySetting @p
-}
 
 $remediationText = 'Intune admin center > Devices > Configuration > Create profile > Windows 10 and later > Device restrictions > General > Removable storage: Block.'
 

--- a/src/M365-Assess/Intune/Get-IntuneRemovableMediaConfig.ps1
+++ b/src/M365-Assess/Intune/Get-IntuneRemovableMediaConfig.ps1
@@ -40,27 +40,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = ''
-    )
-    $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-    }
-    Add-SecuritySetting @p
-}
 
 $remediationText = 'Intune admin center > Devices > Configuration > Create profile > Windows 10 and later > Device restrictions > General > Removable storage: Block. Assign the profile to device or user groups.'
 

--- a/src/M365-Assess/Intune/Get-IntuneSecurityConfig.ps1
+++ b/src/M365-Assess/Intune/Get-IntuneSecurityConfig.ps1
@@ -39,45 +39,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = '',
-        # D1 #785 -- structured evidence schema
-        [string]$ObservedValue = '',
-        [string]$ExpectedValue = '',
-        [string]$EvidenceSource = '',
-        [string]$EvidenceTimestamp = '',
-        [ValidateSet('', 'Direct', 'Derived', 'Inferred')]
-        [string]$CollectionMethod = '',
-        [string]$PermissionRequired = '',
-        [Nullable[double]]$Confidence = $null,
-        [string]$Limitations = ''
-    )
-    $p = @{
-        Settings           = $settings
-        CheckIdCounter     = $checkIdCounter
-        Category           = $Category
-        Setting            = $Setting
-        CurrentValue       = $CurrentValue
-        RecommendedValue   = $RecommendedValue
-        Status             = $Status
-        CheckId            = $CheckId
-        Remediation        = $Remediation
-        ObservedValue      = $ObservedValue
-        ExpectedValue      = $ExpectedValue
-        EvidenceSource     = $EvidenceSource
-        EvidenceTimestamp  = $EvidenceTimestamp
-        CollectionMethod   = $CollectionMethod
-        PermissionRequired = $PermissionRequired
-        Confidence         = $Confidence
-        Limitations        = $Limitations
-    }
-    Add-SecuritySetting @p
-}
 
 # ------------------------------------------------------------------
 # 1. Device Compliance - Non-compliant default (CIS 4.1)

--- a/src/M365-Assess/Intune/Get-IntuneVpnSplitTunnelConfig.ps1
+++ b/src/M365-Assess/Intune/Get-IntuneVpnSplitTunnelConfig.ps1
@@ -39,27 +39,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = ''
-    )
-    $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-    }
-    Add-SecuritySetting @p
-}
 
 # ------------------------------------------------------------------
 # 1. Check VPN device configuration profiles for split tunnel disabled

--- a/src/M365-Assess/Intune/Get-IntuneWifiEapConfig.ps1
+++ b/src/M365-Assess/Intune/Get-IntuneWifiEapConfig.ps1
@@ -39,27 +39,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = ''
-    )
-    $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-    }
-    Add-SecuritySetting @p
-}
 
 # ------------------------------------------------------------------
 # 1. Check Wi-Fi configuration profiles for WPA2-Enterprise EAP-TLS

--- a/src/M365-Assess/PowerBI/Get-PowerBISecurityConfig.ps1
+++ b/src/M365-Assess/PowerBI/Get-PowerBISecurityConfig.ps1
@@ -50,27 +50,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = ''
-    )
-    $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-    }
-    Add-SecuritySetting @p
-}
 
 # ─── Retrieve all tenant settings ────────────────────────────────
 $script:settingsError = $null

--- a/src/M365-Assess/Purview/Get-PurviewRetentionConfig.ps1
+++ b/src/M365-Assess/Purview/Get-PurviewRetentionConfig.ps1
@@ -43,27 +43,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = ''
-    )
-    $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-    }
-    Add-SecuritySetting @p
-}
 
 # ------------------------------------------------------------------
 # 1. Retention Compliance Policies — existence and workload coverage

--- a/src/M365-Assess/Security/Get-ComplianceSecurityConfig.ps1
+++ b/src/M365-Assess/Security/Get-ComplianceSecurityConfig.ps1
@@ -40,27 +40,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = ''
-    )
-    $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-    }
-    Add-SecuritySetting @p
-}
 
 # ------------------------------------------------------------------
 # 1. Unified Audit Log (CIS 3.1.1)

--- a/src/M365-Assess/Security/Get-DefenderCfgDetectConfig.ps1
+++ b/src/M365-Assess/Security/Get-DefenderCfgDetectConfig.ps1
@@ -39,27 +39,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = ''
-    )
-    $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-    }
-    Add-SecuritySetting @p
-}
 
 # ------------------------------------------------------------------
 # 1. Check Secure Score control profiles for device config detection

--- a/src/M365-Assess/Security/Get-DefenderScanConfig.ps1
+++ b/src/M365-Assess/Security/Get-DefenderScanConfig.ps1
@@ -38,27 +38,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = ''
-    )
-    $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-    }
-    Add-SecuritySetting @p
-}
 
 # ------------------------------------------------------------------
 # 1. Check device configurations for Defender real-time protection

--- a/src/M365-Assess/Security/Get-DefenderSecureMonConfig.ps1
+++ b/src/M365-Assess/Security/Get-DefenderSecureMonConfig.ps1
@@ -39,27 +39,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = ''
-    )
-    $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-    }
-    Add-SecuritySetting @p
-}
 
 # ------------------------------------------------------------------
 # 1. Check Secure Score for active monitoring

--- a/src/M365-Assess/Security/Get-DefenderSecurityConfig.ps1
+++ b/src/M365-Assess/Security/Get-DefenderSecurityConfig.ps1
@@ -45,51 +45,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category,
-        [string]$Setting,
-        [string]$CurrentValue,
-        [string]$RecommendedValue,
-        [string]$Status,
-        [string]$CheckId = '',
-        [string]$Remediation = '',
-        [PSCustomObject]$Evidence = $null,
-        # D1 #785 -- structured evidence schema
-        [string]$ObservedValue = '',
-        [string]$ExpectedValue = '',
-        [string]$EvidenceSource = '',
-        [string]$EvidenceTimestamp = '',
-        [ValidateSet('', 'Direct', 'Derived', 'Inferred')]
-        [string]$CollectionMethod = '',
-        [string]$PermissionRequired = '',
-        [Nullable[double]]$Confidence = $null,
-        [string]$Limitations = ''
-    )
-    $p = @{
-        Settings           = $settings
-        CheckIdCounter     = $checkIdCounter
-        Category           = $Category
-        Setting            = $Setting
-        CurrentValue       = $CurrentValue
-        RecommendedValue   = $RecommendedValue
-        Status             = $Status
-        CheckId            = $CheckId
-        Remediation        = $Remediation
-        Evidence           = $Evidence
-        ObservedValue      = $ObservedValue
-        ExpectedValue      = $ExpectedValue
-        EvidenceSource     = $EvidenceSource
-        EvidenceTimestamp  = $EvidenceTimestamp
-        CollectionMethod   = $CollectionMethod
-        PermissionRequired = $PermissionRequired
-        Confidence         = $Confidence
-        Limitations        = $Limitations
-    }
-    Add-SecuritySetting @p
-}
 
 # ------------------------------------------------------------------
 # Helpers & preset policy detection

--- a/src/M365-Assess/Security/Get-DefenderVulnScanConfig.ps1
+++ b/src/M365-Assess/Security/Get-DefenderVulnScanConfig.ps1
@@ -38,27 +38,7 @@ $_scriptDir = if ($MyInvocation.MyCommand.Path) { Split-Path -Parent $MyInvocati
 
 $ctx = Initialize-SecurityConfig
 $settings = $ctx.Settings
-$checkIdCounter = $ctx.CheckIdCounter
 
-function Add-Setting {
-    param(
-        [string]$Category, [string]$Setting, [string]$CurrentValue,
-        [string]$RecommendedValue, [string]$Status,
-        [string]$CheckId = '', [string]$Remediation = ''
-    )
-    $p = @{
-        Settings         = $settings
-        CheckIdCounter   = $checkIdCounter
-        Category         = $Category
-        Setting          = $Setting
-        CurrentValue     = $CurrentValue
-        RecommendedValue = $RecommendedValue
-        Status           = $Status
-        CheckId          = $CheckId
-        Remediation      = $Remediation
-    }
-    Add-SecuritySetting @p
-}
 
 # ------------------------------------------------------------------
 # 1. Check Secure Score for vulnerability management indicators

--- a/tests/Behavior/AddSetting-Centralization.Tests.ps1
+++ b/tests/Behavior/AddSetting-Centralization.Tests.ps1
@@ -1,39 +1,43 @@
-BeforeDiscovery {
-    # Domain folders migrated to the shared Add-Setting (#958). This list grows one
-    # folder per PR; when every collector folder is listed and the repo-wide count
-    # hits zero, the local-wrapper pattern is fully retired. Defined at discovery
-    # time so the per-folder -ForEach below can enumerate it.
-    $migratedFolders = @(
-        'Collaboration'
-    )
-}
-
 BeforeAll {
     $script:repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
     $script:collectorRoot = Join-Path $repoRoot 'src/M365-Assess'
     $script:localWrapperPattern = '^\s*function\s+Add-Setting\b'
+
+    # Collectors that may still define a local Add-Setting, with the reason. These are
+    # NOT thin-wrapper duplicates of the shared helper, so #958's mechanical migration
+    # does not apply as-is:
+    #   Get-StrykerIncidentReadiness.ps1 - a custom wrapper with its own row shape that
+    #   does not forward to Add-SecuritySetting and lacks the evidence schema; migrating
+    #   it changes output and is tracked separately.
+    $script:wrapperExceptions = @('Get-StrykerIncidentReadiness.ps1')
+
+    $script:collectorFiles = Get-ChildItem -Path $script:collectorRoot -Recurse -Filter '*.ps1' |
+        Where-Object { $_.Directory.Name -ne 'Common' }
 }
 
 Describe 'Add-Setting centralization (#958)' {
 
     It 'exports a single canonical Add-Setting from SecurityConfigHelper.ps1' {
-        $helper = Join-Path $collectorRoot 'Common/SecurityConfigHelper.ps1'
+        $helper = Join-Path $script:collectorRoot 'Common/SecurityConfigHelper.ps1'
         $defs = @(Select-String -Path $helper -Pattern $script:localWrapperPattern)
         $defs.Count | Should -Be 1 -Because 'the shared Add-Setting must be defined exactly once in the helper'
     }
 
-    It 'has zero local Add-Setting wrappers in migrated folder <_>' -ForEach $migratedFolders {
-        $path = Join-Path $script:collectorRoot $_
-        $locals = @(Get-ChildItem -Path $path -Recurse -Filter '*.ps1' |
+    It 'has zero local Add-Setting wrappers in collectors (except documented exceptions)' {
+        $locals = @($script:collectorFiles |
+            Where-Object { $_.Name -notin $script:wrapperExceptions } |
             Select-String -Pattern $script:localWrapperPattern)
-        $locals.Count | Should -Be 0 -Because "collectors in $_ should use the shared Add-Setting, not a local wrapper"
+        $locals.Count | Should -Be 0 `
+            -Because 'collectors must use the shared Add-Setting from SecurityConfigHelper.ps1, not a local wrapper'
     }
 
-    It 'reports how many local wrappers remain across not-yet-migrated folders (informational)' {
-        $allLocals = @(Get-ChildItem -Path $script:collectorRoot -Recurse -Filter '*.ps1' |
-            Where-Object { $_.Directory.Name -ne 'Common' } |
-            Select-String -Pattern $script:localWrapperPattern)
-        Write-Host ("    [INFO] Local Add-Setting wrappers still to migrate: " + $allLocals.Count)
-        $allLocals.Count | Should -BeGreaterOrEqual 0
+    It 'every file that still defines a local wrapper is a documented exception' {
+        $remaining = @($script:collectorFiles |
+            Where-Object { (Get-Content $_.FullName -Raw) -match $script:localWrapperPattern } |
+            ForEach-Object { $_.Name })
+        foreach ($name in $remaining) {
+            $name | Should -BeIn $script:wrapperExceptions `
+                -Because "$name still has a local Add-Setting wrapper but is not listed as an intentional exception"
+        }
     }
 }

--- a/tests/Behavior/AddSetting-Centralization.Tests.ps1
+++ b/tests/Behavior/AddSetting-Centralization.Tests.ps1
@@ -1,0 +1,39 @@
+BeforeDiscovery {
+    # Domain folders migrated to the shared Add-Setting (#958). This list grows one
+    # folder per PR; when every collector folder is listed and the repo-wide count
+    # hits zero, the local-wrapper pattern is fully retired. Defined at discovery
+    # time so the per-folder -ForEach below can enumerate it.
+    $migratedFolders = @(
+        'Collaboration'
+    )
+}
+
+BeforeAll {
+    $script:repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
+    $script:collectorRoot = Join-Path $repoRoot 'src/M365-Assess'
+    $script:localWrapperPattern = '^\s*function\s+Add-Setting\b'
+}
+
+Describe 'Add-Setting centralization (#958)' {
+
+    It 'exports a single canonical Add-Setting from SecurityConfigHelper.ps1' {
+        $helper = Join-Path $collectorRoot 'Common/SecurityConfigHelper.ps1'
+        $defs = @(Select-String -Path $helper -Pattern $script:localWrapperPattern)
+        $defs.Count | Should -Be 1 -Because 'the shared Add-Setting must be defined exactly once in the helper'
+    }
+
+    It 'has zero local Add-Setting wrappers in migrated folder <_>' -ForEach $migratedFolders {
+        $path = Join-Path $script:collectorRoot $_
+        $locals = @(Get-ChildItem -Path $path -Recurse -Filter '*.ps1' |
+            Select-String -Pattern $script:localWrapperPattern)
+        $locals.Count | Should -Be 0 -Because "collectors in $_ should use the shared Add-Setting, not a local wrapper"
+    }
+
+    It 'reports how many local wrappers remain across not-yet-migrated folders (informational)' {
+        $allLocals = @(Get-ChildItem -Path $script:collectorRoot -Recurse -Filter '*.ps1' |
+            Where-Object { $_.Directory.Name -ne 'Common' } |
+            Select-String -Pattern $script:localWrapperPattern)
+        Write-Host ("    [INFO] Local Add-Setting wrappers still to migrate: " + $allLocals.Count)
+        $allLocals.Count | Should -BeGreaterOrEqual 0
+    }
+}

--- a/tests/Common/SecurityConfigContract.Tests.ps1
+++ b/tests/Common/SecurityConfigContract.Tests.ps1
@@ -313,12 +313,15 @@ Describe 'Collector Contract Compliance' -ForEach @(
             -Because "$FileName must initialize settings via the contract"
     }
 
-    It '<FileName> defines a thin-wrapper Add-Setting function' {
+    It '<FileName> records findings via Add-Setting' {
+        # Post-#958 contract: collectors call Add-Setting, which is provided by the
+        # dot-sourced SecurityConfigHelper.ps1 (the shared wrapper reads the active
+        # context from Initialize-SecurityConfig). Collectors not yet migrated still
+        # carry a local Add-Setting wrapper; both satisfy this contract, and the
+        # AddSetting-Centralization guard tracks which folders have migrated.
         $content = Get-Content -Path $FilePath -Raw
-        $content | Should -Match 'function\s+Add-Setting' `
-            -Because "$FileName must define a local Add-Setting wrapper"
-        $content | Should -Match 'Add-SecuritySetting' `
-            -Because "$FileName Add-Setting must forward to Add-SecuritySetting"
+        $content | Should -Match '\bAdd-Setting\b' `
+            -Because "$FileName must record findings through Add-Setting (shared helper or, pending #958 migration, a local wrapper)"
     }
 
     It '<FileName> calls Export-SecurityConfigReport for output' {

--- a/tests/Common/SecurityConfigContract.Tests.ps1
+++ b/tests/Common/SecurityConfigContract.Tests.ps1
@@ -313,16 +313,12 @@ Describe 'Collector Contract Compliance' -ForEach @(
             -Because "$FileName must initialize settings via the contract"
     }
 
-    It '<FileName> records findings via Add-Setting' {
-        # Post-#958 contract: collectors call Add-Setting, which is provided by the
-        # dot-sourced SecurityConfigHelper.ps1 (the shared wrapper reads the active
-        # context from Initialize-SecurityConfig). Collectors not yet migrated still
-        # carry a local Add-Setting wrapper; both satisfy this contract, and the
-        # AddSetting-Centralization guard tracks which folders have migrated.
-        $content = Get-Content -Path $FilePath -Raw
-        $content | Should -Match '\bAdd-Setting\b' `
-            -Because "$FileName must record findings through Add-Setting (shared helper or, pending #958 migration, a local wrapper)"
-    }
+    # Note (#958): collectors no longer define a local Add-Setting wrapper -- they use
+    # the shared one from SecurityConfigHelper.ps1. A literal Add-Setting call need not
+    # appear in the collector file itself: delegating collectors (e.g. Defender, Entra)
+    # call it from dot-sourced helper files. The dot-source + Initialize-SecurityConfig
+    # + Export checks here cover the contract, and AddSetting-Centralization.Tests.ps1
+    # guards that no local wrappers remain.
 
     It '<FileName> calls Export-SecurityConfigReport for output' {
         $content = Get-Content -Path $FilePath -Raw

--- a/tests/Common/SecurityConfigHelper.Tests.ps1
+++ b/tests/Common/SecurityConfigHelper.Tests.ps1
@@ -38,6 +38,41 @@ Describe 'Add-SecuritySetting - remediation fallback' {
     }
 }
 
+Describe 'Add-Setting - centralized wrapper (#958)' {
+    BeforeEach {
+        $ctx = Initialize-SecurityConfig
+    }
+
+    It 'adds a finding to the active context set by Initialize-SecurityConfig' {
+        Add-Setting -Category 'Test' -Setting 'Shared wrapper' -CurrentValue 'x' `
+            -RecommendedValue 'y' -Status 'Pass' -CheckId 'TEST-001'
+        $ctx.Settings.Count       | Should -Be 1
+        $ctx.Settings[0].Setting  | Should -Be 'Shared wrapper'
+        $ctx.Settings[0].CheckId  | Should -Be 'TEST-001.1'
+    }
+
+    It 'sub-numbers repeated CheckIds like the canonical helper' {
+        Add-Setting -Category 'T' -Setting 'a' -CurrentValue 'x' -RecommendedValue 'y' -Status 'Pass' -CheckId 'TEST-001'
+        Add-Setting -Category 'T' -Setting 'b' -CurrentValue 'x' -RecommendedValue 'y' -Status 'Fail' -CheckId 'TEST-001'
+        $ctx.Settings[0].CheckId | Should -Be 'TEST-001.1'
+        $ctx.Settings[1].CheckId | Should -Be 'TEST-001.2'
+    }
+
+    It 'forwards structured evidence fields to the canonical helper' {
+        Add-Setting -Category 'T' -Setting 'e' -CurrentValue 'x' -RecommendedValue 'y' `
+            -Status 'Pass' -CheckId 'TEST-001' -ObservedValue 'true' -EvidenceSource '/x'
+        $ctx.Settings[0].ObservedValue  | Should -Be 'true'
+        $ctx.Settings[0].EvidenceSource | Should -Be '/x'
+    }
+
+    It 'throws a clear error when called before Initialize-SecurityConfig' {
+        Remove-Variable -Name ActiveSecurityConfig -Scope Script -ErrorAction SilentlyContinue
+        {
+            Add-Setting -Category 'T' -Setting 'orphan' -CurrentValue 'x' -RecommendedValue 'y' -Status 'Pass'
+        } | Should -Throw -ExpectedMessage '*Initialize-SecurityConfig*'
+    }
+}
+
 Describe 'Add-SecuritySetting - status taxonomy (#774)' {
     BeforeEach {
         $ctx = Initialize-SecurityConfig


### PR DESCRIPTION
## Summary

Resolves #958. The `Add-Setting` wrapper was redefined locally in 32 collectors (each forwarding `Settings` + `CheckIdCounter` to `Add-SecuritySetting`) - ~785 lines of boilerplate that drifts and must be hand-propagated on every contract change. This replaces them all with **one shared `Add-Setting`** in `SecurityConfigHelper.ps1`.

Done in a single PR (per review feedback) rather than one folder at a time.

### How it works
- `Initialize-SecurityConfig` records the active context in `$script:ActiveSecurityConfig`.
- The shared `Add-Setting` reads it and forwards every argument to `Add-SecuritySetting`.
- The helper is **dot-sourced per collector**, so `$script:` resolves to each collector's own scope and resets on every `Initialize` call - sequential collectors stay isolated, no `$global:`.

### Scope
- **Migrated (32):** Collaboration, Entra, Exchange-Online, Intune, PowerBI, Purview, Security - local wrappers and the now-unused `$checkIdCounter` local removed.
- **Exception (1):** `Get-StrykerIncidentReadiness.ps1` keeps its local wrapper - it's a custom implementation with its own row shape that doesn't forward to `Add-SecuritySetting` and lacks the evidence schema, so the mechanical migration doesn't apply. Documented as the single allowed exception in the guard.

### Tests
- New `Add-Setting` cases in `SecurityConfigHelper.Tests.ps1` (active-context, sub-numbering, evidence forwarding, pre-init error) - RED before, GREEN after.
- New `AddSetting-Centralization` guard: shared `Add-Setting` defined exactly once; **zero local wrappers repo-wide except the documented exception**; every remaining wrapper must be listed.
- Dropped the collector-contract test's "defines a local wrapper" assertion (the contract #958 reverses); delegating collectors (Defender, Entra) call `Add-Setting` from dot-sourced helpers, so a literal call need not appear in the collector file - the dot-source + Initialize + Export checks plus the guard cover the contract.
- **Full suite 2079 pass, 0 fail**; migrated collectors lint clean.

### Net
**~785 lines deleted** against one shared definition. Acceptance:
- [x] Canonical `Add-Setting` exported once
- [x] Zero local wrappers (except the documented Stryker exception), test-guarded
- [ ] `/v1.0/subscribedSkus` queried at most once per run - the PIM/SKU cache is a separate slice of #958, follow-up