### PR TITLE
fix(report): bound Critical exposure frameworks column (#968 follow-up)

### DIFF
--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -5733,7 +5733,7 @@ function CriticalExposureBlock() {
       fontWeight: 700
     }
   }, items.length)))), /*#__PURE__*/React.createElement("div", {
-    className: "findings"
+    className: "findings ce-findings"
   }, /*#__PURE__*/React.createElement("div", {
     className: "findings-head"
   }, /*#__PURE__*/React.createElement("div", null, "Status"), /*#__PURE__*/React.createElement("div", null, "Check"), /*#__PURE__*/React.createElement("div", null, "Check ID"), /*#__PURE__*/React.createElement("div", null, "Severity"), /*#__PURE__*/React.createElement("div", null, "Frameworks"), /*#__PURE__*/React.createElement("div", null)), items.map((f, i) => /*#__PURE__*/React.createElement("div", {
@@ -5761,10 +5761,13 @@ function CriticalExposureBlock() {
     className: "bar"
   }, /*#__PURE__*/React.createElement("i", null), /*#__PURE__*/React.createElement("i", null), /*#__PURE__*/React.createElement("i", null), /*#__PURE__*/React.createElement("i", null)), /*#__PURE__*/React.createElement("span", null, SEV_LABEL[f.severity]))), /*#__PURE__*/React.createElement("div", {
     className: "fw-list"
-  }, f.frameworks.map(fw => /*#__PURE__*/React.createElement("span", {
+  }, f.frameworks.slice(0, 8).map(fw => /*#__PURE__*/React.createElement("span", {
     key: fw,
     className: "fw-pill"
-  }, fw))), /*#__PURE__*/React.createElement("div", null))))));
+  }, fw)), f.frameworks.length > 8 && /*#__PURE__*/React.createElement("span", {
+    className: "fw-pill fw-pill-more",
+    title: f.frameworks.join(', ')
+  }, "+", f.frameworks.length - 8)), /*#__PURE__*/React.createElement("div", null))))));
 }
 
 // ======================== Overview (tenant + summary) ========================

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -3787,7 +3787,7 @@ function CriticalExposureBlock() {
           <div><div style={{fontSize:12,color:'var(--muted)'}}>Total</div><div style={{fontWeight:700}}>{items.length}</div></div>
         </div>
       </div>
-      <div className="findings">
+      <div className="findings ce-findings">
         <div className="findings-head">
           <div>Status</div><div>Check</div><div>Check ID</div><div>Severity</div><div>Frameworks</div><div/>
         </div>
@@ -3797,7 +3797,10 @@ function CriticalExposureBlock() {
             <div className="finding-title"><div className="t">{f.setting}</div><div className="sub">{f.section}</div></div>
             <div className="check-id">{f.checkId}</div>
             <div><span className={'sev-badge '+f.severity}><span className="bar"><i/><i/><i/><i/></span><span>{SEV_LABEL[f.severity]}</span></span></div>
-            <div className="fw-list">{f.frameworks.map(fw => <span key={fw} className="fw-pill">{fw}</span>)}</div>
+            <div className="fw-list">
+              {f.frameworks.slice(0, 8).map(fw => <span key={fw} className="fw-pill">{fw}</span>)}
+              {f.frameworks.length > 8 && <span className="fw-pill fw-pill-more" title={f.frameworks.join(', ')}>+{f.frameworks.length - 8}</span>}
+            </div>
             <div/>
           </div>
         ))}

--- a/src/M365-Assess/assets/report-shell.css
+++ b/src/M365-Assess/assets/report-shell.css
@@ -1007,6 +1007,21 @@ mark.search-hl {
   background: var(--chip); color: var(--text-soft);
   border: 1px solid var(--border);
 }
+.fw-pill-more { color: var(--muted); cursor: default; }
+
+/* #968 follow-up: the Critical exposure section reuses the findings grid but is a
+   compact, non-expandable summary whose checks are unusually framework-dense
+   (13-16 each). On desktop give it a wider, flexible Frameworks column and
+   top-align cells, so short cells don't float beside a tall wrapped pill stack.
+   Markup caps the pills to 8 + a "+N" overflow. Left untouched <=720px so the
+   section still collapses with the shared mobile rule. */
+@media (min-width: 721px) {
+  .ce-findings .findings-head,
+  .ce-findings .finding-row {
+    grid-template-columns: 80px minmax(0, 1.6fr) 150px 110px minmax(0, 1.5fr) 28px;
+    align-items: start;
+  }
+}
 
 .caret {
   color: var(--muted); transition: transform .15s;


### PR DESCRIPTION
## Summary

Follow-up to #982 (#968). During live render verification, the revived **Critical exposure** section's Frameworks column broke the table layout: each of the 9 curated checks maps to 13-16 frameworks, and the section reused the shared findings grid (narrow fixed Frameworks column, `align-items: center`). The pills wrapped into a ~13-line stack, and center alignment floated the short cells (Status, Check, Severity) into the middle of ~600px-tall rows.

## Related Issues

Follow-up to #982 / #968 (both already merged/closed).

## Changes

- **Cap the frameworks** to 8 pills + a `+N` overflow chip (with the full list in a `title` tooltip), matching the existing `+N more` idiom used elsewhere in the report.
- **Scope a wider, flexible Frameworks column** and `align-items: start` to the section via a new `.ce-findings` class, gated to `min-width: 721px` so the section still collapses with the shared mobile rule (`<=720px`).

Rows are now a uniform ~88px (was ~600px).

## Test Plan

- [x] `npm run build` + `node --check` clean, deterministic (only `.jsx`/`.js`/`.css` changed)
- [x] **HTML report renders correctly** — verified by generating a synthetic report (`Build-ReportData` -> `Get-ReportTemplate`) with framework-dense critical-exposure findings and rendering it:
  - Desktop (1440px): 9 uniform ~88px rows, 8 pills + `+6` overflow, Frameworks column ~295px wide, cells top-aligned
  - Mobile (390px): section collapses to the shared 3-column grid (`72px / 1fr / 28px`) exactly like the main findings table, no new horizontal overflow
- [x] PSScriptAnalyzer / Pester — N/A (no `.ps1` logic changed)
- [x] No secrets or tenant PII (synthetic fixture only, not committed)

## Breaking Changes

None.
