### PR TITLE
feat(entra): accept All-Users MFA policies as admin coverage (#1000)

### DIFF
--- a/docs/research/review-status-audit.md
+++ b/docs/research/review-status-audit.md
@@ -13,7 +13,7 @@ Get-ChildItem -Path 'src/M365-Assess' -Recurse -Filter '*.ps1' |
 
 | Status | Emissions | What it should mean |
 |---|---|---|
-| `Review` | 69 | Data was collected but a human needs to interpret the result. |
+| `Review` | 70 | Data was collected but a human needs to interpret the result. |
 | `Skipped` | 31 | The check did not run (license-gated, permission-gated, or env-not-applicable). |
 | `Unknown` | 1 | Data could not be collected; this is different from "Skipped". |
 | **Total** | **98** | |
@@ -29,7 +29,7 @@ Per-collector breakdown:
 | `Exchange-Online/Get-DnsSecurityConfig.ps1` | 4 | 0 | 0 |
 | `Exchange-Online/Get-ExoSecurityConfig.ps1` | 5 | 0 | 0 |
 | `Collaboration/Get-TeamsSecurityConfig.ps1` | 2 | 0 | 0 |
-| `Entra/Get-CASecurityConfig.ps1` | 2 | 0 | 0 |
+| `Entra/Get-CASecurityConfig.ps1` | 3 | 0 | 0 |
 | various Intune, Compliance, Defender collectors | ~30 | ~6 | 0 |
 
 (Full per-site table available via `Get-ChildItem -Path 'src/M365-Assess' -Recurse -Filter '*.ps1' | Select-String -Pattern "Status\s*=\s*'(Review|Unknown|Skipped)'"`. Snapshot is intentionally not committed — it would rot quickly.)
@@ -58,16 +58,17 @@ For each emission site, the question is one of three things:
 - **ENTRA-SSPR-001** (#878, fixed this PR) — the legacy "Self service password reset enabled" toggle (None / Selected / All) lives in the Entra admin center under Password reset > Properties and is **not exposed by Microsoft Graph** as of the 2026-04 audit. The previous collector read `authenticationMethodsRegistrationCampaign` (the MFA Registration Campaign — a different control) and labeled it as SSPR. Now correctly emits Review with a manual-verify instruction.
 - **FORMS-CONFIG-001 Skipped emission** (#941, ceiling 28 -> 29) — the `/beta/admin/forms/settings` Graph endpoint that the Forms collector reads is beta-only (no v1.0 endpoint exists) and is not served in GCC High / sovereign clouds, where it returns BadRequest. The collector now emits Skipped naming the cloud, surfaced in the report's not-assessed group. Genuine limitation: there is no correct call to substitute on these tenants.
 - **Teams client-config + meeting-policy Skipped emissions** (#940, ceiling 29 -> 31) — `/beta/teamwork/teamsClientConfiguration` (6 checks: TEAMS-EXTACCESS-001/002/003/004, TEAMS-CLIENT-001/002) and `/beta/teamwork/teamsMeetingPolicy` (9 checks: TEAMS-MEETING-001..009) are beta-only with no v1.0 equivalent (confirmed against Microsoft's Graph v1.0 Teams API reference) and 400 in sovereign clouds. The collector now emits Skipped for the 15 dependent checks via two data-driven loops (so +2 static emissions, not +15) instead of WARN-and-omit. Genuine limitation; the underlying data is only reachable via the MicrosoftTeams PS module (Get-CsTeamsClientConfiguration / Get-CsTeamsMeetingPolicy), a separate dependency out of scope here.
+- **CA-MFA-ADMIN-001 All-Users-with-exclusions Review emission** (#1000, ceiling 69 -> 70) — the "MFA Required for Admin Roles" check now accepts an All-Users MFA policy as admin coverage (community request #1000). When such a policy carries `excludeUsers` / `excludeGroups`, group/user membership is not resolved here (that would need a per-group directory lookup), so the collector cannot prove the administrators are not carved out. Rather than guess Pass (a false negative if admins are excluded) or Fail (a false positive for a benign break-glass exclusion), it emits Review naming the policy and asking the operator to verify. Genuine limitation: confirming exclusion membership is out of scope for this collector; explicit admin-role-targeted coverage and clean All-Users coverage still resolve to Pass.
 
 ### Triage pending (representative — not exhaustive)
 
 - `EntraPasswordAuthChecks.ps1` — 8 Review emissions (was 7; ENTRA-SSPR-001 added per #878 fix above).
 - `Exchange-Online/Get-DnsSecurityConfig.ps1` — 4 Review emissions; verify whether they're genuinely manual-validation or if a Graph endpoint would resolve them.
-- `Get-CASecurityConfig.ps1` — 2 Review emissions; given the CA admin-center reorg + #879 path rot, worth confirming the collector's data path.
+- `Get-CASecurityConfig.ps1` — 3 Review emissions; 1 is by-design (CA-MFA-ADMIN-001 All-Users-exclusion, classified under genuine limitations above), 2 are triage-pending; given the CA admin-center reorg + #879 path rot, worth confirming the collector's data path.
 
 ## Lock-down regression
 
-`tests/Behavior/Status-Emission-Audit.Tests.ps1` asserts the count of Review / Unknown / Skipped emissions stays at or below the current ceiling (69 / 31 / 1 = 101 total). When a new emission is added the test fails, forcing the contributor to:
+`tests/Behavior/Status-Emission-Audit.Tests.ps1` asserts the count of Review / Unknown / Skipped emissions stays at or below the current ceiling (70 / 31 / 1 = 102 total). When a new emission is added the test fails, forcing the contributor to:
 
 1. Justify the new emission (genuine limitation? collector bug?)
 2. Update this doc to add the new site to the audit catalogue

--- a/src/M365-Assess/Entra/Get-CASecurityConfig.ps1
+++ b/src/M365-Assess/Entra/Get-CASecurityConfig.ps1
@@ -119,26 +119,50 @@ function Test-TargetAllUser {
     return ($includeUsers -and ($includeUsers -contains 'All'))
 }
 
+# Helper: check if a policy carves any tracked admin role out via excludeRoles.
+# An All-Users (or admin-role) policy that excludes an admin role leaves that
+# privileged tier unprotected, so it must not count as admin MFA coverage.
+# Note: excludeUsers/excludeGroups are not resolved to membership (that would need
+# a per-group directory lookup), so a group-based admin carve-out is not detected here.
+function Test-ExcludesAdminRole {
+    param([hashtable]$Policy)
+    $excludeRoles = $Policy['conditions']['users']['excludeRoles']
+    if (-not $excludeRoles) { return $false }
+    foreach ($role in $excludeRoles) {
+        if ($role -in $adminRoleIds) { return $true }
+    }
+    return $false
+}
+
 # ------------------------------------------------------------------
 # 1. MFA Required for Admin Roles (CIS 5.2.2.1)
 # ------------------------------------------------------------------
 try {
     Write-Verbose "Checking CA: MFA for admin roles..."
+    # Admins are covered when an enabled MFA policy targets admin directory roles OR
+    # targets All Users (admins are part of that scope). Either way, a policy that
+    # excludes an admin role via excludeRoles carves that tier out and does not count
+    # (#1000). authenticationStrength-based admin MFA is evaluated separately (check 5).
     $mfaAdminPolicies = @($enabledPolicies | Where-Object {
-        (Test-TargetAdminRole -Policy $_) -and
+        ((Test-TargetAdminRole -Policy $_) -or (Test-TargetAllUser -Policy $_)) -and
+        (-not (Test-ExcludesAdminRole -Policy $_)) -and
         ($_['grantControls']['builtInControls'] -contains 'mfa')
     })
+
+    $adminRolePolicies = @($mfaAdminPolicies | Where-Object { Test-TargetAdminRole -Policy $_ })
+    $coverageVia = if ($adminRolePolicies.Count -gt 0) { 'admin-role-targeted' } else { 'All-Users scope' }
 
     $mfaAdminEvidence = [PSCustomObject]@{
         PolicyCount = $mfaAdminPolicies.Count
         PolicyNames = @($mfaAdminPolicies | ForEach-Object { $_['displayName'] })
+        CoverageVia = $coverageVia
     }
     if ($mfaAdminPolicies.Count -gt 0) {
         $names = ($mfaAdminPolicies | ForEach-Object { $_['displayName'] }) -join '; '
         $settingParams = @{
             Category         = 'Conditional Access'
             Setting          = 'MFA Required for Admin Roles'
-            CurrentValue     = "Yes ($($mfaAdminPolicies.Count) policy: $names)"
+            CurrentValue     = "Yes ($($mfaAdminPolicies.Count) policy via ${coverageVia}: $names)"
             RecommendedValue = 'At least 1 policy'
             Status           = 'Pass'
             CheckId          = 'CA-MFA-ADMIN-001'

--- a/src/M365-Assess/Entra/Get-CASecurityConfig.ps1
+++ b/src/M365-Assess/Entra/Get-CASecurityConfig.ps1
@@ -134,6 +134,30 @@ function Test-ExcludesAdminRole {
     return $false
 }
 
+# Helper: does the policy actually REQUIRE MFA? builtInControls listed under
+# grantControls.operator 'OR' alongside other controls (e.g. "mfa OR compliantDevice")
+# do NOT require MFA, since an alternative control satisfies the grant. MFA is required
+# only when it is the sole control or all controls are required (operator AND).
+function Test-RequiresMfa {
+    param([hashtable]$Policy)
+    $grantControls = $Policy['grantControls']
+    if (-not $grantControls) { return $false }
+    $controls = @($grantControls['builtInControls'])
+    if ($controls -notcontains 'mfa') { return $false }
+    return ($controls.Count -eq 1) -or ($grantControls['operator'] -eq 'AND')
+}
+
+# Helper: does the policy carve out specific users or groups? Group/user exclusions
+# cannot be resolved to membership here, so an All-Users policy carrying them may or
+# may not exclude administrators. Used to downgrade All-Users-only coverage to Review.
+function Test-HasUserOrGroupExclusion {
+    param([hashtable]$Policy)
+    $users = $Policy['conditions']['users']
+    $excludeUsers  = @($users['excludeUsers'])
+    $excludeGroups = @($users['excludeGroups'])
+    return (($excludeUsers.Count -gt 0) -or ($excludeGroups.Count -gt 0))
+}
+
 # ------------------------------------------------------------------
 # 1. MFA Required for Admin Roles (CIS 5.2.2.1)
 # ------------------------------------------------------------------
@@ -146,27 +170,62 @@ try {
     $mfaAdminPolicies = @($enabledPolicies | Where-Object {
         ((Test-TargetAdminRole -Policy $_) -or (Test-TargetAllUser -Policy $_)) -and
         (-not (Test-ExcludesAdminRole -Policy $_)) -and
-        ($_['grantControls']['builtInControls'] -contains 'mfa')
+        (Test-RequiresMfa -Policy $_)
     })
 
+    # Explicit admin-role coverage is definitive. All-Users coverage also protects admins,
+    # but only confidently when the policy has no user/group exclusions we cannot resolve;
+    # otherwise the admins may be carved out and the result is Review, not Pass (#1000 review).
     $adminRolePolicies = @($mfaAdminPolicies | Where-Object { Test-TargetAdminRole -Policy $_ })
-    $coverageVia = if ($adminRolePolicies.Count -gt 0) { 'admin-role-targeted' } else { 'All-Users scope' }
+    $allUserOnly       = @($mfaAdminPolicies | Where-Object { -not (Test-TargetAdminRole -Policy $_) })
+    $allUserClean      = @($allUserOnly | Where-Object { -not (Test-HasUserOrGroupExclusion -Policy $_) })
+    $allUserExcluded   = @($allUserOnly | Where-Object { Test-HasUserOrGroupExclusion -Policy $_ })
 
     $mfaAdminEvidence = [PSCustomObject]@{
-        PolicyCount = $mfaAdminPolicies.Count
-        PolicyNames = @($mfaAdminPolicies | ForEach-Object { $_['displayName'] })
-        CoverageVia = $coverageVia
+        PolicyCount            = $mfaAdminPolicies.Count
+        PolicyNames            = @($mfaAdminPolicies | ForEach-Object { $_['displayName'] })
+        AdminRoleTargetedCount = $adminRolePolicies.Count
+        AllUsersCleanCount     = $allUserClean.Count
+        AllUsersExcludedCount  = $allUserExcluded.Count
     }
-    if ($mfaAdminPolicies.Count -gt 0) {
-        $names = ($mfaAdminPolicies | ForEach-Object { $_['displayName'] }) -join '; '
+    if ($adminRolePolicies.Count -gt 0) {
+        $names = ($adminRolePolicies | ForEach-Object { $_['displayName'] }) -join '; '
         $settingParams = @{
             Category         = 'Conditional Access'
             Setting          = 'MFA Required for Admin Roles'
-            CurrentValue     = "Yes ($($mfaAdminPolicies.Count) policy via ${coverageVia}: $names)"
+            CurrentValue     = "Yes ($($adminRolePolicies.Count) admin-role-targeted policy: $names)"
             RecommendedValue = 'At least 1 policy'
             Status           = 'Pass'
             CheckId          = 'CA-MFA-ADMIN-001'
             Remediation      = 'No action needed.'
+            Evidence         = $mfaAdminEvidence
+        }
+        Add-Setting @settingParams
+    }
+    elseif ($allUserClean.Count -gt 0) {
+        $names = ($allUserClean | ForEach-Object { $_['displayName'] }) -join '; '
+        $settingParams = @{
+            Category         = 'Conditional Access'
+            Setting          = 'MFA Required for Admin Roles'
+            CurrentValue     = "Yes (covered by All-Users MFA policy: $names)"
+            RecommendedValue = 'At least 1 policy'
+            Status           = 'Pass'
+            CheckId          = 'CA-MFA-ADMIN-001'
+            Remediation      = 'No action needed. Admins are covered by an All-Users MFA policy; a dedicated admin-role policy would add defense in depth.'
+            Evidence         = $mfaAdminEvidence
+        }
+        Add-Setting @settingParams
+    }
+    elseif ($allUserExcluded.Count -gt 0) {
+        $names = ($allUserExcluded | ForEach-Object { $_['displayName'] }) -join '; '
+        $settingParams = @{
+            Category         = 'Conditional Access'
+            Setting          = 'MFA Required for Admin Roles'
+            CurrentValue     = "All-Users MFA policy found but it excludes users/groups; verify admins are not carved out: $names"
+            RecommendedValue = 'At least 1 policy'
+            Status           = 'Review'
+            CheckId          = 'CA-MFA-ADMIN-001'
+            Remediation      = 'Confirm the excluded users/groups do not contain administrators, or add a dedicated Conditional Access policy targeting admin directory roles with Require multifactor authentication.'
             Evidence         = $mfaAdminEvidence
         }
         Add-Setting @settingParams

--- a/tests/Behavior/Status-Emission-Audit.Tests.ps1
+++ b/tests/Behavior/Status-Emission-Audit.Tests.ps1
@@ -46,9 +46,9 @@ Describe 'Review/Unknown/Skipped emission count lock-down (#884)' {
     # audit.md classifying the new emission as genuine-limitation vs.
     # collector-bug.
 
-    It "Review emissions stay at or below the audited ceiling (69)" {
+    It "Review emissions stay at or below the audited ceiling (70)" {
         $script:counts.Review |
-            Should -BeLessOrEqual 69 -Because 'a new Review emission was added without updating docs/research/review-status-audit.md — see issue #884'
+            Should -BeLessOrEqual 70 -Because 'a new Review emission was added without updating docs/research/review-status-audit.md — see issue #884'
     }
 
     It "Skipped emissions stay at or below the audited ceiling (31)" {
@@ -62,7 +62,7 @@ Describe 'Review/Unknown/Skipped emission count lock-down (#884)' {
     }
 
     It 'reports current emission counts for visibility (informational)' {
-        Write-Host ("    [INFO] Review:  $($script:counts.Review) / 69")
+        Write-Host ("    [INFO] Review:  $($script:counts.Review) / 70")
         Write-Host ("    [INFO] Skipped: $($script:counts.Skipped) / 31")
         Write-Host ("    [INFO] Unknown: $($script:counts.Unknown) / 1")
         Write-Host ("    [INFO] Total:   $($script:emissions.Count)")

--- a/tests/Entra/Get-CASecurityConfig.Tests.ps1
+++ b/tests/Entra/Get-CASecurityConfig.Tests.ps1
@@ -711,3 +711,113 @@ Describe 'Get-CASecurityConfig - CA-STALEREF-001 Fail path' {
         Remove-Item Function:\Update-CheckProgress -ErrorAction SilentlyContinue
     }
 }
+
+Describe 'Get-CASecurityConfig - Admin MFA via All-Users policy (#1000)' {
+    BeforeAll {
+        function global:Update-CheckProgress {
+            param($CheckId, $Setting, $Status)
+        }
+
+        function Get-MgContext { return @{ TenantId = 'test-tenant-id' } }
+
+        # Security Defaults off, a single enabled policy that requires MFA for All Users
+        # (no policy explicitly targets admin directory roles). Admins are covered because
+        # they are part of the All-Users assignment.
+        Mock Invoke-MgGraphRequest {
+            param($Method, $Uri)
+            if ($Uri -like '*identitySecurityDefaultsEnforcementPolicy*') {
+                return @{ isEnabled = $false }
+            }
+            if ($Uri -like '*conditionalAccess/policies*') {
+                return @{ value = @(
+                    @{
+                        id = 'ca-allusers-mfa'
+                        displayName = 'Require MFA for all users'
+                        state = 'enabled'
+                        conditions = @{
+                            users = @{
+                                includeUsers  = @('All')
+                                includeRoles  = @()
+                                excludeRoles  = @()
+                                excludeUsers  = @()
+                                excludeGroups = @()
+                            }
+                            clientAppTypes = @('all')
+                        }
+                        grantControls = @{ builtInControls = @('mfa') }
+                        sessionControls = @{}
+                    }
+                )}
+            }
+            return @{ value = @() }
+        }
+
+        . "$PSScriptRoot/../../src/M365-Assess/Orchestrator/AssessmentHelpers.ps1"
+        . "$PSScriptRoot/../../src/M365-Assess/Entra/Get-CASecurityConfig.ps1"
+    }
+
+    It 'MFA for admin roles passes when only an All-Users MFA policy exists' {
+        $check = $settings | Where-Object { $_.Setting -eq 'MFA Required for Admin Roles' }
+        $check | Should -Not -BeNullOrEmpty
+        $check.Status | Should -Be 'Pass' -Because 'admins are included in the All-Users MFA policy'
+    }
+
+    AfterAll {
+        Remove-Item Function:\Update-CheckProgress -ErrorAction SilentlyContinue
+    }
+}
+
+Describe 'Get-CASecurityConfig - Admin MFA All-Users policy excludes admins (#1000)' {
+    BeforeAll {
+        function global:Update-CheckProgress {
+            param($CheckId, $Setting, $Status)
+        }
+
+        function Get-MgContext { return @{ TenantId = 'test-tenant-id' } }
+
+        # Security Defaults off, one enabled All-Users MFA policy that EXCLUDES the Global
+        # Administrator role. Admins are carved out, so the control must still Fail rather
+        # than be marked covered.
+        Mock Invoke-MgGraphRequest {
+            param($Method, $Uri)
+            if ($Uri -like '*identitySecurityDefaultsEnforcementPolicy*') {
+                return @{ isEnabled = $false }
+            }
+            if ($Uri -like '*conditionalAccess/policies*') {
+                return @{ value = @(
+                    @{
+                        id = 'ca-allusers-excl-admin'
+                        displayName = 'MFA for all users except admins'
+                        state = 'enabled'
+                        conditions = @{
+                            users = @{
+                                includeUsers  = @('All')
+                                includeRoles  = @()
+                                excludeRoles  = @('62e90394-69f5-4237-9190-012177145e10')
+                                excludeUsers  = @()
+                                excludeGroups = @()
+                            }
+                            clientAppTypes = @('all')
+                        }
+                        grantControls = @{ builtInControls = @('mfa') }
+                        sessionControls = @{}
+                    }
+                )}
+            }
+            return @{ value = @() }
+        }
+
+        . "$PSScriptRoot/../../src/M365-Assess/Orchestrator/AssessmentHelpers.ps1"
+        . "$PSScriptRoot/../../src/M365-Assess/Entra/Get-CASecurityConfig.ps1"
+    }
+
+    It 'MFA for admin roles fails when the All-Users policy excludes an admin role' {
+        $check = $settings | Where-Object { $_.Setting -eq 'MFA Required for Admin Roles' }
+        $check | Should -Not -BeNullOrEmpty
+        $check.Status | Should -Be 'Fail' -Because 'the Global Administrator role is excluded from the policy'
+    }
+
+    AfterAll {
+        Remove-Item Function:\Update-CheckProgress -ErrorAction SilentlyContinue
+    }
+}

--- a/tests/Entra/Get-CASecurityConfig.Tests.ps1
+++ b/tests/Entra/Get-CASecurityConfig.Tests.ps1
@@ -821,3 +821,122 @@ Describe 'Get-CASecurityConfig - Admin MFA All-Users policy excludes admins (#10
         Remove-Item Function:\Update-CheckProgress -ErrorAction SilentlyContinue
     }
 }
+
+Describe 'Get-CASecurityConfig - All-Users MFA under operator OR (#1000 review)' {
+    BeforeAll {
+        function global:Update-CheckProgress { param($CheckId, $Setting, $Status) }
+        function Get-MgContext { return @{ TenantId = 'test-tenant-id' } }
+
+        # One All-Users policy whose grant is "MFA OR compliant device" (operator OR).
+        # MFA is NOT actually required, so it must not count as admin MFA coverage.
+        Mock Invoke-MgGraphRequest {
+            param($Method, $Uri)
+            if ($Uri -like '*identitySecurityDefaultsEnforcementPolicy*') { return @{ isEnabled = $false } }
+            if ($Uri -like '*conditionalAccess/policies*') {
+                return @{ value = @(
+                    @{
+                        id = 'ca-or'
+                        displayName = 'MFA or compliant device for all users'
+                        state = 'enabled'
+                        conditions = @{ users = @{ includeUsers = @('All'); includeRoles = @(); excludeRoles = @(); excludeUsers = @(); excludeGroups = @() }; clientAppTypes = @('all') }
+                        grantControls = @{ builtInControls = @('mfa', 'compliantDevice'); operator = 'OR' }
+                        sessionControls = @{}
+                    }
+                )}
+            }
+            return @{ value = @() }
+        }
+
+        . "$PSScriptRoot/../../src/M365-Assess/Orchestrator/AssessmentHelpers.ps1"
+        . "$PSScriptRoot/../../src/M365-Assess/Entra/Get-CASecurityConfig.ps1"
+    }
+
+    It 'does not treat an OR-combined mfa-or-device policy as admin MFA' {
+        $check = $settings | Where-Object { $_.Setting -eq 'MFA Required for Admin Roles' }
+        $check | Should -Not -BeNullOrEmpty
+        $check.Status | Should -Be 'Fail' -Because 'MFA is not required when a compliant device is an OR alternative'
+    }
+
+    AfterAll {
+        Remove-Item Function:\Update-CheckProgress -ErrorAction SilentlyContinue
+    }
+}
+
+Describe 'Get-CASecurityConfig - All-Users MFA under operator AND (#1000 review)' {
+    BeforeAll {
+        function global:Update-CheckProgress { param($CheckId, $Setting, $Status) }
+        function Get-MgContext { return @{ TenantId = 'test-tenant-id' } }
+
+        # "MFA AND compliant device" (operator AND) DOES require MFA, so it still passes.
+        Mock Invoke-MgGraphRequest {
+            param($Method, $Uri)
+            if ($Uri -like '*identitySecurityDefaultsEnforcementPolicy*') { return @{ isEnabled = $false } }
+            if ($Uri -like '*conditionalAccess/policies*') {
+                return @{ value = @(
+                    @{
+                        id = 'ca-and'
+                        displayName = 'MFA and compliant device for all users'
+                        state = 'enabled'
+                        conditions = @{ users = @{ includeUsers = @('All'); includeRoles = @(); excludeRoles = @(); excludeUsers = @(); excludeGroups = @() }; clientAppTypes = @('all') }
+                        grantControls = @{ builtInControls = @('mfa', 'compliantDevice'); operator = 'AND' }
+                        sessionControls = @{}
+                    }
+                )}
+            }
+            return @{ value = @() }
+        }
+
+        . "$PSScriptRoot/../../src/M365-Assess/Orchestrator/AssessmentHelpers.ps1"
+        . "$PSScriptRoot/../../src/M365-Assess/Entra/Get-CASecurityConfig.ps1"
+    }
+
+    It 'passes when an AND-combined policy requires MFA for all users' {
+        $check = $settings | Where-Object { $_.Setting -eq 'MFA Required for Admin Roles' }
+        $check | Should -Not -BeNullOrEmpty
+        $check.Status | Should -Be 'Pass' -Because 'MFA is required under operator AND'
+    }
+
+    AfterAll {
+        Remove-Item Function:\Update-CheckProgress -ErrorAction SilentlyContinue
+    }
+}
+
+Describe 'Get-CASecurityConfig - All-Users MFA with group exclusion (#1000 review)' {
+    BeforeAll {
+        function global:Update-CheckProgress { param($CheckId, $Setting, $Status) }
+        function Get-MgContext { return @{ TenantId = 'test-tenant-id' } }
+
+        # One All-Users MFA policy that excludes a group. We cannot resolve group membership,
+        # so admins might be carved out; the control must report Review, not Pass.
+        Mock Invoke-MgGraphRequest {
+            param($Method, $Uri)
+            if ($Uri -like '*identitySecurityDefaultsEnforcementPolicy*') { return @{ isEnabled = $false } }
+            if ($Uri -like '*conditionalAccess/policies*') {
+                return @{ value = @(
+                    @{
+                        id = 'ca-allusers-exclgroup'
+                        displayName = 'MFA for all users except a group'
+                        state = 'enabled'
+                        conditions = @{ users = @{ includeUsers = @('All'); includeRoles = @(); excludeRoles = @(); excludeUsers = @(); excludeGroups = @('11111111-2222-3333-4444-555555555555') }; clientAppTypes = @('all') }
+                        grantControls = @{ builtInControls = @('mfa') }
+                        sessionControls = @{}
+                    }
+                )}
+            }
+            return @{ value = @() }
+        }
+
+        . "$PSScriptRoot/../../src/M365-Assess/Orchestrator/AssessmentHelpers.ps1"
+        . "$PSScriptRoot/../../src/M365-Assess/Entra/Get-CASecurityConfig.ps1"
+    }
+
+    It 'reports Review when the only coverage is an All-Users policy excluding a group' {
+        $check = $settings | Where-Object { $_.Setting -eq 'MFA Required for Admin Roles' }
+        $check | Should -Not -BeNullOrEmpty
+        $check.Status | Should -Be 'Review' -Because 'the excluded group might contain administrators'
+    }
+
+    AfterAll {
+        Remove-Item Function:\Update-CheckProgress -ErrorAction SilentlyContinue
+    }
+}


### PR DESCRIPTION
## Summary

The "MFA Required for Admin Roles" check (`CA-MFA-ADMIN-001`) only matched Conditional Access policies that explicitly targeted admin directory roles. Organizations that enforce MFA for All Users - which includes administrators - were reported as `No matching CA policy found`, a false FAIL, even though admins were fully protected.

## Related Issues

Closes #1000

## Changes

- Accept an enabled MFA policy that targets **All Users** as admin coverage (admins are part of that scope), in addition to the existing admin-role-targeted match. Reuses the existing `Test-TargetAllUser` helper.
- Guard against carve-outs so the change cannot introduce a false negative:
  - `Test-ExcludesAdminRole` - a policy that excludes an admin role via `excludeRoles` does not count.
  - `Test-RequiresMfa` (adversarial-review follow-up) - a grant of "MFA OR compliant device" (operator `OR`) does not require MFA, so it no longer counts; MFA counts only when it is the sole control or the operator is `AND`.
  - When admin coverage comes **only** from an All-Users policy that also carries `excludeUsers`/`excludeGroups` (not resolvable to membership here), the control reports **Review** with guidance instead of a confident Pass, so a group-based admin carve-out cannot silently pass.
- The output distinguishes admin-role-targeted coverage, clean All-Users coverage, and the Review case.

## Test Plan

- [x] PSScriptAnalyzer passes on changed `.ps1` files (0 issues under `PSScriptAnalyzerSettings.psd1`)
- [x] Pester tests pass (`tests/Entra` 229 passed, 0 failed). Scenarios: All-Users covers admins -> Pass; All-Users excludes admin role -> Fail; MFA-OR-device -> not counted; MFA-AND-device -> Pass; All-Users + group exclusion -> Review
- [ ] Ran against test tenant - pending live verification on a tenant whose admin MFA is provided only by an All-Users policy
- [ ] HTML report renders correctly - N/A (collector data only)
- [x] No secrets or tenant PII in committed files

## Remaining limitation

For an All-Users policy with user/group exclusions, membership is not resolved, so the control reports **Review** (verify admins are not excluded) rather than guessing Pass/Fail. Resolving membership to decide automatically would require a per-group directory lookup.

## Breaking Changes

None. Tenants covered only by a clean All-Users MFA policy now correctly pass instead of falsely failing; ambiguous exclusion cases surface as Review rather than a silent false pass.
