### PR TITLE
chore(deps): upgrade Babel to 8 with pinned classic JSX runtime

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,0 +1,5 @@
+{
+  "presets": [
+    ["@babel/preset-react", { "runtime": "classic" }]
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,91 +8,87 @@
       "name": "m365-assess-report",
       "version": "1.0.0",
       "devDependencies": {
-        "@babel/cli": "^7.29.7",
-        "@babel/core": "^7.29.7",
-        "@babel/preset-react": "^7.29.7"
+        "@babel/cli": "^8.0.1",
+        "@babel/core": "^8.0.1",
+        "@babel/preset-react": "^8.0.1"
       }
     },
     "node_modules/@babel/cli": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.29.7.tgz",
-      "integrity": "sha512-/75HwRbAYPqXv/Ax1h7Fg3IZfXgdU98jnA8H93/m/QBaPV3Hp5ICoLqzGYye1yHBCgpmXvtqgSUN8oOKX5tojQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-8.0.1.tgz",
+      "integrity": "sha512-cttmeKZGho8XpXNz3nvGMjEnpDW5qkPVGNW2buav2byKxArJnBROsJrLA7CioPQhjzsZ26aZRqg+Gvpk+FHGEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.28",
-        "commander": "^6.2.0",
+        "commander": "^14.0.2",
         "convert-source-map": "^2.0.0",
-        "fs-readdir-recursive": "^1.1.0",
-        "glob": "^7.2.0",
-        "make-dir": "^2.1.0",
-        "slash": "^2.0.0"
+        "glob": "^13.0.0",
+        "slash": "^5.1.0"
       },
       "bin": {
-        "babel": "bin/babel.js",
-        "babel-external-helpers": "bin/babel-external-helpers.js"
+        "babel": "bin/babel.js"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "optionalDependencies": {
-        "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
         "chokidar": "^3.6.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+      "integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
+        "@babel/helper-validator-identifier": "^8.0.0",
+        "js-tokens": "^10.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
-      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-8.0.0.tgz",
+      "integrity": "sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
-      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-8.0.1.tgz",
+      "integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
-        "@babel/helper-compilation-targets": "^7.29.7",
-        "@babel/helper-module-transforms": "^7.29.7",
-        "@babel/helpers": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/template": "^7.29.7",
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "@jridgewell/remapping": "^2.3.5",
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-compilation-targets": "^8.0.0",
+        "@babel/helpers": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/template": "^8.0.0",
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "@types/gensync": "^1.0.5",
         "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
+        "empathic": "^2.0.1",
         "gensync": "^1.0.0-beta.2",
+        "import-meta-resolve": "^4.2.0",
         "json5": "^2.2.3",
-        "semver": "^6.3.1"
+        "obug": "^2.1.1",
+        "semver": "^7.7.3"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "funding": {
         "type": "opencollective",
@@ -100,316 +96,302 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+      "integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
+        "@types/jsesc": "^2.5.0",
         "jsesc": "^3.0.2"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
-      "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-8.0.0.tgz",
+      "integrity": "sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^8.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
-      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-8.0.0.tgz",
+      "integrity": "sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.29.7",
-        "@babel/helper-validator-option": "^7.29.7",
+        "@babel/compat-data": "^8.0.0",
+        "@babel/helper-validator-option": "^8.0.0",
         "browserslist": "^4.24.0",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
+        "lru-cache": "^11.0.0",
+        "semver": "^7.7.3"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
-      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-8.0.0.tgz",
+      "integrity": "sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
-      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-8.0.0.tgz",
+      "integrity": "sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7"
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
-      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
-      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+      "integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
-      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
-      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
+      "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
-      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-8.0.0.tgz",
+      "integrity": "sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
-      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7"
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0.tgz",
+      "integrity": "sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^8.0.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
-      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-8.0.1.tgz",
+      "integrity": "sha512-n0jtCOxEovhU7METqSQjcZO9pX53nu9uNIjMS+hEt+Nt9jA7oOZoBIgbCxhhASmF6T6rPDGge5UAvh6Z4eFz/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-react-display-name": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.29.7.tgz",
-      "integrity": "sha512-+1wdDMGNb4UPeY3Q4L5yLiYe6TXPXubs4NjrgRFw13hPRLJfEMw2Q5OXkee6/IfdqePIeW4Jjwe3aBh7SdKz4Q==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-8.0.1.tgz",
+      "integrity": "sha512-soLishXlkyu6jcICPyO3HEP7A3GCzKEnn7XfvYrImuWEOwFAz93qShmWSYPf5ww0ZkO4By0zsN2bVIDF54fSdA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.29.7.tgz",
-      "integrity": "sha512-WsZulLVBUHXVj2cUcPVx6UE21TpalB6bHbSFErKT0Ib++ax24jjXe73FqlWvdylFOjiuPHYi6VCcgRad1ItN+A==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-8.0.1.tgz",
+      "integrity": "sha512-NgkoF7Uq+30TmOPDdNUimT0Nta02uVjqJRFNlVWKrbOCu/CkzfHa4aMnIs0lMpkMmZmWA1e42Va+F04i/pY1zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.29.7",
-        "@babel/helper-module-imports": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/plugin-syntax-jsx": "^7.29.7",
-        "@babel/types": "^7.29.7"
+        "@babel/helper-annotate-as-pure": "^8.0.0",
+        "@babel/helper-module-imports": "^8.0.0",
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/plugin-syntax-jsx": "^8.0.1",
+        "@babel/types": "^8.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-development": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.29.7.tgz",
-      "integrity": "sha512-Xfy3UVMF04+ypnFbkhvfqtmvwfe92qwQdbGZVonhE+6v35GzlofmOnA1szaZqzb9xYWr0nl1e5EMmzi0DNON1g==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-8.0.1.tgz",
+      "integrity": "sha512-Hb+HUZpV9KFHjm+F+P3aLDMi8QXU9l3ROCQv20z18Me2sGyW5nNNR5YTevNlgHvCpFek3BnAwhDGq/BRndXViw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/plugin-transform-react-jsx": "^7.29.7"
+        "@babel/plugin-transform-react-jsx": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-react-pure-annotations": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.29.7.tgz",
-      "integrity": "sha512-H5E+HBgDpr6Q5t+Aj11tL7XkIui1jhbIoArVQnqjgXo5/3YxkN7ZEBcWF4RQlB0T4rrxJQbXS6kiFV6B7XTqUA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-8.0.1.tgz",
+      "integrity": "sha512-7/8UwU8hoPBurXa9tUiTTC8aACTRy5tCqLUtqikHp2eGiWoEB57AduOdbQ71OOMTEvawKrGhv3WfzkDpI+/oSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-annotate-as-pure": "^8.0.0",
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/preset-react": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.29.7.tgz",
-      "integrity": "sha512-C+PV1TFUPTmBQGoPBL8j2QmLpZ117YTCwxIZeJOM96GbYMFSc7/pOXU5lVykwnZxyTqQxRsvoRk6f2FktZgGHA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-8.0.1.tgz",
+      "integrity": "sha512-jrFuPp/pTddFZbtmWhdLNAYc6UMcpboeUPnw0BBrm4nOmcAko/1TRcFi1PzWCeOFRU+VaSiKmat87W1HvR7mIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-validator-option": "^7.29.7",
-        "@babel/plugin-transform-react-display-name": "^7.29.7",
-        "@babel/plugin-transform-react-jsx": "^7.29.7",
-        "@babel/plugin-transform-react-jsx-development": "^7.29.7",
-        "@babel/plugin-transform-react-pure-annotations": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/helper-validator-option": "^8.0.0",
+        "@babel/plugin-transform-react-display-name": "^8.0.1",
+        "@babel/plugin-transform-react-jsx": "^8.0.1",
+        "@babel/plugin-transform-react-jsx-development": "^8.0.1",
+        "@babel/plugin-transform-react-pure-annotations": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
-      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+      "integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7"
+        "@babel/code-frame": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
-      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.0.tgz",
+      "integrity": "sha512-bxTj/W2VclGE6CctlfQOpxg8MPDzXArRqkOBePw8EHfebcjF7fETWSS3BriEECo+UiU/Yblq+xUtSImFu7cTbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
-        "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "debug": "^4.3.1"
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-globals": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "obug": "^2.1.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
+      "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7"
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -420,17 +402,6 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/remapping": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
@@ -462,13 +433,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@nicolo-ribaudo/chokidar-2": {
-      "version": "2.1.8-no-fsevents.3",
-      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
-      "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
+    "node_modules/@types/gensync": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/gensync/-/gensync-1.0.5.tgz",
+      "integrity": "sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
+    },
+    "node_modules/@types/jsesc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
@@ -486,16 +463,19 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.32",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
-      "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
+      "version": "2.10.42",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
+      "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -520,14 +500,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -545,9 +527,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
+      "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
       "dev": true,
       "funding": [
         {
@@ -565,10 +547,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001800",
+        "electron-to-chromium": "^1.5.387",
+        "node-releases": "^2.0.50",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -579,9 +561,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001793",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
-      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "version": "1.0.30001803",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
+      "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
       "dev": true,
       "funding": [
         {
@@ -626,21 +608,14 @@
       }
     },
     "node_modules/commander": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 6"
+        "node": ">=20"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -649,30 +624,22 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.361",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.361.tgz",
-      "integrity": "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==",
+      "version": "1.5.389",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/empathic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -697,20 +664,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/fs-readdir-recursive": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
-      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -738,22 +691,18 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -773,24 +722,16 @@
         "node": ">= 6"
       }
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -843,9 +784,9 @@
       }
     },
     "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -876,63 +817,45 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/make-dir": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^4.0.1",
-        "semver": "^5.6.0"
-      },
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
+        "node": "20 || >=22"
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "MIT"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
     },
     "node_modules/node-releases": {
-      "version": "2.0.46",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
-      "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -950,24 +873,35 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
       "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/picocolors": {
@@ -991,16 +925,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pify": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -1016,23 +940,29 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/slash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6"
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/to-regex-range": {
@@ -1079,20 +1009,6 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
-      "license": "ISC"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "private": true,
   "description": "Build tooling for the M365-Assess React HTML report",
   "scripts": {
-    "build": "babel src/M365-Assess/assets/report-app.jsx --presets @babel/preset-react --out-file src/M365-Assess/assets/report-app.js"
+    "build": "babel src/M365-Assess/assets/report-app.jsx --out-file src/M365-Assess/assets/report-app.js"
   },
   "devDependencies": {
-    "@babel/cli": "^7.29.7",
-    "@babel/core": "^7.29.7",
-    "@babel/preset-react": "^7.29.7"
+    "@babel/cli": "^8.0.1",
+    "@babel/core": "^8.0.1",
+    "@babel/preset-react": "^8.0.1"
   }
 }

--- a/src/M365-Assess/assets/report-app.js
+++ b/src/M365-Assess/assets/report-app.js
@@ -626,7 +626,7 @@ function Sidebar({
     className: "sc-title"
   }, "TENANT"), /*#__PURE__*/React.createElement("span", {
     className: "sc-sub"
-  }, "\xB7 SNAPSHOT")), /*#__PURE__*/React.createElement("div", {
+  }, "· SNAPSHOT")), /*#__PURE__*/React.createElement("div", {
     className: "sc-row"
   }, /*#__PURE__*/React.createElement("span", null, "org"), /*#__PURE__*/React.createElement("span", null, TENANT.DefaultDomain || TENANT.OrgDisplayName)), /*#__PURE__*/React.createElement("div", {
     className: "sc-row"
@@ -684,7 +684,7 @@ function Sidebar({
     className: "sc-title"
   }, "MFA"), /*#__PURE__*/React.createElement("span", {
     className: "sc-sub"
-  }, "\xB7 COVERAGE")), MFA_STATS.phishResistant > 0 && /*#__PURE__*/React.createElement("div", {
+  }, "· COVERAGE")), MFA_STATS.phishResistant > 0 && /*#__PURE__*/React.createElement("div", {
     className: "sc-row"
   }, /*#__PURE__*/React.createElement("span", {
     title: "Phishing-resistant MFA (FIDO2 keys, Windows Hello, certificates)"
@@ -785,18 +785,18 @@ function Topbar({
     className: "edit-toolbar"
   }, /*#__PURE__*/React.createElement("span", {
     className: "edit-toolbar-badge"
-  }, "\u270E Edit Mode"), hiddenCount > 0 && /*#__PURE__*/React.createElement("span", {
+  }, "✎ Edit Mode"), hiddenCount > 0 && /*#__PURE__*/React.createElement("span", {
     className: "edit-toolbar-info"
   }, hiddenCount, " finding", hiddenCount === 1 ? '' : 's', " hidden"), /*#__PURE__*/React.createElement("button", {
     className: "edit-toolbar-reset",
     onClick: onReset
-  }, "\u21BA Reset all"), /*#__PURE__*/React.createElement("button", {
+  }, "↺ Reset all"), /*#__PURE__*/React.createElement("button", {
     className: "edit-toolbar-finalize",
     onClick: onFinalize
-  }, "\u2193 Finalize report"), /*#__PURE__*/React.createElement("button", {
+  }, "↓ Finalize report"), /*#__PURE__*/React.createElement("button", {
     className: "edit-toolbar-exit",
     onClick: onEditToggle
-  }, "\u2715 Exit edit mode")), /*#__PURE__*/React.createElement("div", {
+  }, "✕ Exit edit mode")), /*#__PURE__*/React.createElement("div", {
     className: "topbar"
   }, /*#__PURE__*/React.createElement("button", {
     className: "hamburger-btn",
@@ -806,7 +806,7 @@ function Topbar({
     className: "title"
   }, "Security posture report", /*#__PURE__*/React.createElement("span", {
     className: "title-sub"
-  }, "\xB7 ", TENANT.OrgDisplayName)), /*#__PURE__*/React.createElement("div", {
+  }, "· ", TENANT.OrgDisplayName)), /*#__PURE__*/React.createElement("div", {
     className: "spacer"
   }), /*#__PURE__*/React.createElement("div", {
     className: "search"
@@ -821,7 +821,7 @@ function Topbar({
         setSearch('');
       }
     },
-    placeholder: "Search findings, check IDs, remediation\u2026 (Enter to cycle)"
+    placeholder: "Search findings, check IDs, remediation… (Enter to cycle)"
   }), search && /*#__PURE__*/React.createElement("span", {
     className: 'search-counter' + ((searchMatches || []).length === 0 ? ' is-empty' : '')
   }, (searchMatches || []).length === 0 ? '0/0' : matchIdx + 1 + '/' + searchMatches.length), /*#__PURE__*/React.createElement("kbd", null, "/")), /*#__PURE__*/React.createElement("div", {
@@ -855,7 +855,7 @@ function Topbar({
       fontSize: 13,
       letterSpacing: '-0.02em'
     }
-  }, "A\u2212")), /*#__PURE__*/React.createElement("button", {
+  }, "A−")), /*#__PURE__*/React.createElement("button", {
     className: 'icon-btn text-scale-step text-scale-step-inc' + (!canIncrement ? ' disabled' : ''),
     title: incTitle,
     "aria-disabled": !canIncrement,
@@ -1001,7 +1001,7 @@ function ScoringViews({
       className: "scoring-view-domain"
     }, f.domain))), items.length > 8 && /*#__PURE__*/React.createElement("li", {
       className: "scoring-view-more"
-    }, "+ ", items.length - 8, " more \u2014 see ", /*#__PURE__*/React.createElement("a", {
+    }, "+ ", items.length - 8, " more — see ", /*#__PURE__*/React.createElement("a", {
       href: "#findings-anchor",
       onClick: e => {
         e.preventDefault();
@@ -1019,7 +1019,7 @@ function ScoringViews({
     className: "section-head"
   }, /*#__PURE__*/React.createElement("span", {
     className: "eyebrow"
-  }, "01c \xB7 Scoring"), /*#__PURE__*/React.createElement("h2", null, "Posture views by audience"), /*#__PURE__*/React.createElement("div", {
+  }, "01c · Scoring"), /*#__PURE__*/React.createElement("h2", null, "Posture views by audience"), /*#__PURE__*/React.createElement("div", {
     className: "hr"
   })), /*#__PURE__*/React.createElement("div", {
     className: "scoring-views"
@@ -1070,7 +1070,7 @@ function PermissionsPanel() {
       color: 'var(--text-soft)',
       marginBottom: 10
     }
-  }, p.authMode, " auth \xB7 ", sections.length, " section", sections.length === 1 ? '' : 's', " checked \xB7 ", allOk ? 'all granted' : `${missingTotal} role(s) missing`), /*#__PURE__*/React.createElement("table", {
+  }, p.authMode, " auth · ", sections.length, " section", sections.length === 1 ? '' : 's', " checked · ", allOk ? 'all granted' : `${missingTotal} role(s) missing`), /*#__PURE__*/React.createElement("table", {
     className: "permissions-table"
   }, /*#__PURE__*/React.createElement("thead", null, /*#__PURE__*/React.createElement("tr", null, /*#__PURE__*/React.createElement("th", null, "Section"), /*#__PURE__*/React.createElement("th", null, "Required"), /*#__PURE__*/React.createElement("th", null, "Missing"), /*#__PURE__*/React.createElement("th", null, "Status"))), /*#__PURE__*/React.createElement("tbody", null, sections.map(([name, s]) => {
     const req = asArray(s.required);
@@ -1084,7 +1084,7 @@ function PermissionsPanel() {
       className: "status-badge unknown"
     }, m)) : /*#__PURE__*/React.createElement("span", {
       className: "muted"
-    }, "\u2014")), /*#__PURE__*/React.createElement("td", null, s.ok ? /*#__PURE__*/React.createElement("span", {
+    }, "—")), /*#__PURE__*/React.createElement("td", null, s.ok ? /*#__PURE__*/React.createElement("span", {
       className: "status-badge pass"
     }, "OK") : /*#__PURE__*/React.createElement("span", {
       className: "status-badge fail"
@@ -1327,7 +1327,7 @@ function Posture() {
     title: `Peer avg ${avg}%`
   })), /*#__PURE__*/React.createElement("div", {
     className: "score-footnote"
-  }, /*#__PURE__*/React.createElement("span", null, "0"), avgAvailable && /*#__PURE__*/React.createElement("span", null, "Peer avg \xB7 ", avg.toFixed(1), "%"), /*#__PURE__*/React.createElement("span", null, "100")), /*#__PURE__*/React.createElement(Sparkline, {
+  }, /*#__PURE__*/React.createElement("span", null, "0"), avgAvailable && /*#__PURE__*/React.createElement("span", null, "Peer avg · ", avg.toFixed(1), "%"), /*#__PURE__*/React.createElement("span", null, "100")), /*#__PURE__*/React.createElement(Sparkline, {
     scores: D.score,
     avg: avg
   }), SCORE.MicrosoftScore != null && SCORE.CustomerScore != null && SCORE.MicrosoftScore > 0 && /*#__PURE__*/React.createElement("div", {
@@ -1346,7 +1346,7 @@ function Posture() {
     className: "score-split-value"
   }, fmt(SCORE.CustomerScore), " pts"))), /*#__PURE__*/React.createElement("div", {
     className: "score-disclaimer"
-  }, "Microsoft refreshes Secure Score on a delay \u2014 recent configuration changes can take up to 24 hours to reflect. The score above reflects Microsoft's last published value at assessment time, not the live tenant state.")) : /*#__PURE__*/React.createElement("div", {
+  }, "Microsoft refreshes Secure Score on a delay — recent configuration changes can take up to 24 hours to reflect. The score above reflects Microsoft's last published value at assessment time, not the live tenant state.")) : /*#__PURE__*/React.createElement("div", {
     className: "score-card score-card--unavailable"
   }, /*#__PURE__*/React.createElement("div", {
     className: "score-eyebrow"
@@ -1661,9 +1661,9 @@ function TrendChart() {
     id: "trend"
   }, /*#__PURE__*/React.createElement("div", headProps, /*#__PURE__*/React.createElement("span", {
     className: "eyebrow"
-  }, "01b \xB7 Trend"), /*#__PURE__*/React.createElement("h2", null, "Posture trend"), /*#__PURE__*/React.createElement("span", {
+  }, "01b · Trend"), /*#__PURE__*/React.createElement("h2", null, "Posture trend"), /*#__PURE__*/React.createElement("span", {
     className: "trend-subtitle"
-  }, trend.length, " snapshots \xB7 ", daysSpan, " day", daysSpan === 1 ? '' : 's', " span"), /*#__PURE__*/React.createElement("span", {
+  }, trend.length, " snapshots · ", daysSpan, " day", daysSpan === 1 ? '' : 's', " span"), /*#__PURE__*/React.createElement("span", {
     className: "section-chevron",
     "aria-hidden": "true"
   }, open ? '▾' : '▸'), /*#__PURE__*/React.createElement("div", {
@@ -1919,7 +1919,7 @@ function DnsAuthPanel() {
   }, risks.map((r, i) => /*#__PURE__*/React.createElement("span", {
     key: i,
     className: 'dns-risk-chip ' + r.cls
-  }, "\u26A0 ", r.msg))));
+  }, "⚠ ", r.msg))));
 }
 
 // ======================== Intune category grid ========================
@@ -2013,7 +2013,7 @@ function IntuneCategoryGrid() {
     className: "icat-pct"
   }, "%")), /*#__PURE__*/React.createElement("div", {
     className: "icat-meta"
-  }, b.pass, " pass \xB7 ", b.fail, " fail \xB7 ", b.fs.length, " checks"), /*#__PURE__*/React.createElement("div", {
+  }, b.pass, " pass · ", b.fail, " fail · ", b.fs.length, " checks"), /*#__PURE__*/React.createElement("div", {
     className: "dc-bar",
     style: {
       height: 4,
@@ -2047,7 +2047,7 @@ function MailboxSummaryPanel() {
     className: "domain-sub-panel"
   }, /*#__PURE__*/React.createElement("div", {
     className: "panel-sublabel"
-  }, "Exchange Online \xB7 mailbox estate"), /*#__PURE__*/React.createElement("div", {
+  }, "Exchange Online · mailbox estate"), /*#__PURE__*/React.createElement("div", {
     className: "kpi-strip",
     style: {
       flexWrap: 'wrap'
@@ -2060,7 +2060,7 @@ function MailboxSummaryPanel() {
     className: "kpi-value"
   }, fmt(total)), /*#__PURE__*/React.createElement("div", {
     className: "kpi-hint"
-  }, fmt(mb.UserMailboxes || 0), " user \xB7 ", fmt(mb.SharedMailboxes || 0), " shared"), /*#__PURE__*/React.createElement("div", {
+  }, fmt(mb.UserMailboxes || 0), " user · ", fmt(mb.SharedMailboxes || 0), " shared"), /*#__PURE__*/React.createElement("div", {
     className: "tiny-bar"
   }, /*#__PURE__*/React.createElement("span", {
     style: {
@@ -2104,7 +2104,7 @@ function MailboxSummaryPanel() {
     className: "kpi-value"
   }, fmt((mf.inboundConnectors || 0) + (mf.outboundConnectors || 0))), /*#__PURE__*/React.createElement("div", {
     className: "kpi-hint"
-  }, mf.inboundConnectors || 0, " in \xB7 ", mf.outboundConnectors || 0, " out"), /*#__PURE__*/React.createElement("div", {
+  }, mf.inboundConnectors || 0, " in · ", mf.outboundConnectors || 0, " out"), /*#__PURE__*/React.createElement("div", {
     className: "tiny-bar"
   }, /*#__PURE__*/React.createElement("span", {
     style: {
@@ -2245,13 +2245,13 @@ function AdHybridPanel() {
     className: "domain-sub-panel"
   }, /*#__PURE__*/React.createElement("div", {
     className: "panel-sublabel"
-  }, "Active Directory \xB7 hybrid posture", ad.entraOnly && /*#__PURE__*/React.createElement("span", {
+  }, "Active Directory · hybrid posture", ad.entraOnly && /*#__PURE__*/React.createElement("span", {
     className: "kpi-hint",
     style: {
       marginLeft: 8,
       fontWeight: 400
     }
-  }, "(Entra data \u2014 AD collectors not run)")), /*#__PURE__*/React.createElement("div", {
+  }, "(Entra data — AD collectors not run)")), /*#__PURE__*/React.createElement("div", {
     className: "spo-summary-row"
   }, /*#__PURE__*/React.createElement("div", {
     className: "spo-stat-card"
@@ -2312,7 +2312,7 @@ function AdHybridPanel() {
     }
   }, "N/A"), /*#__PURE__*/React.createElement("div", {
     className: "kpi-hint"
-  }, "Cloud-only tenant \u2014 no on-prem hashes to sync")), ad.syncErrorCount > 0 && /*#__PURE__*/React.createElement("div", {
+  }, "Cloud-only tenant — no on-prem hashes to sync")), ad.syncErrorCount > 0 && /*#__PURE__*/React.createElement("div", {
     className: "spo-stat-card spo-stat-bad"
   }, /*#__PURE__*/React.createElement("div", {
     className: "kpi-label"
@@ -2332,7 +2332,7 @@ function AdHybridPanel() {
     }
   }, "%")), /*#__PURE__*/React.createElement("div", {
     className: "kpi-hint"
-  }, pass, " pass \xB7 ", fail, " fail"), /*#__PURE__*/React.createElement("div", {
+  }, pass, " pass · ", fail, " fail"), /*#__PURE__*/React.createElement("div", {
     className: "tiny-bar"
   }, /*#__PURE__*/React.createElement("span", {
     style: {
@@ -2383,7 +2383,7 @@ function DomainRollup({
     onClick: toggleOpen
   }, /*#__PURE__*/React.createElement("span", {
     className: "eyebrow"
-  }, "02 \xB7 Domains"), /*#__PURE__*/React.createElement("h2", null, "Security posture by domain ", /*#__PURE__*/React.createElement("span", {
+  }, "02 · Domains"), /*#__PURE__*/React.createElement("h2", null, "Security posture by domain ", /*#__PURE__*/React.createElement("span", {
     className: "section-chevron",
     "aria-hidden": "true"
   }, open ? '\u25be' : '\u25b8')), /*#__PURE__*/React.createElement("div", {
@@ -2888,11 +2888,11 @@ function FwManageButton({
     className: "fw-manage-head"
   }, /*#__PURE__*/React.createElement("div", {
     className: "fw-manage-eyebrow"
-  }, "Frameworks in scope \xB7 ", visibleIds.length, " of ", allFw.length), /*#__PURE__*/React.createElement("div", {
+  }, "Frameworks in scope · ", visibleIds.length, " of ", allFw.length), /*#__PURE__*/React.createElement("div", {
     className: "fw-manage-bulk"
   }, /*#__PURE__*/React.createElement("button", {
     onClick: () => onSetAll(allFw.map(f => f.id))
-  }, "Select all"), /*#__PURE__*/React.createElement("span", null, "\xB7"), /*#__PURE__*/React.createElement("button", {
+  }, "Select all"), /*#__PURE__*/React.createElement("span", null, "·"), /*#__PURE__*/React.createElement("button", {
     onClick: () => onSetAll([allFw[0].id]),
     disabled: visibleIds.length === 1
   }, "Reset"))), allFw.map(f => {
@@ -2923,7 +2923,7 @@ function FwManageButton({
         color: 'var(--muted)',
         fontFamily: 'var(--font-mono)'
       }
-    }, f.id, " \xB7 ", data?.counts.total || 0, " controls")), /*#__PURE__*/React.createElement("span", {
+    }, f.id, " · ", data?.counts.total || 0, " controls")), /*#__PURE__*/React.createElement("span", {
       className: 'ct ' + r.tone
     }, pct, "%"));
   })));
@@ -3128,7 +3128,7 @@ function CoverageChart({
       fontSize: 12,
       color: 'var(--text-soft)'
     }
-  }, frameworks.length, " frameworks \xB7 sorted by coverage")), /*#__PURE__*/React.createElement("div", {
+  }, frameworks.length, " frameworks · sorted by coverage")), /*#__PURE__*/React.createElement("div", {
     className: "fw-cov-chart-axis"
   }, /*#__PURE__*/React.createElement("span", null, "0%"), /*#__PURE__*/React.createElement("span", null, "50%"), /*#__PURE__*/React.createElement("span", null, "100%"))), /*#__PURE__*/React.createElement("div", {
     className: "fw-cov-chart-body"
@@ -3362,7 +3362,7 @@ function CompareTableM({
         e.stopPropagation();
         onRemove(fw.id);
       }
-    }, "\xD7"), /*#__PURE__*/React.createElement("span", {
+    }, "×"), /*#__PURE__*/React.createElement("span", {
       className: "fw-cmp-chev"
     }, isFocused ? '▾' : '▸')));
   }));
@@ -3457,7 +3457,7 @@ function FrameworkQuilt({
     id: "frameworks"
   }, /*#__PURE__*/React.createElement("div", headProps, /*#__PURE__*/React.createElement("span", {
     className: "eyebrow"
-  }, "01 \xB7 Compliance"), /*#__PURE__*/React.createElement("h2", null, "Framework coverage"), /*#__PURE__*/React.createElement("span", {
+  }, "01 · Compliance"), /*#__PURE__*/React.createElement("h2", null, "Framework coverage"), /*#__PURE__*/React.createElement("span", {
     style: {
       fontSize: 13,
       color: 'var(--muted)',
@@ -3652,7 +3652,7 @@ function FrameworkQuilt({
       fontSize: 12,
       color: 'var(--text-soft)'
     }
-  }, focused.families.length, " families \xB7 sorted by gaps \xB7 click a row to filter"))), /*#__PURE__*/React.createElement(FamilyChartM, {
+  }, focused.families.length, " families · sorted by gaps · click a row to filter"))), /*#__PURE__*/React.createElement(FamilyChartM, {
     families: [...focused.families].sort((a, b) => b.fail - a.fail),
     focused: family,
     onFocus: setFamily
@@ -3687,7 +3687,7 @@ function FrameworkQuilt({
     className: "fw-merged-detail-eyebrow"
   }, /*#__PURE__*/React.createElement("span", {
     className: "fw-merged-detail-arrow"
-  }, "\u2193"), "Selected \xB7 ", focused.id), /*#__PURE__*/React.createElement("div", {
+  }, "↓"), "Selected · ", focused.id), /*#__PURE__*/React.createElement("div", {
     className: "fw-merged-score-name",
     style: {
       fontSize: 20
@@ -3744,7 +3744,7 @@ function FrameworkQuilt({
       letterSpacing: 0,
       fontWeight: 400
     }
-  }, "\xB7 click a row to filter")), /*#__PURE__*/React.createElement(FamilyChartM, {
+  }, "· click a row to filter")), /*#__PURE__*/React.createElement(FamilyChartM, {
     families: [...focused.families].sort((a, b) => b.fail - a.fail),
     focused: family,
     onFocus: setFamily
@@ -3895,12 +3895,12 @@ function FilterBar({
   })), /*#__PURE__*/React.createElement("input", {
     value: search,
     onChange: e => setSearch(e.target.value),
-    placeholder: "Search findings, check IDs, categories\u2026"
+    placeholder: "Search findings, check IDs, categories…"
   }), search && /*#__PURE__*/React.createElement("button", {
     className: "fb-clear-x",
     onClick: () => setSearch(''),
     "aria-label": "Clear"
-  }, "\xD7"))), /*#__PURE__*/React.createElement("div", {
+  }, "×"))), /*#__PURE__*/React.createElement("div", {
     className: "fb-row fb-row-flow"
   }, /*#__PURE__*/React.createElement("div", {
     className: "filter-group"
@@ -4501,7 +4501,7 @@ function FindingsTable({
             style: {
               color: 'var(--muted)'
             }
-          }, "\u2014"));
+          }, "—"));
         }
       case 'finding':
         return /*#__PURE__*/React.createElement("div", {
@@ -4609,7 +4609,7 @@ function FindingsTable({
     id: "findings"
   }, /*#__PURE__*/React.createElement("div", headProps, /*#__PURE__*/React.createElement("span", {
     className: "eyebrow"
-  }, "03 \xB7 Detail"), /*#__PURE__*/React.createElement("h2", null, "All findings", isFiltered ? /*#__PURE__*/React.createElement("span", {
+  }, "03 · Detail"), /*#__PURE__*/React.createElement("h2", null, "All findings", isFiltered ? /*#__PURE__*/React.createElement("span", {
     style: {
       marginLeft: 8,
       fontSize: 12,
@@ -4627,13 +4627,13 @@ function FindingsTable({
       color: 'var(--muted)',
       fontSize: 13
     }
-  }, " \xB7 ", FINDINGS.length, " total")), editMode && hiddenFindings?.size > 0 && /*#__PURE__*/React.createElement("button", {
+  }, " · ", FINDINGS.length, " total")), editMode && hiddenFindings?.size > 0 && /*#__PURE__*/React.createElement("button", {
     className: "restore-all-btn",
     onClick: e => {
       e.stopPropagation();
       onRestoreAll();
     }
-  }, "\u21A9 Restore ", hiddenFindings.size, " hidden"), /*#__PURE__*/React.createElement("button", {
+  }, "↩ Restore ", hiddenFindings.size, " hidden"), /*#__PURE__*/React.createElement("button", {
     className: "chip chip-more",
     style: {
       marginLeft: 12,
@@ -4723,7 +4723,7 @@ function FindingsTable({
       onDragEnd: onColDragEnd,
       title: "Drag to reorder column",
       "aria-label": `Reorder ${c.label} column`
-    }, "\u22EE\u22EE"), sortable ? /*#__PURE__*/React.createElement("button", {
+    }, "⋮⋮"), sortable ? /*#__PURE__*/React.createElement("button", {
       type: "button",
       className: 'findings-col-sort' + (isActive ? ' active' : ''),
       onClick: () => cycleSort(c.id),
@@ -4796,7 +4796,7 @@ function FindingsTable({
       href: r.url,
       target: "_blank",
       rel: "noreferrer noopener"
-    }, "\uD83D\uDCD6 ", r.title, " \u2197"))), /*#__PURE__*/React.createElement(FindingProvenanceFooter, {
+    }, "📖 ", r.title, " ↗"))), /*#__PURE__*/React.createElement(FindingProvenanceFooter, {
       evidence: f.evidence
     })));
   })));
@@ -4953,7 +4953,7 @@ function FindingStateStrip({
   } else {
     sequenceNode = /*#__PURE__*/React.createElement("span", {
       className: "val muted"
-    }, "\u2014");
+    }, "—");
   }
   const effort = f.effort ? f.effort[0].toUpperCase() + f.effort.slice(1) : '—';
 
@@ -4988,7 +4988,7 @@ function FindingStateStrip({
     className: 'val ' + affectedClass
   }, affectedText) : /*#__PURE__*/React.createElement("span", {
     className: "val muted"
-  }, "\u2014")), /*#__PURE__*/React.createElement("div", {
+  }, "—")), /*#__PURE__*/React.createElement("div", {
     className: "fdd-strip-cell"
   }, /*#__PURE__*/React.createElement("span", {
     className: "label"
@@ -5000,7 +5000,7 @@ function FindingStateStrip({
     className: "label"
   }, "Ticket"), /*#__PURE__*/React.createElement("span", {
     className: "val muted"
-  }, "\u2014")));
+  }, "—")));
 }
 function FindingRiskNarrative({
   f
@@ -5074,11 +5074,11 @@ function FindingProvenanceFooter({
     className: "prov-key"
   }, "Provenance"), summaryEntries.length === 0 && /*#__PURE__*/React.createElement("span", {
     className: "prov-sep"
-  }, "\xB7"), summaryEntries.map(([k, v], i) => /*#__PURE__*/React.createElement(React.Fragment, {
+  }, "·"), summaryEntries.map(([k, v], i) => /*#__PURE__*/React.createElement(React.Fragment, {
     key: k
   }, i > 0 && /*#__PURE__*/React.createElement("span", {
     className: "prov-sep"
-  }, "\xB7"), /*#__PURE__*/React.createElement("code", null, k === 'confidence' ? `${Math.round(v * 100)}%` : String(v))))), /*#__PURE__*/React.createElement("span", {
+  }, "·"), /*#__PURE__*/React.createElement("code", null, k === 'confidence' ? `${Math.round(v * 100)}%` : String(v))))), /*#__PURE__*/React.createElement("span", {
     className: "prov-toggle"
   }, "View details")), /*#__PURE__*/React.createElement("div", {
     className: "fdd-prov-body"
@@ -5390,7 +5390,7 @@ function Roadmap({
       className: "dot"
     }), statusLabel(t.status))), /*#__PURE__*/React.createElement("div", {
       className: "task-id"
-    }, t.checkId, " \xB7 ", t.domain), /*#__PURE__*/React.createElement("div", {
+    }, t.checkId, " · ", t.domain), /*#__PURE__*/React.createElement("div", {
       className: "task-tags"
     }, /*#__PURE__*/React.createElement("span", {
       className: 'task-tag task-tag-sev sev-' + t.severity
@@ -5413,25 +5413,25 @@ function Roadmap({
         e.stopPropagation();
         moveTo(key, 'soon');
       }
-    }, "Next \u2192"), lane === 'soon' && /*#__PURE__*/React.createElement("button", {
+    }, "Next →"), lane === 'soon' && /*#__PURE__*/React.createElement("button", {
       className: "task-move-btn",
       onClick: e => {
         e.stopPropagation();
         moveTo(key, 'now');
       }
-    }, "\u2190 Now"), lane === 'soon' && /*#__PURE__*/React.createElement("button", {
+    }, "← Now"), lane === 'soon' && /*#__PURE__*/React.createElement("button", {
       className: "task-move-btn",
       onClick: e => {
         e.stopPropagation();
         moveTo(key, 'later');
       }
-    }, "Later \u2192"), lane === 'later' && /*#__PURE__*/React.createElement("button", {
+    }, "Later →"), lane === 'later' && /*#__PURE__*/React.createElement("button", {
       className: "task-move-btn",
       onClick: e => {
         e.stopPropagation();
         moveTo(key, 'soon');
       }
-    }, "\u2190 Next"), isCustom && /*#__PURE__*/React.createElement("button", {
+    }, "← Next"), isCustom && /*#__PURE__*/React.createElement("button", {
       className: "task-move-btn task-move-reset",
       onClick: e => {
         e.stopPropagation();
@@ -5457,7 +5457,7 @@ function Roadmap({
       style: {
         color: 'var(--muted)'
       }
-    }, "\u2014"))), /*#__PURE__*/React.createElement("div", {
+    }, "—"))), /*#__PURE__*/React.createElement("div", {
       className: "task-field"
     }, /*#__PURE__*/React.createElement("div", {
       className: "task-field-label"
@@ -5467,7 +5467,7 @@ function Roadmap({
       style: {
         color: 'var(--muted)'
       }
-    }, "\u2014")))), t.remediation && /*#__PURE__*/React.createElement("div", {
+    }, "—")))), t.remediation && /*#__PURE__*/React.createElement("div", {
       className: "task-field"
     }, /*#__PURE__*/React.createElement("div", {
       className: "task-field-label"
@@ -5499,7 +5499,7 @@ function Roadmap({
         color: 'var(--accent-text)',
         textDecoration: 'none'
       }
-    }, "\uD83D\uDCD6 ", r.title, " \u2197")))), /*#__PURE__*/React.createElement("div", {
+    }, "📖 ", r.title, " ↗")))), /*#__PURE__*/React.createElement("div", {
       className: "task-meta-row"
     }, /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, "Section:"), " ", t.section), /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, "Severity:"), " ", SEV_LABEL[t.severity]), t.effort && /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, "Effort:"), " ", t.effort), /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, "Frameworks:"), " ", t.frameworks.join(', ') || '—')), /*#__PURE__*/React.createElement("div", {
       className: "task-actions"
@@ -5509,7 +5509,7 @@ function Roadmap({
         e.preventDefault();
         onViewFinding?.(t.checkId);
       }
-    }, "View in findings table \u2192"))));
+    }, "View in findings table →"))));
   };
   const LaneReset = ({
     laneItems
@@ -5526,7 +5526,7 @@ function Roadmap({
     id: "roadmap"
   }, /*#__PURE__*/React.createElement("div", headProps, /*#__PURE__*/React.createElement("span", {
     className: "eyebrow"
-  }, "04 \xB7 Action plan"), /*#__PURE__*/React.createElement("h2", null, "Remediation roadmap"), /*#__PURE__*/React.createElement("span", {
+  }, "04 · Action plan"), /*#__PURE__*/React.createElement("h2", null, "Remediation roadmap"), /*#__PURE__*/React.createElement("span", {
     className: "section-chevron",
     "aria-hidden": "true"
   }, sectionOpen ? '▾' : '▸'), /*#__PURE__*/React.createElement("div", {
@@ -5546,11 +5546,11 @@ function Roadmap({
     className: "roadmap-intro-head"
   }, "How we prioritized"), /*#__PURE__*/React.createElement("div", {
     className: "roadmap-intro-body"
-  }, "Findings are bucketed by severity. Critical findings \u2014 identity takeover, data exfiltration, privilege escalation paths \u2014 always go in ", /*#__PURE__*/React.createElement("b", null, "Now"), ". High-severity findings land in ", /*#__PURE__*/React.createElement("b", null, "Next"), ": risk is real but remediation typically requires coordination or scheduling. Medium-severity items also join ", /*#__PURE__*/React.createElement("b", null, "Next"), " when tractable, or ", /*#__PURE__*/React.createElement("b", null, "Later"), " for larger hardening work. ", /*#__PURE__*/React.createElement("br", null), /*#__PURE__*/React.createElement("span", {
+  }, "Findings are bucketed by severity. Critical findings — identity takeover, data exfiltration, privilege escalation paths — always go in ", /*#__PURE__*/React.createElement("b", null, "Now"), ". High-severity findings land in ", /*#__PURE__*/React.createElement("b", null, "Next"), ": risk is real but remediation typically requires coordination or scheduling. Medium-severity items also join ", /*#__PURE__*/React.createElement("b", null, "Next"), " when tractable, or ", /*#__PURE__*/React.createElement("b", null, "Later"), " for larger hardening work. ", /*#__PURE__*/React.createElement("br", null), /*#__PURE__*/React.createElement("span", {
     style: {
       color: 'var(--muted)'
     }
-  }, "Click any task to expand it, or use the move buttons on each card to reprioritize. Use Finalize (\u270E) to bake lane changes into the report."))), /*#__PURE__*/React.createElement("div", {
+  }, "Click any task to expand it, or use the move buttons on each card to reprioritize. Use Finalize (✎) to bake lane changes into the report."))), /*#__PURE__*/React.createElement("div", {
     className: "roadmap"
   }, /*#__PURE__*/React.createElement(HideableBlock, {
     hideKey: "roadmap-lane-now",
@@ -5569,7 +5569,7 @@ function Roadmap({
       color: 'var(--muted)',
       fontWeight: 400
     }
-  }, "\xB7 ", now.length)), /*#__PURE__*/React.createElement("div", {
+  }, "· ", now.length)), /*#__PURE__*/React.createElement("div", {
     style: {
       display: 'flex',
       alignItems: 'center',
@@ -5596,7 +5596,7 @@ function Roadmap({
       color: 'var(--muted)',
       fontWeight: 400
     }
-  }, "\xB7 ", soon.length)), /*#__PURE__*/React.createElement("div", {
+  }, "· ", soon.length)), /*#__PURE__*/React.createElement("div", {
     style: {
       display: 'flex',
       alignItems: 'center',
@@ -5606,7 +5606,7 @@ function Roadmap({
     laneItems: soon
   }), /*#__PURE__*/React.createElement("div", {
     className: "lane-eta"
-  }, "1 \u2013 4 weeks"))), soon.map(t => renderTask(t, 'soon')))), /*#__PURE__*/React.createElement(HideableBlock, {
+  }, "1 – 4 weeks"))), soon.map(t => renderTask(t, 'soon')))), /*#__PURE__*/React.createElement(HideableBlock, {
     hideKey: "roadmap-lane-later",
     label: "Later lane"
   }, /*#__PURE__*/React.createElement("div", {
@@ -5623,7 +5623,7 @@ function Roadmap({
       color: 'var(--muted)',
       fontWeight: 400
     }
-  }, "\xB7 ", later.length)), /*#__PURE__*/React.createElement("div", {
+  }, "· ", later.length)), /*#__PURE__*/React.createElement("div", {
     style: {
       display: 'flex',
       alignItems: 'center',
@@ -5633,7 +5633,7 @@ function Roadmap({
     laneItems: later
   }), /*#__PURE__*/React.createElement("div", {
     className: "lane-eta"
-  }, "1 \u2013 3 months"))), later.map(t => renderTask(t, 'later')))))));
+  }, "1 – 3 months"))), later.map(t => renderTask(t, 'later')))))));
 }
 
 // ======================== Critical Exposure section ========================
@@ -5655,7 +5655,7 @@ function CriticalExposureBlock() {
     id: "critical-exposure"
   }, /*#__PURE__*/React.createElement("div", headProps, /*#__PURE__*/React.createElement("span", {
     className: "eyebrow"
-  }, "01b \xB7 Critical exposure"), /*#__PURE__*/React.createElement("h2", null, "Critical exposure analysis"), /*#__PURE__*/React.createElement("span", {
+  }, "01b · Critical exposure"), /*#__PURE__*/React.createElement("h2", null, "Critical exposure analysis"), /*#__PURE__*/React.createElement("span", {
     className: "section-chevron",
     "aria-hidden": "true"
   }, open ? '▾' : '▸'), /*#__PURE__*/React.createElement("div", {
@@ -5697,7 +5697,7 @@ function CriticalExposureBlock() {
       color: 'var(--text-soft)',
       lineHeight: 1.55
     }
-  }, "Mapped to MITRE ATT&CK Enterprise techniques and CISA Known Exploited Vulnerabilities (KEV). Prioritized by CIS Critical Security Controls v8 \u2014 covers privileged account exposure, CA exclusions, dangerous Graph permissions, and audit trail gaps."), /*#__PURE__*/React.createElement("div", {
+  }, "Mapped to MITRE ATT&CK Enterprise techniques and CISA Known Exploited Vulnerabilities (KEV). Prioritized by CIS Critical Security Controls v8 — covers privileged account exposure, CA exclusions, dangerous Graph permissions, and audit trail gaps."), /*#__PURE__*/React.createElement("div", {
     style: {
       display: 'flex',
       gap: 18,
@@ -5772,15 +5772,15 @@ function Overview() {
     className: "tenant-line"
   }, /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, TENANT.OrgDisplayName)), /*#__PURE__*/React.createElement("span", {
     className: "sep"
-  }, "\u2502"), /*#__PURE__*/React.createElement("span", null, "Tenant ", /*#__PURE__*/React.createElement("b", null, TENANT.TenantId)), /*#__PURE__*/React.createElement("span", {
+  }, "│"), /*#__PURE__*/React.createElement("span", null, "Tenant ", /*#__PURE__*/React.createElement("b", null, TENANT.TenantId)), /*#__PURE__*/React.createElement("span", {
     className: "sep"
-  }, "\u2502"), /*#__PURE__*/React.createElement("span", null, "Default domain ", /*#__PURE__*/React.createElement("b", null, TENANT.DefaultDomain)), /*#__PURE__*/React.createElement("span", {
+  }, "│"), /*#__PURE__*/React.createElement("span", null, "Default domain ", /*#__PURE__*/React.createElement("b", null, TENANT.DefaultDomain)), /*#__PURE__*/React.createElement("span", {
     className: "sep"
-  }, "\u2502"), /*#__PURE__*/React.createElement("span", null, "Users ", /*#__PURE__*/React.createElement("b", null, USERS.TotalUsers), " \xB7 licensed ", /*#__PURE__*/React.createElement("b", null, USERS.Licensed)), /*#__PURE__*/React.createElement("span", {
+  }, "│"), /*#__PURE__*/React.createElement("span", null, "Users ", /*#__PURE__*/React.createElement("b", null, USERS.TotalUsers), " · licensed ", /*#__PURE__*/React.createElement("b", null, USERS.Licensed)), /*#__PURE__*/React.createElement("span", {
     className: "sep"
-  }, "\u2502"), /*#__PURE__*/React.createElement("span", null, "Run ", /*#__PURE__*/React.createElement("b", null, new Date(SCORE.CreatedDateTime || Date.now()).toLocaleString()))), /*#__PURE__*/React.createElement("div", {
+  }, "│"), /*#__PURE__*/React.createElement("span", null, "Run ", /*#__PURE__*/React.createElement("b", null, new Date(SCORE.CreatedDateTime || Date.now()).toLocaleString()))), /*#__PURE__*/React.createElement("div", {
     className: "overview-meta"
-  }, /*#__PURE__*/React.createElement("span", null, "\u203A ", D.summary.length, " collectors executed"), /*#__PURE__*/React.createElement("span", null, "\u203A ", fmt(totalChecks), " data points inventoried"), /*#__PURE__*/React.createElement("span", null, "\u203A ", FINDINGS.length, " controls evaluated"), /*#__PURE__*/React.createElement("span", null, "\u203A ", FRAMEWORKS.length, " frameworks mapped")));
+  }, /*#__PURE__*/React.createElement("span", null, "› ", D.summary.length, " collectors executed"), /*#__PURE__*/React.createElement("span", null, "› ", fmt(totalChecks), " data points inventoried"), /*#__PURE__*/React.createElement("span", null, "› ", FINDINGS.length, " controls evaluated"), /*#__PURE__*/React.createElement("span", null, "› ", FRAMEWORKS.length, " frameworks mapped")));
 }
 
 // ======================== Appendix ========================
@@ -5835,7 +5835,7 @@ function Appendix() {
     id: "appendix"
   }, /*#__PURE__*/React.createElement("div", headProps, /*#__PURE__*/React.createElement("span", {
     className: "eyebrow"
-  }, "05 \xB7 Reference"), /*#__PURE__*/React.createElement("h2", null, "Tenant appendix"), /*#__PURE__*/React.createElement("span", {
+  }, "05 · Reference"), /*#__PURE__*/React.createElement("h2", null, "Tenant appendix"), /*#__PURE__*/React.createElement("span", {
     className: "section-chevron",
     "aria-hidden": "true"
   }, open ? '▾' : '▸'), /*#__PURE__*/React.createElement("div", {
@@ -6205,7 +6205,7 @@ function TweaksPanel({
       fontSize: 16,
       lineHeight: 1
     }
-  }, "\xD7")), /*#__PURE__*/React.createElement("div", {
+  }, "×")), /*#__PURE__*/React.createElement("div", {
     className: "tw-row"
   }, /*#__PURE__*/React.createElement("div", {
     className: "tw-label"
@@ -6660,7 +6660,7 @@ function App() {
     className: 'edit-mode-toggle' + (editMode ? ' active' : ''),
     onClick: () => setEditMode(e => !e),
     title: "Toggle edit mode"
-  }, "\u270E"))), showTweaks && /*#__PURE__*/React.createElement(TweaksPanel, {
+  }, "✎"))), showTweaks && /*#__PURE__*/React.createElement(TweaksPanel, {
     onClose: () => setShowTweaks(false),
     theme: theme,
     setTheme: setTheme,


### PR DESCRIPTION
## Summary

Upgrades Babel from 7 to 8. Supersedes the three Dependabot Babel bumps (#994/#995/#996), which **could not be merged as-is**: Babel 8 changed `@babel/preset-react`'s default from the **classic** runtime (`React.createElement`) to the **automatic** runtime (`jsx`/`jsxDEV` plus an `import` from `react/jsx-dev-runtime`). Since `report-app.js` is inlined into a plain `<script>` tag with no bundler, that `import` would throw and blank the entire report.

## Related Issues

Supersedes #994, #995, #996 (to be closed).

## Changes

- Bump `@babel/cli`, `@babel/core`, `@babel/preset-react` to `^8.0.1` (regenerated `package-lock.json`).
- Add `babel.config.json` pinning `@babel/preset-react` to `runtime: "classic"`, and drop the now-redundant `--presets` flag from the build script.
- Recompile `report-app.js`. The only change is cosmetic: Babel 8 emits literal UTF-8 glyphs (`·`, `✎`, `↺`) where Babel 7 emitted ASCII escapes (`\xB7`, `✎`, `↺`); the `React.createElement` structure is otherwise unchanged. The report is written UTF-8 with `<meta charset="UTF-8">`, so literal glyphs render correctly.

## Test Plan

- [x] PSScriptAnalyzer passes (no `.ps1` changes)
- [x] `npm install` clean (0 vulnerabilities)
- [x] `node --check src/M365-Assess/assets/report-app.js` passes
- [x] Build is deterministic — CI's `report-app.js` drift check passes (rebuild matches committed)
- [x] Verified the compiled diff is unicode-escaping only, with identical `React.createElement` output
- [ ] Live report render on next assessment — final confirmation the glyphs display (functionally identical, near-zero risk)
- [x] No secrets or tenant PII in committed files

## Breaking Changes

None. The compiled report output is functionally identical; only the source encoding of a handful of glyphs changed (ASCII escape -> literal UTF-8), and the report is UTF-8.
