### PR TITLE
fix(report): move Critical exposure below Secure Score, drop frameworks column

### DIFF
--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -5736,7 +5736,7 @@ function CriticalExposureBlock() {
     className: "findings ce-findings"
   }, /*#__PURE__*/React.createElement("div", {
     className: "findings-head"
-  }, /*#__PURE__*/React.createElement("div", null, "Status"), /*#__PURE__*/React.createElement("div", null, "Check"), /*#__PURE__*/React.createElement("div", null, "Check ID"), /*#__PURE__*/React.createElement("div", null, "Severity"), /*#__PURE__*/React.createElement("div", null, "Frameworks"), /*#__PURE__*/React.createElement("div", null)), items.map((f, i) => /*#__PURE__*/React.createElement("div", {
+  }, /*#__PURE__*/React.createElement("div", null, "Status"), /*#__PURE__*/React.createElement("div", null, "Check"), /*#__PURE__*/React.createElement("div", null, "Check ID"), /*#__PURE__*/React.createElement("div", null, "Severity"), /*#__PURE__*/React.createElement("div", null)), items.map((f, i) => /*#__PURE__*/React.createElement("div", {
     key: i,
     className: "finding-row",
     style: {
@@ -5759,15 +5759,7 @@ function CriticalExposureBlock() {
     className: 'sev-badge ' + f.severity
   }, /*#__PURE__*/React.createElement("span", {
     className: "bar"
-  }, /*#__PURE__*/React.createElement("i", null), /*#__PURE__*/React.createElement("i", null), /*#__PURE__*/React.createElement("i", null), /*#__PURE__*/React.createElement("i", null)), /*#__PURE__*/React.createElement("span", null, SEV_LABEL[f.severity]))), /*#__PURE__*/React.createElement("div", {
-    className: "fw-list"
-  }, f.frameworks.slice(0, 8).map(fw => /*#__PURE__*/React.createElement("span", {
-    key: fw,
-    className: "fw-pill"
-  }, fw)), f.frameworks.length > 8 && /*#__PURE__*/React.createElement("span", {
-    className: "fw-pill fw-pill-more",
-    title: f.frameworks.join(', ')
-  }, "+", f.frameworks.length - 8)), /*#__PURE__*/React.createElement("div", null))))));
+  }, /*#__PURE__*/React.createElement("i", null), /*#__PURE__*/React.createElement("i", null), /*#__PURE__*/React.createElement("i", null), /*#__PURE__*/React.createElement("i", null)), /*#__PURE__*/React.createElement("span", null, SEV_LABEL[f.severity]))), /*#__PURE__*/React.createElement("div", null))))));
 }
 
 // ======================== Overview (tenant + summary) ========================
@@ -6593,7 +6585,7 @@ function App() {
     onViewFinding: onViewFinding,
     onShowCritical: onShowCritical,
     onShowQuickWins: onShowQuickWins
-  }), /*#__PURE__*/React.createElement(Overview, null), /*#__PURE__*/React.createElement(CriticalExposureBlock, null), /*#__PURE__*/React.createElement(Posture, null), /*#__PURE__*/React.createElement(ScoringViews, {
+  }), /*#__PURE__*/React.createElement(Overview, null), /*#__PURE__*/React.createElement(Posture, null), /*#__PURE__*/React.createElement(CriticalExposureBlock, null), /*#__PURE__*/React.createElement(ScoringViews, {
     view: scoringView,
     setView: setScoringView
   }), /*#__PURE__*/React.createElement(TrendChart, null), /*#__PURE__*/React.createElement(FrameworkQuilt, {

--- a/src/M365-Assess/assets/report-app.jsx
+++ b/src/M365-Assess/assets/report-app.jsx
@@ -3789,7 +3789,7 @@ function CriticalExposureBlock() {
       </div>
       <div className="findings ce-findings">
         <div className="findings-head">
-          <div>Status</div><div>Check</div><div>Check ID</div><div>Severity</div><div>Frameworks</div><div/>
+          <div>Status</div><div>Check</div><div>Check ID</div><div>Severity</div><div/>
         </div>
         {items.map((f,i) => (
           <div key={i} className="finding-row" style={{cursor:'default'}}>
@@ -3797,10 +3797,6 @@ function CriticalExposureBlock() {
             <div className="finding-title"><div className="t">{f.setting}</div><div className="sub">{f.section}</div></div>
             <div className="check-id">{f.checkId}</div>
             <div><span className={'sev-badge '+f.severity}><span className="bar"><i/><i/><i/><i/></span><span>{SEV_LABEL[f.severity]}</span></span></div>
-            <div className="fw-list">
-              {f.frameworks.slice(0, 8).map(fw => <span key={fw} className="fw-pill">{fw}</span>)}
-              {f.frameworks.length > 8 && <span className="fw-pill fw-pill-more" title={f.frameworks.join(', ')}>+{f.frameworks.length - 8}</span>}
-            </div>
             <div/>
           </div>
         ))}
@@ -4323,8 +4319,8 @@ function App() {
         />
         <Briefing onViewFinding={onViewFinding} onShowCritical={onShowCritical} onShowQuickWins={onShowQuickWins}/>
         <Overview/>
-        <CriticalExposureBlock/>
         <Posture/>
+        <CriticalExposureBlock/>
         <ScoringViews view={scoringView} setView={setScoringView}/>
         <TrendChart/>
         <FrameworkQuilt onSelect={onFrameworkSelect} selected={filters.framework[0]} onProfileSelect={onProfileSelect} activeProfiles={filters.profile || []}/>

--- a/src/M365-Assess/assets/report-shell.css
+++ b/src/M365-Assess/assets/report-shell.css
@@ -1007,19 +1007,15 @@ mark.search-hl {
   background: var(--chip); color: var(--text-soft);
   border: 1px solid var(--border);
 }
-.fw-pill-more { color: var(--muted); cursor: default; }
-
-/* #968 follow-up: the Critical exposure section reuses the findings grid but is a
-   compact, non-expandable summary whose checks are unusually framework-dense
-   (13-16 each). On desktop give it a wider, flexible Frameworks column and
-   top-align cells, so short cells don't float beside a tall wrapped pill stack.
-   Markup caps the pills to 8 + a "+N" overflow. Left untouched <=720px so the
-   section still collapses with the shared mobile rule. */
+/* #968: the Critical exposure section is a compact 4-column summary (Status,
+   Check, Check ID, Severity) with no frameworks column — the section's framing
+   already conveys that these are a small, high-priority set. Override the shared
+   findings grid so the cells fill the row instead of leaving empty trailing
+   columns. Scoped >=721px so the section still collapses with the shared mobile rule. */
 @media (min-width: 721px) {
   .ce-findings .findings-head,
   .ce-findings .finding-row {
-    grid-template-columns: 80px minmax(0, 1.6fr) 150px 110px minmax(0, 1.5fr) 28px;
-    align-items: start;
+    grid-template-columns: 80px minmax(0, 1fr) 200px 130px 28px;
   }
 }
 


### PR DESCRIPTION
## Summary

Two UX refinements to the Critical exposure section after reviewing the merged report (#982/#991):

1. **Moved below the Secure Score boxes.** The section now mounts after `<Posture/>` (was after `<Overview/>`), so the report flows Briefing → Overview → Posture/Secure Score → Critical exposure → Scoring.
2. **Dropped the Frameworks column.** The section's coverage card and blurb already frame these findings as a small, high-priority set of attack-relevant exposures, so per-row framework pills added noise without value. The section is now a compact 4-column summary: Status, Check, Check ID, Severity.

## Related Issues

Follow-up to #982 / #991 (#968).

## Changes

- Mount `CriticalExposureBlock` after `<Posture/>`.
- Remove the Frameworks column from the section header and rows.
- Simplify the `.ce-findings` grid to 4 columns + caret slot (`80px / 1fr / 200px / 130px / 28px`); drop the now-unused `.fw-pill-more` rule. Still scoped `>=721px` so the section collapses with the shared mobile rule.

## Test Plan

- [x] `npm run build` + `node --check` clean, deterministic (only `.jsx`/`.js`/`.css` changed)
- [x] **HTML report renders correctly** — verified via synthetic report (`Build-ReportData` -> `Get-ReportTemplate`): DOM order is `… posture, critical-exposure, scoring …`; section has no frameworks (`.fw-list`/`.fw-pill` absent), 5 cells/row, uniform ~50px rows
- [x] PSScriptAnalyzer / Pester — N/A (no `.ps1` logic changed)
- [x] No secrets or tenant PII (synthetic fixture only, not committed)

## Breaking Changes

None.
