### PR TITLE
fix(tests): stub Install-Module when the runner lacks it (CI resilience)

### DIFF
--- a/tests/Orchestrator/Test-ModuleCompatibility.Tests.ps1
+++ b/tests/Orchestrator/Test-ModuleCompatibility.Tests.ps1
@@ -8,6 +8,23 @@ Describe 'Test-ModuleCompatibility' {
         . "$PSScriptRoot/../../src/M365-Assess/Orchestrator/AssessmentHelpers.ps1"
         . "$PSScriptRoot/../../src/M365-Assess/Orchestrator/Test-ModuleCompatibility.ps1"
 
+        # Some CI runner images ship PowerShell without PowerShellGet's Install-Module on
+        # the command path (the PSResourceGet migration). Pester's Mock requires the command
+        # to exist, so define a no-op stub with the parameters the collector actually passes
+        # when the real cmdlet is absent. Real environments keep the genuine cmdlet, so this
+        # branch is a no-op locally and only engages on a stripped-down runner.
+        if (-not (Get-Command -Name Install-Module -ErrorAction SilentlyContinue)) {
+            function Install-Module {
+                [CmdletBinding()]
+                param(
+                    [string]$Name,
+                    [string]$RequiredVersion,
+                    [string]$Scope,
+                    [switch]$Force
+                )
+            }
+        }
+
         Mock Write-Host { }
         Mock Write-AssessmentLog { }
 


### PR DESCRIPTION
## Summary

The `Pester Tests` job started failing on every PR (and would fail on `main` if re-run) with `CommandNotFoundException: Could not find Command Install-Module`. Newer GitHub-hosted runner images ship PowerShell without PowerShellGet's `Install-Module` on the command path (the PSResourceGet migration). `tests/Orchestrator/Test-ModuleCompatibility.Tests.ps1` calls `Mock Install-Module`, and Pester's `Mock` requires the command to exist, so every context in that file errored at setup time.

This is an environment regression, not a code change: the affected test passes locally where `Install-Module` exists, and the failure appeared across unrelated PRs.

## Related Issues

None (CI infrastructure fix). Unblocks #1003, #1004, #1005.

## Changes

- Define a no-op `Install-Module` stub (with the `-Name`/`-RequiredVersion`/`-Scope`/`-Force` parameters the collector passes) in the test's top `BeforeAll`, guarded by `Get-Command`, so it only engages when the real cmdlet is absent. Pester can then mock it on any runner. Real environments keep the genuine cmdlet, so the branch is a no-op locally.

## Test Plan

- [x] PSScriptAnalyzer passes (CI excludes `*.Tests.ps1` from the analyzer)
- [x] Pester tests pass locally (`Test-ModuleCompatibility` 16/0)
- [x] Reproduced the runner condition locally (auto-loading disabled + PowerShellGet removed so `Install-Module` is not visible): suite still passes 16/0 with the stub
- [ ] Ran against test tenant - N/A (test-only change)
- [x] No secrets or tenant PII in committed files

## Breaking Changes

None. Test-only change; behavior is identical on environments that already have `Install-Module`.
