### PR TITLE
Fix: Exchange Online & Purview certificate app-only auth on Linux/macOS

### DIFF
--- a/src/M365-Assess/Common/Connect-Service.ps1
+++ b/src/M365-Assess/Common/Connect-Service.ps1
@@ -17,7 +17,17 @@
     Application (client) ID for app-only authentication. Requires TenantId
     and either CertificateThumbprint or ClientSecret.
 .PARAMETER CertificateThumbprint
-    Certificate thumbprint for app-only authentication.
+    Certificate thumbprint for app-only authentication. For Exchange Online and Purview
+    this is Windows-only (Connect-ExchangeOnline / Connect-IPPSSession resolve it through
+    the Windows certificate store); on Linux/macOS pass -Certificate or -CertificatePath.
+.PARAMETER Certificate
+    App-only authentication certificate as an X509Certificate2 object. Portable across
+    Windows, Linux and macOS -- the recommended input for non-Windows Exchange/Purview.
+.PARAMETER CertificatePath
+    Path to a certificate file (.pfx/.p12) for app-only authentication; loaded with
+    -CertificatePassword. Portable alternative to -CertificateThumbprint.
+.PARAMETER CertificatePassword
+    SecureString password protecting the -CertificatePath file, if any.
 .PARAMETER ClientSecret
     Client secret for app-only authentication. Less secure than certificate auth.
 .PARAMETER UserPrincipalName
@@ -78,6 +88,15 @@ param(
     [string]$CertificateThumbprint,
 
     [Parameter()]
+    [System.Security.Cryptography.X509Certificates.X509Certificate2]$Certificate,
+
+    [Parameter()]
+    [string]$CertificatePath,
+
+    [Parameter()]
+    [SecureString]$CertificatePassword,
+
+    [Parameter()]
     [SecureString]$ClientSecret,
 
     [Parameter()]
@@ -95,6 +114,99 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+
+function Resolve-AppOnlyCertificate {
+    <#
+    .SYNOPSIS
+        Returns the app-only authentication certificate as an X509Certificate2, from either the
+        -Certificate object or the -CertificatePath (+ -CertificatePassword) file, or $null when
+        neither is supplied. Portable across Windows, Linux and macOS -- it never touches the
+        Windows-only PowerShell Cert: provider.
+    #>
+    [OutputType([System.Security.Cryptography.X509Certificates.X509Certificate2])]
+    param(
+        [System.Security.Cryptography.X509Certificates.X509Certificate2]$Certificate,
+        [string]$CertificatePath,
+        [System.Security.SecureString]$CertificatePassword
+    )
+    if ($Certificate) { return $Certificate }
+    if (-not $CertificatePath) { return $null }
+    if (-not (Test-Path -Path $CertificatePath)) {
+        throw "Certificate file not found: '$CertificatePath'."
+    }
+    try {
+        if ($CertificatePassword) {
+            return [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($CertificatePath, $CertificatePassword)
+        }
+        return [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($CertificatePath)
+    }
+    catch {
+        throw "Failed to load certificate from '$CertificatePath': $($_.Exception.Message)"
+    }
+}
+
+function Resolve-InitialDomain {
+    <#
+    .SYNOPSIS
+        Resolves the tenant's initial (*.onmicrosoft.*) domain, which app-only Exchange Online /
+        Purview authentication requires as -Organization. Prefers -TenantId when it already is an
+        initial domain; otherwise queries Microsoft Graph with a RELATIVE request so the connected
+        sovereign-cloud endpoint (commercial, GCC High, DoD) is honoured. Returns $null on failure.
+    #>
+    [OutputType([string])]
+    param([string]$TenantId)
+    if ($TenantId -and $TenantId -match '\.onmicrosoft\.[a-z]+$') { return $TenantId }
+    try {
+        $verifiedDomains = (Invoke-MgGraphRequest -Method GET -Uri '/v1.0/organization?$select=verifiedDomains').value.verifiedDomains
+        $initial = $verifiedDomains | Where-Object { $_.isInitial } | Select-Object -First 1
+        if ($initial.name) { return [string]$initial.name }
+    }
+    catch {
+        Write-Verbose "Initial-domain lookup via Graph failed: $($_.Exception.Message)"
+    }
+    return $null
+}
+
+function Set-ExchangeAppOnlyAuth {
+    <#
+    .SYNOPSIS
+        Configures Exchange Online / Purview app-only certificate authentication cross-platform.
+    .DESCRIPTION
+        Connect-ExchangeOnline and Connect-IPPSSession resolve -CertificateThumbprint only through
+        the Windows certificate store, which is unavailable on Linux/macOS. When a certificate
+        object is supplied it is passed via -Certificate together with -Organization (the tenant's
+        initial domain). Windows keeps the unchanged -CertificateThumbprint code path. Fails early
+        with an actionable error when the required material cannot be resolved.
+    #>
+    param(
+        [Parameter(Mandatory)][hashtable]$ConnectParams,
+        [Parameter(Mandatory)][string]$ClientId,
+        [string]$CertificateThumbprint,
+        [System.Security.Cryptography.X509Certificates.X509Certificate2]$Certificate,
+        [string]$TenantId
+    )
+    $ConnectParams['AppId'] = $ClientId
+    if ($Certificate) {
+        $ConnectParams['Certificate'] = $Certificate
+        $organization = Resolve-InitialDomain -TenantId $TenantId
+        if (-not $organization) {
+            throw "Could not resolve the tenant's initial (*.onmicrosoft.*) domain, which app-only Exchange Online / Purview authentication requires. Connect to Microsoft Graph first, or pass -TenantId as the initial domain."
+        }
+        $ConnectParams['Organization'] = $organization
+    }
+    elseif ($CertificateThumbprint) {
+        if ($IsWindows -eq $false) {
+            throw "-CertificateThumbprint is Windows-only for Exchange Online / Purview (it is resolved through the Windows certificate store). On Linux/macOS, pass the certificate with -Certificate or -CertificatePath instead."
+        }
+        $ConnectParams['CertificateThumbprint'] = $CertificateThumbprint
+    }
+    else {
+        throw "App-only Exchange Online / Purview authentication requires a certificate: pass -Certificate, -CertificatePath, or (on Windows) -CertificateThumbprint."
+    }
+}
+
+# Resolve the app-only certificate object once (from -Certificate or -CertificatePath).
+$appOnlyCertificate = Resolve-AppOnlyCertificate -Certificate $Certificate -CertificatePath $CertificatePath -CertificatePassword $CertificatePassword
 
 $moduleMap = @{
     'Graph'           = 'Microsoft.Graph.Authentication'
@@ -149,9 +261,12 @@ try {
             if ($ManagedIdentity) {
                 $connectParams['Identity'] = $true
             }
-            elseif ($ClientId -and $CertificateThumbprint) {
+            elseif ($ClientId -and ($appOnlyCertificate -or $CertificateThumbprint)) {
                 $connectParams['ClientId'] = $ClientId
-                $connectParams['CertificateThumbprint'] = $CertificateThumbprint
+                # Connect-MgGraph accepts a certificate object cross-platform; the thumbprint
+                # path stays for Windows callers that rely on the certificate store.
+                if ($appOnlyCertificate) { $connectParams['Certificate'] = $appOnlyCertificate }
+                else { $connectParams['CertificateThumbprint'] = $CertificateThumbprint }
             }
             elseif ($ClientId -and $ClientSecret) {
                 $credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $ClientId, $ClientSecret
@@ -200,9 +315,8 @@ try {
             if ($ManagedIdentity) {
                 $connectParams['ManagedIdentity'] = $true
             }
-            elseif ($ClientId -and $CertificateThumbprint) {
-                $connectParams['AppId'] = $ClientId
-                $connectParams['CertificateThumbprint'] = $CertificateThumbprint
+            elseif ($ClientId -and ($appOnlyCertificate -or $CertificateThumbprint)) {
+                Set-ExchangeAppOnlyAuth -ConnectParams $connectParams -ClientId $ClientId -CertificateThumbprint $CertificateThumbprint -Certificate $appOnlyCertificate -TenantId $TenantId
             }
             elseif ($ClientId -and $ClientSecret) {
                 throw "Exchange Online does not support client secret authentication. Use -CertificateThumbprint for app-only auth."
@@ -240,9 +354,8 @@ try {
                 Write-Warning "Purview (Connect-IPPSSession) does not support managed identity auth. Falling back to browser-based login."
             }
 
-            if ($ClientId -and $CertificateThumbprint) {
-                $connectParams['AppId'] = $ClientId
-                $connectParams['CertificateThumbprint'] = $CertificateThumbprint
+            if ($ClientId -and ($appOnlyCertificate -or $CertificateThumbprint)) {
+                Set-ExchangeAppOnlyAuth -ConnectParams $connectParams -ClientId $ClientId -CertificateThumbprint $CertificateThumbprint -Certificate $appOnlyCertificate -TenantId $TenantId
             }
             elseif ($ClientId -and $ClientSecret) {
                 throw "Purview does not support client secret authentication. Use -CertificateThumbprint for app-only auth."

--- a/src/M365-Assess/Invoke-M365Assessment.ps1
+++ b/src/M365-Assess/Invoke-M365Assessment.ps1
@@ -27,7 +27,16 @@
 .PARAMETER ClientId
     Application (client) ID for app-only authentication.
 .PARAMETER CertificateThumbprint
-    Certificate thumbprint for app-only authentication.
+    Certificate thumbprint for app-only authentication. For Exchange Online and Purview
+    this is Windows-only; on Linux/macOS use -Certificate or -CertificatePath.
+.PARAMETER Certificate
+    App-only authentication certificate as an X509Certificate2 object. Portable across
+    Windows, Linux and macOS -- recommended for non-Windows runs.
+.PARAMETER CertificatePath
+    Path to a certificate file (.pfx/.p12) for app-only authentication, loaded with
+    -CertificatePassword. Portable alternative to -CertificateThumbprint.
+.PARAMETER CertificatePassword
+    SecureString password protecting the -CertificatePath file, if any.
 .PARAMETER ClientSecret
     Client secret for app-only authentication. Less secure than certificate
     auth -- prefer -CertificateThumbprint for production use.
@@ -201,8 +210,10 @@ param(
     # tenant cannot be inferred interactively. Must be listed explicitly in every
     # set — mixing named-set attributes with a bare [Parameter()] (__AllParameterSets)
     # causes parameter-set resolution failures in PowerShell 7.6+.
-    [Parameter(ParameterSetName = 'AppOnlyCert',      Mandatory)]
-    [Parameter(ParameterSetName = 'AppOnlySecret',    Mandatory)]
+    [Parameter(ParameterSetName = 'AppOnlyCert',       Mandatory)]
+    [Parameter(ParameterSetName = 'AppOnlyCertObject', Mandatory)]
+    [Parameter(ParameterSetName = 'AppOnlyCertFile',   Mandatory)]
+    [Parameter(ParameterSetName = 'AppOnlySecret',     Mandatory)]
     [Parameter(ParameterSetName = 'Interactive')]
     [Parameter(ParameterSetName = 'DeviceCode')]
     [Parameter(ParameterSetName = 'ManagedIdentity')]
@@ -217,12 +228,25 @@ param(
     [Parameter(ParameterSetName = 'SkipConnection', Mandatory)]
     [switch]$SkipConnection,
 
-    [Parameter(ParameterSetName = 'AppOnlyCert',   Mandatory)]
-    [Parameter(ParameterSetName = 'AppOnlySecret', Mandatory)]
+    [Parameter(ParameterSetName = 'AppOnlyCert',       Mandatory)]
+    [Parameter(ParameterSetName = 'AppOnlyCertObject', Mandatory)]
+    [Parameter(ParameterSetName = 'AppOnlyCertFile',   Mandatory)]
+    [Parameter(ParameterSetName = 'AppOnlySecret',     Mandatory)]
     [string]$ClientId,
 
     [Parameter(ParameterSetName = 'AppOnlyCert', Mandatory)]
     [string]$CertificateThumbprint,
+
+    # Portable app-only cert inputs -- work on Windows, Linux and macOS (unlike a bare
+    # thumbprint for Exchange/Purview, which is resolved through the Windows cert store).
+    [Parameter(ParameterSetName = 'AppOnlyCertObject', Mandatory)]
+    [System.Security.Cryptography.X509Certificates.X509Certificate2]$Certificate,
+
+    [Parameter(ParameterSetName = 'AppOnlyCertFile', Mandatory)]
+    [string]$CertificatePath,
+
+    [Parameter(ParameterSetName = 'AppOnlyCertFile')]
+    [SecureString]$CertificatePassword,
 
     [Parameter(ParameterSetName = 'AppOnlySecret', Mandatory)]
     [SecureString]$ClientSecret,

--- a/src/M365-Assess/Orchestrator/Connect-RequiredService.ps1
+++ b/src/M365-Assess/Orchestrator/Connect-RequiredService.ps1
@@ -41,6 +41,10 @@ function Connect-RequiredService {
             if ($TenantId) { $connectParams['TenantId'] = $TenantId }
             if ($ClientId) { $connectParams['ClientId'] = $ClientId }
             if ($CertificateThumbprint) { $connectParams['CertificateThumbprint'] = $CertificateThumbprint }
+            # Portable app-only certificate inputs (cross-platform Exchange/Purview/Graph).
+            if ($Certificate) { $connectParams['Certificate'] = $Certificate }
+            if ($CertificatePath) { $connectParams['CertificatePath'] = $CertificatePath }
+            if ($CertificatePassword) { $connectParams['CertificatePassword'] = $CertificatePassword }
             if ($ClientSecret) { $connectParams['ClientSecret'] = $ClientSecret }
             if ($UserPrincipalName -and $svc -ne 'Graph') {
                 $connectParams['UserPrincipalName'] = $UserPrincipalName

--- a/tests/Common/Connect-Service.Tests.ps1
+++ b/tests/Common/Connect-Service.Tests.ps1
@@ -138,4 +138,110 @@ Describe 'Connect-Service' {
             }
         }
     }
+
+    Context 'Exchange/Purview certificate app-only auth (portable, #1009)' {
+        BeforeAll {
+            # Stub the Exchange/Purview cmdlets + Graph request so nothing reaches a tenant.
+            function global:Connect-ExchangeOnline {
+                param($AppId, $Organization, $Certificate, $CertificateThumbprint,
+                      $ManagedIdentity, $Device, $UserPrincipalName, $ExchangeEnvironmentName)
+            }
+            function global:Connect-IPPSSession {
+                param($AppId, $Organization, $Certificate, $CertificateThumbprint,
+                      $UserPrincipalName, $ConnectionUri, $AzureADAuthorizationEndpointUri)
+            }
+            if (-not (Get-Command -Name Invoke-MgGraphRequest -ErrorAction SilentlyContinue)) {
+                function global:Invoke-MgGraphRequest { param($Method, $Uri) }
+            }
+            Mock Get-Module { @{ Name = 'ExchangeOnlineManagement' } }
+            Mock Import-Module { }
+            Mock Connect-ExchangeOnline { }
+            Mock Connect-IPPSSession { }
+            # Relative-URI Graph lookup returns an initial domain distinct from -TenantId.
+            Mock Invoke-MgGraphRequest {
+                @{ value = @{ verifiedDomains = @(
+                    @{ name = 'primary.example.com';        isInitial = $false }
+                    @{ name = 'contoso.onmicrosoft.com';    isInitial = $true  }
+                ) } }
+            } -ParameterFilter { $Uri -like '*organization*' }
+
+            # Cross-platform ephemeral self-signed certificate (no Windows Cert: provider).
+            $rsa = [System.Security.Cryptography.RSA]::Create(2048)
+            $req = [System.Security.Cryptography.X509Certificates.CertificateRequest]::new(
+                'CN=M365Assess-Test', $rsa,
+                [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+                [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
+            $script:testCert  = $req.CreateSelfSigned([System.DateTimeOffset]::UtcNow.AddDays(-1), [System.DateTimeOffset]::UtcNow.AddDays(1))
+            $script:testThumb = $script:testCert.Thumbprint
+        }
+
+        AfterAll {
+            Remove-Item -Path 'function:global:Connect-ExchangeOnline' -ErrorAction SilentlyContinue
+            Remove-Item -Path 'function:global:Connect-IPPSSession' -ErrorAction SilentlyContinue
+            Remove-Item -Path 'function:global:Invoke-MgGraphRequest' -ErrorAction SilentlyContinue
+        }
+
+        It 'Exchange Online with -Certificate connects with the object + resolved Organization' {
+            & $script:scriptPath -Service 'ExchangeOnline' -TenantId '00000000-0000-0000-0000-000000000000' `
+                -ClientId 'app-id' -Certificate $script:testCert -WarningAction SilentlyContinue
+            Should -Invoke Connect-ExchangeOnline -ParameterFilter {
+                $Certificate.Thumbprint -eq $script:testThumb -and
+                $Organization -eq 'contoso.onmicrosoft.com' -and
+                $AppId -eq 'app-id' -and
+                -not $CertificateThumbprint
+            }
+        }
+
+        It 'Purview with -Certificate connects with the object + resolved Organization' {
+            & $script:scriptPath -Service 'Purview' -TenantId '00000000-0000-0000-0000-000000000000' `
+                -ClientId 'app-id' -Certificate $script:testCert -WarningAction SilentlyContinue
+            Should -Invoke Connect-IPPSSession -ParameterFilter {
+                $Certificate.Thumbprint -eq $script:testThumb -and
+                $Organization -eq 'contoso.onmicrosoft.com' -and
+                $AppId -eq 'app-id'
+            }
+        }
+
+        It 'resolves the initial domain via a RELATIVE Graph request (sovereign-cloud safe)' {
+            & $script:scriptPath -Service 'ExchangeOnline' -TenantId '00000000-0000-0000-0000-000000000000' `
+                -ClientId 'app-id' -Certificate $script:testCert -WarningAction SilentlyContinue
+            Should -Invoke Invoke-MgGraphRequest -ParameterFilter {
+                $Uri -notmatch '^https?://' -and $Uri -like '/v1.0/organization*'
+            }
+        }
+
+        It 'uses -TenantId directly when it already is an initial domain (no Graph call)' {
+            & $script:scriptPath -Service 'ExchangeOnline' -TenantId 'fabrikam.onmicrosoft.com' `
+                -ClientId 'app-id' -Certificate $script:testCert -WarningAction SilentlyContinue
+            Should -Invoke Connect-ExchangeOnline -ParameterFilter { $Organization -eq 'fabrikam.onmicrosoft.com' }
+            Should -Not -Invoke Invoke-MgGraphRequest
+        }
+
+        It 'loads the certificate from -CertificatePath' {
+            $certPwd = ConvertTo-SecureString 'p@ss' -AsPlainText -Force
+            $pfxBytes = $script:testCert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Pfx, $certPwd)
+            $pfxPath  = Join-Path ([System.IO.Path]::GetTempPath()) ("m365a-test-{0}.pfx" -f [System.IO.Path]::GetRandomFileName())
+            [System.IO.File]::WriteAllBytes($pfxPath, $pfxBytes)
+            try {
+                & $script:scriptPath -Service 'ExchangeOnline' -TenantId 'fabrikam.onmicrosoft.com' `
+                    -ClientId 'app-id' -CertificatePath $pfxPath -CertificatePassword $certPwd -WarningAction SilentlyContinue
+                Should -Invoke Connect-ExchangeOnline -ParameterFilter { $Certificate.Thumbprint -eq $script:testThumb }
+            }
+            finally { Remove-Item -Path $pfxPath -ErrorAction SilentlyContinue }
+        }
+
+        It 'uses -CertificateThumbprint on Windows' -Skip:(-not $IsWindows) {
+            & $script:scriptPath -Service 'ExchangeOnline' -TenantId 'fabrikam.onmicrosoft.com' `
+                -ClientId 'app-id' -CertificateThumbprint 'AB12CD34EF56' -WarningAction SilentlyContinue
+            Should -Invoke Connect-ExchangeOnline -ParameterFilter {
+                $CertificateThumbprint -eq 'AB12CD34EF56' -and -not $Certificate
+            }
+        }
+
+        It 'throws for a bare thumbprint on Linux/macOS (Cert store is Windows-only)' -Skip:($IsWindows) {
+            { & $script:scriptPath -Service 'ExchangeOnline' -TenantId 'fabrikam.onmicrosoft.com' `
+                -ClientId 'app-id' -CertificateThumbprint 'AB12CD34EF56' -ErrorAction Stop } |
+                Should -Throw -ExpectedMessage '*Windows-only*'
+        }
+    }
 }

--- a/tests/Smoke/Cross-Platform.Tests.ps1
+++ b/tests/Smoke/Cross-Platform.Tests.ps1
@@ -94,4 +94,100 @@ Describe 'Cross-platform smoke (B6 #777)' {
             $json.TrimEnd() | Should -Match ';\s*$'
         }
     }
+
+    Context 'Portable app-only certificate authentication (#1009)' {
+        BeforeAll {
+            $script:connectServicePath = Join-Path $script:moduleRoot 'Common/Connect-Service.ps1'
+            $connectServiceSource = Get-Content -Path $script:connectServicePath -Raw
+
+            # This smoke test is added ahead of the portable-auth implementation on
+            # the maintenance branch. Skip there; the PR that introduces the new
+            # parameters will exercise these assertions on Ubuntu/macOS.
+            $script:portableAuthAvailable =
+                $connectServiceSource -match '\[System\.Security\.Cryptography\.X509Certificates\.X509Certificate2\]\$Certificate' -and
+                $connectServiceSource -match '\$CertificatePath' -and
+                $connectServiceSource -match 'Resolve-InitialDomain'
+
+            if (-not $script:portableAuthAvailable) { return }
+
+            # The smoke lane deliberately has no Graph, EXO, or Purview modules.
+            # Stub only the commands needed to exercise Connect-Service's parameter
+            # plumbing; no network or tenant calls are possible.
+            if (-not (Get-Command -Name Connect-ExchangeOnline -ErrorAction SilentlyContinue)) {
+                function global:Connect-ExchangeOnline {
+                    param(
+                        $AppId, $Organization, $Certificate, $CertificateThumbprint,
+                        $ShowBanner, $ExchangeEnvironmentName
+                    )
+                }
+                $script:createdPortableAuthStubs += 'Connect-ExchangeOnline'
+            }
+            if (-not (Get-Command -Name Invoke-MgGraphRequest -ErrorAction SilentlyContinue)) {
+                function global:Invoke-MgGraphRequest { param($Method, $Uri) }
+                $script:createdPortableAuthStubs += 'Invoke-MgGraphRequest'
+            }
+
+            Mock Get-Module { @{ Name = $Name } }
+            Mock Connect-ExchangeOnline { }
+            Mock Invoke-MgGraphRequest {
+                @{ value = @{ verifiedDomains = @(
+                    @{ name = 'primary.example.com';     isInitial = $false }
+                    @{ name = 'contoso.onmicrosoft.com'; isInitial = $true  }
+                ) } }
+            } -ParameterFilter { $Uri -like '/v1.0/organization*' }
+
+            $rsa = [System.Security.Cryptography.RSA]::Create(2048)
+            $request = [System.Security.Cryptography.X509Certificates.CertificateRequest]::new(
+                'CN=M365Assess-Smoke', $rsa,
+                [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+                [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
+            $script:portableSmokeCertificate = $request.CreateSelfSigned(
+                [System.DateTimeOffset]::UtcNow.AddDays(-1),
+                [System.DateTimeOffset]::UtcNow.AddDays(1))
+        }
+
+        AfterAll {
+            foreach ($commandName in @($script:createdPortableAuthStubs)) {
+                Remove-Item -Path "function:global:$commandName" -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'should pass an X509Certificate2 object and relative Graph lookup to Exchange Online' {
+            if (-not $script:portableAuthAvailable) {
+                Set-ItResult -Skipped -Because 'portable certificate parameters are not present on this branch'
+                return
+            }
+
+            & $script:connectServicePath -Service 'ExchangeOnline' `
+                -TenantId '00000000-0000-0000-0000-000000000000' `
+                -ClientId 'smoke-app-id' -Certificate $script:portableSmokeCertificate `
+                -ErrorAction Stop -WarningAction SilentlyContinue
+
+            Should -Invoke Connect-ExchangeOnline -ParameterFilter {
+                $AppId -eq 'smoke-app-id' -and
+                $Organization -eq 'contoso.onmicrosoft.com' -and
+                $Certificate.Thumbprint -eq $script:portableSmokeCertificate.Thumbprint -and
+                -not $CertificateThumbprint
+            }
+            Should -Invoke Invoke-MgGraphRequest -ParameterFilter {
+                $Uri -eq '/v1.0/organization?$select=verifiedDomains'
+            }
+        }
+
+        It 'should reject a bare Exchange thumbprint on non-Windows' {
+            if (-not $script:portableAuthAvailable) {
+                Set-ItResult -Skipped -Because 'portable certificate parameters are not present on this branch'
+                return
+            }
+            if ($IsWindows) {
+                Set-ItResult -Skipped -Because 'thumbprints are supported by the Windows certificate store'
+                return
+            }
+
+            { & $script:connectServicePath -Service 'ExchangeOnline' `
+                -TenantId 'contoso.onmicrosoft.com' -ClientId 'smoke-app-id' `
+                -CertificateThumbprint 'AB12CD34EF56' -ErrorAction Stop } |
+                Should -Throw -ExpectedMessage '*Windows-only*'
+        }
+    }
 }


### PR DESCRIPTION
## Problem
`Common/Connect-Service.ps1` uses `-CertificateThumbprint` for app-only auth to Exchange Online and Purview. `Connect-ExchangeOnline` / `Connect-IPPSSession` resolve that thumbprint through the **Windows certificate store**, which does not exist on Linux/macOS. When the assessment runs on a non-Windows host (e.g. a Linux container / CI runner), every Exchange Online and Purview collector fails to connect and is silently skipped.

## Repro
- Linux, PowerShell 7.x, certificate app-only auth.
- `.\Common\Connect-Service.ps1 -Service ExchangeOnline -TenantId <tenant> -ClientId <appId> -CertificateThumbprint <thumb>` → connection fails; EXO/Purview sections empty.

## Fix
On non-Windows platforms (`$IsWindows -eq $false`), resolve the thumbprint to a certificate object from the PowerShell `Cert:` provider and connect with `-Certificate` instead of `-CertificateThumbprint`, and set `-Organization` to the tenant's initial `*.onmicrosoft.com` domain (required for app-only Exchange auth). Windows behaviour is unchanged. The logic is centralised in a new private helper `Set-AppOnlyExchangeCertificateAuth`, used by both the ExchangeOnline and Purview branches.

## Notes
- Read-only; no tenant changes.
- On non-Windows the certificate (with private key) must be imported into `Cert:\CurrentUser\My` (or `LocalMachine\My`); a clear error is thrown if the thumbprint is not found.
- Resolving the initial domain needs an active Graph connection, which the assessment already establishes before connecting to Exchange/Purview.
- PSScriptAnalyzer (repo settings): 0 findings. Verified on Linux PS 7.x against a live tenant — EXO + Purview collectors now connect.