### PR TITLE
fix(entra): treat enforced/default MFA states as compliant (#998, #999)

### DIFF
--- a/src/M365-Assess/Entra/EntraPasswordAuthChecks.ps1
+++ b/src/M365-Assess/Entra/EntraPasswordAuthChecks.ps1
@@ -424,10 +424,15 @@ try {
             if ($null -ne $featureSettings) {
                 $numberMatchState = $featureSettings['numberMatchingRequiredState']
                 $appInfoState = $featureSettings['displayAppInformationRequiredState']
-                $numberMatch = if ($numberMatchState) { $numberMatchState['state'] } else { 'not configured' }
+                # Number matching has been enforced tenant-wide since May 2023. Once enforced,
+                # Graph stops returning numberMatchingRequiredState, so an absent property means
+                # "enforced" (on), not "not configured". Treat absence as the enforced state
+                # rather than failing the check (community issue #998).
+                $numberMatch = if ($numberMatchState) { $numberMatchState['state'] } else { 'enforced (mandatory)' }
                 $appInfo = if ($appInfoState) { $appInfoState['state'] } else { 'not configured' }
 
-                $fatiguePassed = ($numberMatch -eq 'enabled') -and ($appInfo -eq 'enabled')
+                $numberMatchOn = $numberMatch -in @('enabled', 'enforced (mandatory)')
+                $fatiguePassed = $numberMatchOn -and ($appInfo -eq 'enabled')
                 $settingParams = @{
                     Category         = 'Authentication Methods'
                     Setting          = 'Authenticator Fatigue Protection'
@@ -476,14 +481,19 @@ catch {
 try {
     if ($sspr) {
         $systemPreferred = $sspr['systemCredentialPreferences']
-        $sysState = if ($systemPreferred) { $systemPreferred['state'] } else { 'not configured' }
+        # System-preferred MFA is GA and enabled by default. Graph omits
+        # systemCredentialPreferences (or returns state 'default') until it is explicitly
+        # changed, so an absent property or a 'default' state means enabled, not
+        # "not configured". Only an explicit 'disabled' should fail (community issue #999).
+        $sysState = if ($systemPreferred) { $systemPreferred['state'] } else { 'default (enabled)' }
+        $sysEnabled = $sysState -in @('enabled', 'default', 'default (enabled)')
 
         $settingParams = @{
             Category         = 'Authentication Methods'
             Setting          = 'System-Preferred MFA'
             CurrentValue     = "$sysState"
             RecommendedValue = 'enabled'
-            Status           = $(if ($sysState -eq 'enabled') { 'Pass' } else { 'Fail' })
+            Status           = $(if ($sysEnabled) { 'Pass' } else { 'Fail' })
             CheckId          = 'ENTRA-AUTHMETHOD-004'
             Remediation      = 'Entra admin center > Protection > Authentication methods > Settings > System-preferred multifactor authentication > Enabled.'
         }

--- a/src/M365-Assess/Entra/EntraPasswordAuthChecks.ps1
+++ b/src/M365-Assess/Entra/EntraPasswordAuthChecks.ps1
@@ -431,7 +431,9 @@ try {
                 $numberMatch = if ($numberMatchState) { $numberMatchState['state'] } else { 'enforced (mandatory)' }
                 $appInfo = if ($appInfoState) { $appInfoState['state'] } else { 'not configured' }
 
-                $numberMatchOn = $numberMatch -in @('enabled', 'enforced (mandatory)')
+                # 'default' is the Microsoft-managed advancedConfigState; for number matching
+                # (enforced tenant-wide) it means on, matching the System-Preferred MFA path.
+                $numberMatchOn = $numberMatch -in @('enabled', 'enforced (mandatory)', 'default')
                 $fatiguePassed = $numberMatchOn -and ($appInfo -eq 'enabled')
                 $settingParams = @{
                     Category         = 'Authentication Methods'

--- a/tests/Entra/EntraPasswordAuthChecks.Tests.ps1
+++ b/tests/Entra/EntraPasswordAuthChecks.Tests.ps1
@@ -75,8 +75,10 @@ Describe 'EntraPasswordAuthChecks' {
                                 id    = 'MicrosoftAuthenticator'
                                 state = 'enabled'
                                 '@odata.type' = '#microsoft.graph.microsoftAuthenticatorAuthenticationMethodConfiguration'
+                                # Modern Graph shape: number matching has been enforced tenant-wide
+                                # since May 2023, so Graph no longer returns numberMatchingRequiredState
+                                # under featureSettings. Only the admin-controllable context toggles remain.
                                 featureSettings = @{
-                                    numberMatchingRequiredState        = @{ state = 'enabled' }
                                     displayAppInformationRequiredState = @{ state = 'enabled' }
                                 }
                             }
@@ -90,7 +92,8 @@ Describe 'EntraPasswordAuthChecks' {
                                 includeTargets = @( @{ id = 'all_users'; targetType = 'group' } )
                             }
                         }
-                        systemCredentialPreferences = @{ state = 'enabled' }
+                        # Modern Graph shape: system-preferred MFA is GA and default-on, so Graph
+                        # omits systemCredentialPreferences unless it has been explicitly changed.
                     }
                 }
                 '*/v1.0/settings' {
@@ -242,6 +245,111 @@ Describe 'EntraPasswordAuthChecks' {
             $s.CheckId | Should -Match '^ENTRA-' `
                 -Because "CheckId '$($s.CheckId)' should start with ENTRA-"
         }
+    }
+
+    AfterAll {
+        Remove-Item Function:\Update-CheckProgress -ErrorAction SilentlyContinue
+        Remove-Item Function:\Get-MgContext -ErrorAction SilentlyContinue
+        Remove-Item Function:\Add-Setting -ErrorAction SilentlyContinue
+    }
+}
+
+Describe 'EntraPasswordAuthChecks - Modern schema with disabled states' {
+    # Guards the #998/#999 fix against over-loosening: when Graph explicitly returns a
+    # disabled state (rather than omitting the property), the checks must still Fail.
+    BeforeAll {
+        function global:Update-CheckProgress {
+            param($CheckId, $Setting, $Status)
+        }
+
+        function global:Get-MgContext {
+            return @{ TenantId = 'test-tenant-id' }
+        }
+
+        Mock Import-Module { }
+
+        Mock Invoke-MgGraphRequest {
+            param($Method, $Uri, $Headers, $ErrorAction)
+            switch -Wildcard ($Uri) {
+                '*/identitySecurityDefaultsEnforcementPolicy' {
+                    return @{ isEnabled = $false }
+                }
+                '*/identity/conditionalAccess/policies' {
+                    return @{ value = @() }
+                }
+                '*/policies/authenticationMethodsPolicy' {
+                    return @{
+                        authenticationMethodConfigurations = @(
+                            @{
+                                id    = 'MicrosoftAuthenticator'
+                                state = 'enabled'
+                                '@odata.type' = '#microsoft.graph.microsoftAuthenticatorAuthenticationMethodConfiguration'
+                                # numberMatchingRequiredState omitted (enforced), but the admin
+                                # explicitly turned OFF application context display.
+                                featureSettings = @{
+                                    displayAppInformationRequiredState = @{ state = 'disabled' }
+                                }
+                            }
+                        )
+                        registrationEnforcement = @{
+                            authenticationMethodsRegistrationCampaign = @{
+                                state          = 'disabled'
+                                includeTargets = @()
+                            }
+                        }
+                        # System-preferred MFA explicitly disabled by the admin.
+                        systemCredentialPreferences = @{ state = 'disabled' }
+                    }
+                }
+                '*/v1.0/settings' { return @{ value = @() } }
+                '*/v1.0/domains' {
+                    return @{ value = @(
+                        @{ id = 'contoso.com'; isVerified = $true; passwordValidityPeriodInDays = 2147483647 }
+                    )}
+                }
+                '*/v1.0/organization' {
+                    return @{ value = @(
+                        @{ onPremisesSyncEnabled = $false; onPremisesLastPasswordSyncDateTime = $null }
+                    )}
+                }
+                default { return @{ value = @() } }
+            }
+        }
+
+        . "$PSScriptRoot/../../src/M365-Assess/Orchestrator/AssessmentHelpers.ps1"
+        . "$PSScriptRoot/../../src/M365-Assess/Common/SecurityConfigHelper.ps1"
+
+        $ctx            = Initialize-SecurityConfig
+        $settings       = $ctx.Settings
+        $checkIdCounter = $ctx.CheckIdCounter
+
+        function Add-Setting {
+            param([string]$Category, [string]$Setting, [string]$CurrentValue,
+                  [string]$RecommendedValue, [string]$Status,
+                  [string]$CheckId = '', [string]$Remediation = '')
+            Add-SecuritySetting -Settings $settings -CheckIdCounter $checkIdCounter `
+                -Category $Category -Setting $Setting -CurrentValue $CurrentValue `
+                -RecommendedValue $RecommendedValue -Status $Status `
+                -CheckId $CheckId -Remediation $Remediation
+        }
+
+        $sspr       = $null
+        $orgSettings = $null
+        $pwSettings  = $null
+
+        . "$PSScriptRoot/../../src/M365-Assess/Entra/EntraPasswordAuthChecks.ps1"
+    }
+
+    It 'Authenticator fatigue protection fails when application context is explicitly disabled' {
+        $check = $settings | Where-Object { $_.Setting -eq 'Authenticator Fatigue Protection' }
+        $check | Should -Not -BeNullOrEmpty
+        $check.Status | Should -Be 'Fail' -Because 'application context display is off even though number matching is enforced'
+    }
+
+    It 'System-preferred MFA fails when explicitly disabled' {
+        $check = $settings | Where-Object { $_.Setting -eq 'System-Preferred MFA' }
+        $check | Should -Not -BeNullOrEmpty
+        $check.Status | Should -Be 'Fail' -Because 'the admin explicitly turned it off'
     }
 
     AfterAll {

--- a/tests/Entra/EntraPasswordAuthChecks.Tests.ps1
+++ b/tests/Entra/EntraPasswordAuthChecks.Tests.ps1
@@ -536,3 +536,108 @@ Describe 'EntraPasswordAuthChecks - Security Defaults OFF no CA' {
         Remove-Item Function:\Add-Setting -ErrorAction SilentlyContinue
     }
 }
+
+Describe 'EntraPasswordAuthChecks - Modern schema with default states' {
+    # Graph can return a control at the advancedConfigState value 'default' (Microsoft-managed)
+    # instead of omitting it. For number matching and system-preferred MFA, 'default' means ON,
+    # so both checks must Pass. Guards consistency between the two fixes.
+    BeforeAll {
+        function global:Update-CheckProgress {
+            param($CheckId, $Setting, $Status)
+        }
+
+        function global:Get-MgContext {
+            return @{ TenantId = 'test-tenant-id' }
+        }
+
+        Mock Import-Module { }
+
+        Mock Invoke-MgGraphRequest {
+            param($Method, $Uri, $Headers, $ErrorAction)
+            switch -Wildcard ($Uri) {
+                '*/identitySecurityDefaultsEnforcementPolicy' {
+                    return @{ isEnabled = $false }
+                }
+                '*/identity/conditionalAccess/policies' {
+                    return @{ value = @() }
+                }
+                '*/policies/authenticationMethodsPolicy' {
+                    return @{
+                        authenticationMethodConfigurations = @(
+                            @{
+                                id    = 'MicrosoftAuthenticator'
+                                state = 'enabled'
+                                '@odata.type' = '#microsoft.graph.microsoftAuthenticatorAuthenticationMethodConfiguration'
+                                # 'default' = Microsoft-managed = on. App context explicitly enabled.
+                                featureSettings = @{
+                                    numberMatchingRequiredState        = @{ state = 'default' }
+                                    displayAppInformationRequiredState = @{ state = 'enabled' }
+                                }
+                            }
+                        )
+                        registrationEnforcement = @{
+                            authenticationMethodsRegistrationCampaign = @{
+                                state          = 'disabled'
+                                includeTargets = @()
+                            }
+                        }
+                        systemCredentialPreferences = @{ state = 'default' }
+                    }
+                }
+                '*/v1.0/settings' { return @{ value = @() } }
+                '*/v1.0/domains' {
+                    return @{ value = @(
+                        @{ id = 'contoso.com'; isVerified = $true; passwordValidityPeriodInDays = 2147483647 }
+                    )}
+                }
+                '*/v1.0/organization' {
+                    return @{ value = @(
+                        @{ onPremisesSyncEnabled = $false; onPremisesLastPasswordSyncDateTime = $null }
+                    )}
+                }
+                default { return @{ value = @() } }
+            }
+        }
+
+        . "$PSScriptRoot/../../src/M365-Assess/Orchestrator/AssessmentHelpers.ps1"
+        . "$PSScriptRoot/../../src/M365-Assess/Common/SecurityConfigHelper.ps1"
+
+        $ctx            = Initialize-SecurityConfig
+        $settings       = $ctx.Settings
+        $checkIdCounter = $ctx.CheckIdCounter
+
+        function Add-Setting {
+            param([string]$Category, [string]$Setting, [string]$CurrentValue,
+                  [string]$RecommendedValue, [string]$Status,
+                  [string]$CheckId = '', [string]$Remediation = '')
+            Add-SecuritySetting -Settings $settings -CheckIdCounter $checkIdCounter `
+                -Category $Category -Setting $Setting -CurrentValue $CurrentValue `
+                -RecommendedValue $RecommendedValue -Status $Status `
+                -CheckId $CheckId -Remediation $Remediation
+        }
+
+        $sspr       = $null
+        $orgSettings = $null
+        $pwSettings  = $null
+
+        . "$PSScriptRoot/../../src/M365-Assess/Entra/EntraPasswordAuthChecks.ps1"
+    }
+
+    It 'Authenticator fatigue protection passes when number matching is at default (Microsoft-managed)' {
+        $check = $settings | Where-Object { $_.Setting -eq 'Authenticator Fatigue Protection' }
+        $check | Should -Not -BeNullOrEmpty
+        $check.Status | Should -Be 'Pass' -Because "'default' number matching is enforced by Microsoft"
+    }
+
+    It 'System-preferred MFA passes when at default' {
+        $check = $settings | Where-Object { $_.Setting -eq 'System-Preferred MFA' }
+        $check | Should -Not -BeNullOrEmpty
+        $check.Status | Should -Be 'Pass' -Because "'default' system-preferred MFA is on"
+    }
+
+    AfterAll {
+        Remove-Item Function:\Update-CheckProgress -ErrorAction SilentlyContinue
+        Remove-Item Function:\Get-MgContext -ErrorAction SilentlyContinue
+        Remove-Item Function:\Add-Setting -ErrorAction SilentlyContinue
+    }
+}


### PR DESCRIPTION
## Summary

Two community-reported false FAILs in the Entra authentication-methods collector, both caused by Microsoft Graph schema drift. When a feature becomes mandatory or default-on, Graph stops returning its toggle property. The collector read the absent property as `not configured` and failed the check.

## Related Issues

Closes #998
Closes #999

## Changes

- **#998 Authenticator Fatigue Protection (`ENTRA-AUTHMETHOD-003`):** number matching has been enforced tenant-wide since May 2023, so Graph no longer returns `numberMatchingRequiredState`. An absent value is now treated as enforced (on) rather than `not configured`. The check still meaningfully gates on the admin-controllable application-context display toggle.
- **#999 System-Preferred MFA (`ENTRA-AUTHMETHOD-004`):** system-preferred MFA is GA and default-on, so Graph omits `systemCredentialPreferences` (or returns state `default`) until it is explicitly changed. Absent or `default` is now treated as enabled.
- An explicit `disabled` state still fails in both checks, so an admin who intentionally turns either off is still surfaced.
- Refreshed the stale test fixture that still returned the now-absent properties (this is why CI never caught the regression) and added negative coverage for the explicit-disabled path.

## Test Plan

- [x] PSScriptAnalyzer passes on changed `.ps1` files (0 issues under `PSScriptAnalyzerSettings.psd1`)
- [x] Pester tests pass (`tests/Entra` 226 passed, 0 failed; file under test 20/20)
- [ ] Ran against test tenant — pending live verification on a tenant with number matching enforced and system-preferred MFA on
- [ ] HTML report renders correctly — N/A (collector data only, no report-app change)
- [x] No secrets or tenant PII in committed files

Note on the live check: please confirm on the live run that a tenant with system-preferred MFA explicitly disabled returns state `disabled` (not an omitted property). If a disabled tenant also omits the property, the absent-as-enabled mapping would need a tighter signal.

## Breaking Changes

None. Tenants that were correctly configured but falsely failing will now correctly pass; no schema or parameter changes.
