### PR TITLE
Fix: guard against null grantControls in Conditional Access checks

### DIFF
--- a/src/M365-Assess/Entra/EntraPasswordAuthChecks.ps1
+++ b/src/M365-Assess/Entra/EntraPasswordAuthChecks.ps1
@@ -109,7 +109,7 @@ if ($isEnabled -eq $false) {
         $azureMgmtAppId = '797f4846-ba00-4fd7-ba43-dac1f8f63013'
 
         foreach ($policy in $caEnabled) {
-            $grants = $policy['grantControls']['builtInControls']
+            $grants = if ($null -ne $policy['grantControls']) { $policy['grantControls']['builtInControls'] } else { @() }
             $users = $policy['conditions']['users']
             $clientApps = $policy['conditions']['clientAppTypes']
             $apps = $policy['conditions']['applications']

--- a/src/M365-Assess/Entra/Get-CASecurityConfig.ps1
+++ b/src/M365-Assess/Entra/Get-CASecurityConfig.ps1
@@ -268,7 +268,7 @@ try {
     Write-Verbose "Checking CA: MFA for all users..."
     $mfaAllPolicies = @($enabledPolicies | Where-Object {
         (Test-TargetAllUser -Policy $_) -and
-        ($_['grantControls']['builtInControls'] -contains 'mfa')
+        ($null -ne $_['grantControls'] -and $_['grantControls']['builtInControls'] -contains 'mfa')
     })
 
     $mfaAllEvidence = [PSCustomObject]@{
@@ -329,7 +329,7 @@ try {
     $legacyBlockPolicies = @($enabledPolicies | Where-Object {
         $clientApps = $_['conditions']['clientAppTypes']
         ($clientApps -contains 'exchangeActiveSync' -or $clientApps -contains 'other') -and
-        ($_['grantControls']['builtInControls'] -contains 'block')
+        ($null -ne $_['grantControls'] -and $_['grantControls']['builtInControls'] -contains 'block')
     })
 
     $legacyAuthEvidence = [PSCustomObject]@{
@@ -433,7 +433,7 @@ try {
     Write-Verbose "Checking CA: Phishing-resistant MFA for admins..."
     $phishResPolicies = @($enabledPolicies | Where-Object {
         (Test-TargetAdminRole -Policy $_) -and
-        $null -ne $_['grantControls']['authenticationStrength']
+        $null -ne $_['grantControls'] -and $null -ne $_['grantControls']['authenticationStrength']
     })
 
     if ($phishResPolicies.Count -gt 0) {
@@ -555,8 +555,8 @@ try {
         $riskLevels = $_['conditions']['signInRiskLevels']
         $riskLevels -and
         ($riskLevels -contains 'medium' -or $riskLevels -contains 'high') -and
-        ($_['grantControls']['builtInControls'] -contains 'block' -or
-         $_['grantControls']['builtInControls'] -contains 'mfa')
+        ($null -ne $_['grantControls'] -and ($_['grantControls']['builtInControls'] -contains 'block' -or
+         $_['grantControls']['builtInControls'] -contains 'mfa'))
     })
 
     if ($signinRiskBlockPolicies.Count -gt 0) {
@@ -607,8 +607,8 @@ catch {
 try {
     Write-Verbose "Checking CA: Managed device required..."
     $devicePolicies = @($enabledPolicies | Where-Object {
-        $_['grantControls']['builtInControls'] -contains 'compliantDevice' -or
-        $_['grantControls']['builtInControls'] -contains 'domainJoinedDevice'
+        $null -ne $_['grantControls'] -and ($_['grantControls']['builtInControls'] -contains 'compliantDevice' -or
+        $_['grantControls']['builtInControls'] -contains 'domainJoinedDevice')
     })
 
     if ($devicePolicies.Count -gt 0) {
@@ -652,8 +652,8 @@ try {
             $userActions = $_['conditions']['applications']['includeUserActions']
         }
         ($userActions -contains 'urn:user:registersecurityinfo') -and
-        ($_['grantControls']['builtInControls'] -contains 'compliantDevice' -or
-         $_['grantControls']['builtInControls'] -contains 'domainJoinedDevice')
+        ($null -ne $_['grantControls'] -and ($_['grantControls']['builtInControls'] -contains 'compliantDevice' -or
+         $_['grantControls']['builtInControls'] -contains 'domainJoinedDevice'))
     })
 
     if ($secInfoDevicePolicies.Count -gt 0) {
@@ -741,7 +741,7 @@ try {
         $transferMethods = if ($authFlows) { $authFlows['transferMethods'] } else { $null }
         $transferMethods -and
         ($transferMethods -contains 'deviceCodeFlow') -and
-        ($_['grantControls']['builtInControls'] -contains 'block')
+        ($null -ne $_['grantControls'] -and $_['grantControls']['builtInControls'] -contains 'block')
     })
 
     if ($deviceCodePolicies.Count -gt 0) {
@@ -867,7 +867,7 @@ try {
 
     # Check if any of those also require device compliance
     $persistentWithoutDevice = @($persistentBrowserPolicies | Where-Object {
-        $grantControls = $_['grantControls']['builtInControls']
+        $grantControls = if ($null -ne $_['grantControls']) { $_['grantControls']['builtInControls'] } else { @() }
         -not ($grantControls -contains 'compliantDevice' -or $grantControls -contains 'domainJoinedDevice')
     })
 


### PR DESCRIPTION
## Problem
Several Conditional Access checks in `Entra/Get-CASecurityConfig.ps1` (and one in `Entra/EntraPasswordAuthChecks.ps1`) index into `$_['grantControls']['builtInControls']` (or `['authenticationStrength']`) without a null check. Conditional Access policies that only set **session controls** (e.g. sign-in frequency, persistent browser) — or are otherwise grant-less — have `grantControls = null`. For tenants with such policies these checks throw `Cannot index into a null array`, so legacy-auth block, phishing-resistant MFA, risk-based, managed-device, device-code-flow block and MFA-for-all-users checks cannot complete.

## Repro
- A tenant with at least one enabled CA policy that has session controls but no grant controls (`grantControls: null`).
- Run the Conditional Access collector -> `Cannot index into a null array`.

## Fix
Add a `$null -ne $_['grantControls']` (resp. `$policy['grantControls']`) guard in front of each remaining raw access. Semantically correct: a policy without grant controls cannot enforce MFA / block / compliant-device, so it should simply not match. 8 sites in `Get-CASecurityConfig.ps1` + 1 in `EntraPasswordAuthChecks.ps1`. The admin-MFA path already routes through `Test-RequiresMfa`, which is null-safe, so it needs no change.

## Notes
- Rebased onto current `main` (post #1003/#1004).
- Read-only; behaviour unchanged for policies that do have grant controls.
- PSScriptAnalyzer (repo settings): 0 findings.